### PR TITLE
fix: Change order of emitting events 

### DIFF
--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -81,8 +81,6 @@ export class EventEmitter {
             const newVariableValue = newVariable && newVariableSet[key].value
 
             if (oldVariableValue !== newVariableValue) {
-                this.emit(`${EventNames.VARIABLE_UPDATED}:*`, key, newVariable)
-                this.emit(`${EventNames.VARIABLE_UPDATED}:${key}`, key, newVariable)
                 const variables = variableDefaultMap[key] && Object.values(variableDefaultMap[key])
                 if (variables) {
                     variables.forEach((variable) => {
@@ -90,6 +88,8 @@ export class EventEmitter {
                         variable.callback?.call(variable, variable.value)
                     })
                 }
+                this.emit(`${EventNames.VARIABLE_UPDATED}:*`, key, newVariable)
+                this.emit(`${EventNames.VARIABLE_UPDATED}:${key}`, key, newVariable)
             }
         })
     }


### PR DESCRIPTION
# Changes

- emit events later so that changes to the variable default mapping can be read from with the updated value first