### PR TITLE
fix: lower case key for variables

### DIFF
--- a/sdk/nodejs/__tests__/models/variable.spec.ts
+++ b/sdk/nodejs/__tests__/models/variable.spec.ts
@@ -37,4 +37,12 @@ describe('DVCVariable Unit Tests', () => {
             isDefaulted: true
         }))
     })
+
+    it('should lowercase key name', () => {
+        const variable = new DVCVariable({
+            key: 'camelCaseKey',
+            defaultValue: false
+        })
+        expect(variable.key).toBe('camelcasekey')
+    })
 })

--- a/sdk/nodejs/src/models/variable.ts
+++ b/sdk/nodejs/src/models/variable.ts
@@ -19,7 +19,7 @@ export class DVCVariable implements DVCVariableInterface {
         checkParamDefined('key', key)
         checkParamDefined('defaultValue', defaultValue)
         checkParamType('key', key, typeEnum.string)
-        this.key = key
+        this.key = key.toLowerCase()
         this.isDefaulted = (value === undefined || value === null)
         this.value = (value === undefined || value === null)
             ? defaultValue


### PR DESCRIPTION
# Changes

- made node js sdk keys for variables lower case