### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devcycle/devcycle-js-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The DevCycle JS SDK used for feature management.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
# Changes

- release `1.1.1`
- fixed event emitter emitting before callbacks