### PR TITLE
fix nodejs types output and remove dependency on js sdk

### DIFF
--- a/sdk/nodejs-server-sdk/src/client.ts
+++ b/sdk/nodejs-server-sdk/src/client.ts
@@ -8,7 +8,7 @@ import {
     DVCEvent,
     DVCLogger,
     DVCUser
-} from '../types'
+} from './types'
 import { EnvironmentConfigManager } from './environmentConfigManager'
 import { bucketUserForConfig } from './utils/userBucketingHelper'
 import { DVCVariable } from './models/variable'

--- a/sdk/nodejs-server-sdk/src/environmentConfigManager.ts
+++ b/sdk/nodejs-server-sdk/src/environmentConfigManager.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios'
 import { ConfigBody } from '@devcycle/types'
-import { DVCLogger, DVCOptions } from '../types'
+import { DVCLogger, DVCOptions } from './types'
 import { getEnvironmentConfig } from './request'
 import { plainToClass } from 'class-transformer'
 

--- a/sdk/nodejs-server-sdk/src/eventQueue.ts
+++ b/sdk/nodejs-server-sdk/src/eventQueue.ts
@@ -1,4 +1,4 @@
-import { DVCEvent, DVCLogger } from '../types'
+import { DVCEvent, DVCLogger } from './types'
 import { publishEvents } from './request'
 import { checkParamDefined, checkParamString } from './utils/paramUtils'
 import { DVCRequestEvent } from './models/requestEvent'

--- a/sdk/nodejs-server-sdk/src/index.ts
+++ b/sdk/nodejs-server-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { DVCOptions } from '../types'
+import { DVCOptions } from './types'
 import { DVCClient } from './client'
 export { DVCClient } from './client'
 

--- a/sdk/nodejs-server-sdk/src/models/populatedUser.ts
+++ b/sdk/nodejs-server-sdk/src/models/populatedUser.ts
@@ -1,4 +1,4 @@
-import { JSON, DVCUser } from '../../types'
+import { JSON, DVCUser } from '../types'
 import * as packageJson from '../../package.json'
 import { checkParamType, typeEnum } from '../utils/paramUtils'
 

--- a/sdk/nodejs-server-sdk/src/models/requestEvent.ts
+++ b/sdk/nodejs-server-sdk/src/models/requestEvent.ts
@@ -1,4 +1,4 @@
-import { DVCEvent } from '../../types'
+import { DVCEvent } from '../types'
 import { checkParamDefined, checkParamString } from '../utils/paramUtils'
 
 export const EventTypes: Record<string, string> = {

--- a/sdk/nodejs-server-sdk/src/models/variable.ts
+++ b/sdk/nodejs-server-sdk/src/models/variable.ts
@@ -1,4 +1,4 @@
-import { DVCVariable as DVCVariableInterface, DVCVariableValue } from '../../types'
+import { DVCVariable as DVCVariableInterface, DVCVariableValue } from '../types'
 import { checkParamDefined, checkParamType, typeEnum } from '../utils/paramUtils'
 
 type VariableParam = Pick<DVCVariableInterface, 'key' | 'defaultValue'> & {

--- a/sdk/nodejs-server-sdk/src/request.ts
+++ b/sdk/nodejs-server-sdk/src/request.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from 'axios'
-import { DVCLogger } from '../types'
+import { DVCLogger } from './types'
 import { SDKEventBatchRequestBody } from '@devcycle/types'
 
 const axiosClient = axios.create({

--- a/sdk/nodejs-server-sdk/src/types.ts
+++ b/sdk/nodejs-server-sdk/src/types.ts
@@ -1,10 +1,53 @@
-import { DVCUser as User } from '@devcycle/devcycle-js-sdk'
+export interface DVCUser {
+    /**
+     * Identifies the current user. Must be defined
+     */
+    user_id: string
 
-export interface DVCUser extends Omit<User, 'isAnonymous' | 'user_id'> {
-  /**
-   * Identifies the user
-   */
-  user_id: string
+    /**
+     * Email used for identifying a device user in the dashboard,
+     * or used for audience segmentation.
+     */
+    email?: string
+
+    /**
+     * Name of the user which can be used for identifying a device user,
+     * or used for audience segmentation.
+     */
+    name?: string
+
+    /**
+     * ISO 639-1 two letter codes, or ISO 639-2 three letter codes
+     */
+    language?: string
+
+    /**
+     * ISO 3166 two or three letter codes
+     */
+    country?: string
+
+    /**
+     * Application Version, can be used for audience segmentation.
+     */
+    appVersion?: string
+
+    /**
+     * Application Build, can be used for audience segmentation.
+     */
+    appBuild?: number
+
+    /**
+     * Custom JSON data used for audience segmentation, must be limited to __kb in size.
+     * Values will be logged to DevCycle's servers and available in the dashboard to view.
+     */
+    customData?: JSON
+
+    /**
+     * Private Custom JSON data used for audience segmentation, must be limited to __kb in size.
+     * Values will not be logged to DevCycle's servers and
+     * will not be available in the dashboard.
+     */
+    privateCustomData?: JSON
 }
 
 /**
@@ -12,10 +55,10 @@ export interface DVCUser extends Omit<User, 'isAnonymous' | 'user_id'> {
  * @param environmentKey
  * @param options
  */
-export async function initialize(
+export type initialize = (
     environmentKey: string,
     options?: DVCOptions
-): DVCClient
+) => Promise<DVCClient>
 
 /**
  * Options to control the setup of the DevCycle NodeJS Server SDK.
@@ -50,7 +93,7 @@ export interface DVCOptions {
     disableEventLogging?: boolean
 }
 
-export class DVCClient {
+export interface DVCClient {
     /**
      * Notify the user when Features have been loaded from the server.
      * An optional callback can be passed in, and will return a promise if no callback has been passed in.
@@ -103,7 +146,7 @@ export class DVCClient {
 }
 
 export type DVCVariableValue = string | number | boolean | JSON
-type JSON = { [key: string]: string | number | boolean }
+export type JSON = { [key: string]: string | number | boolean }
 
 export type DVCVariableSet = Record<string,
     Omit<DVCVariable, 'defaultValue' | 'isDefaulted'> & { _id: string }
@@ -199,4 +242,4 @@ export type DVCDefaultLoggerOptions = {
     logWriter?: (message: string) => void
 }
 
-export function defaultLogger(options?: DVCDefaultLoggerOptions): DVCLogger
+export type defaultLogger = (options?: DVCDefaultLoggerOptions) => DVCLogger

--- a/sdk/nodejs-server-sdk/src/utils/logger.ts
+++ b/sdk/nodejs-server-sdk/src/utils/logger.ts
@@ -1,7 +1,7 @@
 import { isNumber } from 'lodash'
 import {
     DVCDefaultLoggerOptions, DVCLogger
-} from '../../types'
+} from '../types'
 
 const prefix = '[DevCycle]: '
 export enum DVCLogLevels {


### PR DESCRIPTION
- move nodejs types from a declaration file to an actual typescript file, otherwise it is stripped from the build output
- remove dependency on js sdk by duplicated DVCUser type definition again