### PR TITLE
DVC-2743 override lerna

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This allows you to lint and/or test all projects at once.
 
 ### Publishing a Release
 To publish a release, use lerna to create new versions of all changed packages (ensure you do this on the main branch)
-`lerna version`
+`yarn lerna:version`
 
 Push up the new tags and version changes, then run:
 

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,6 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "independent"
+  "version": "independent",
+  "ignoreChanges": ["**"]
 }

--- a/package.json
+++ b/package.json
@@ -18,14 +18,7 @@
     "affected:test": "nx affected --base=origin/main --target=test --codeCoverage",
     "npm-publish": "nx affected --base=origin/main~1 --target=npm-publish",
     "start": "nx serve",
-    "lerna": "lerna",
-    "lerna:test:unit": "lerna run unit-test",
-    "lerna:version": "lerna version -m \"Release\"",
-    "lerna:version:force": "lerna version -m \"Release\" --force-publish",
-    "lerna:version:force:minor": "lerna version minor -m \"Release\" --force-publish",
-    "lerna:version:patch": "lerna version patch -m \"Release\"",
-    "lerna:version:minor": "lerna version minor -m \"Release\"",
-    "lerna:version:major": "lerna version major -m \"Release\""
+    "lerna:version": "scripts/lerna-version.sh"
   },
   "dependencies": {
     "@assemblyscript/loader": "^0.19.23",

--- a/scripts/lerna-version.sh
+++ b/scripts/lerna-version.sh
@@ -1,0 +1,47 @@
+DESCRIBE_OUTPUT=$(git describe --always --long --dirty --first-parent)
+
+# Get the last tagged sha from the output of "git describe"
+LAST_TAGGED_SHA=$(echo $DESCRIBE_OUTPUT | sed -En 's/^.*-g([0-9a-f]+)(-dirty)?$/\1/p')
+
+if [ -z "$LAST_TAGGED_SHA" ]; then
+  echo "Unable to find last tagged sha"
+  exit 1
+fi
+
+echo "Last tagged sha: $LAST_TAGGED_SHA"
+
+AFFECTED_PROJECTS=$(yarn --silent nx print-affected --base $LAST_TAGGED_SHA --select=projects)
+echo "Affected projects: $AFFECTED_PROJECTS"
+
+# exit if no affected projects
+if [ -z "$AFFECTED_PROJECTS" ]; then
+  echo "No affected projects found. Exiting."
+  exit 0
+fi
+
+# strip whitespace from affected projects
+AFFECTED_PROJECTS=$(echo "$AFFECTED_PROJECTS" | tr -d '[:space:]')
+
+# split affect projects on comma
+IFS=',' read -ra AFFECTED_PROJECTS <<< "$AFFECTED_PROJECTS"
+
+# loop through affected projects
+PACKAGES=()
+for PROJECT in "${AFFECTED_PROJECTS[@]}"; do
+
+  echo "Getting package name for $PROJECT"
+
+  # get filepath from project.json
+  FILEPATH=$(cat "workspace.json" | jq -r ".projects.\"$PROJECT\"")
+
+  # get package name from project.json
+  PACKAGE=$(cat "$FILEPATH/package.json" | jq -r '.name')
+
+  # add package to array
+  PACKAGES+=("$PACKAGE")
+done
+
+# join packages with comma
+PACKAGES=$(IFS=','; echo "${PACKAGES[*]}")
+
+yarn lerna version --force-publish=$PACKAGES -m "chore(release): " "$@"


### PR DESCRIPTION
- continue using `lerna version` to manage commits and tagging, but override the set of projects it will tag by using the output of `nx affected`
- wrote a script that borrows `lerna version` approach to finding the "base" commit to compare against by looking for the last commit that is tagged with a version
- grab a list of affected projects using `nx affected`
- turn those affected project names into package names by reading the "name" field from each project's package.json
- pass that list to `lerna version` and disable its change tracking