### PR TITLE
[DVC-2712] fix dvc client export on nodejs sdk

### DIFF
--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -1,6 +1,6 @@
 import {
-    DVCClient as DVCClientInterface,
     DVCOptions,
+    DVCClient as DVCClientInterface,
     DVCVariableValue,
     DVCVariable as DVCVariableInterface,
     DVCVariableSet,

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -1,12 +1,11 @@
-import { DVCOptions } from './types'
+import { DVCOptions, DVCClient as DVCClientInterface } from './types'
 import { DVCClient } from './client'
-export { DVCClient } from './client'
 
 export { defaultLogger } from './utils/logger'
 
 export * from './types'
 
-export function initialize(environmentKey: string, options?: DVCOptions): DVCClient {
+export function initialize(environmentKey: string, options?: DVCOptions): DVCClientInterface {
     if (!environmentKey) {
         throw new Error('Missing environment key! Call initialize with a valid environment key')
     }

--- a/sdk/nodejs/src/types.ts
+++ b/sdk/nodejs/src/types.ts
@@ -51,16 +51,6 @@ export interface DVCUser {
 }
 
 /**
- * Initialize the SDK
- * @param environmentKey
- * @param options
- */
-export type initialize = (
-    environmentKey: string,
-    options?: DVCOptions
-) => Promise<DVCClient>
-
-/**
  * Options to control the setup of the DevCycle NodeJS Server SDK.
  */
 export interface DVCOptions {


### PR DESCRIPTION
Export only the interface, not the class