### PR TITLE
[DVC-2081] fix: return default value for updated variable value

### DIFF
--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -84,7 +84,7 @@ export class EventEmitter {
                 const variables = variableDefaultMap[key] && Object.values(variableDefaultMap[key])
                 if (variables) {
                     variables.forEach((variable) => {
-                        variable.value = newVariableValue
+                        variable.value = newVariableValue ?? variable.defaultValue
                         variable.callback?.call(variable, variable.value)
                     })
                 }


### PR DESCRIPTION
# Changes

- if user gets unsegmented from a variable, instead of updating value to `undefined`, set it back to the default value