### PR TITLE
chore: switch to npm for publishing

### DIFF
--- a/scripts/npm-safe-publish.sh
+++ b/scripts/npm-safe-publish.sh
@@ -51,7 +51,7 @@ if [[ "$NPM_SHOW" != "$NPM_LS" ]]; then
     exit 1
   fi
 
-  yarn publish --otp=$OTP
+  npm publish --otp=$OTP
 else
   echo "Versions are the same ($NPM_SHOW = $NPM_LS). Not pushing"
 fi


### PR DESCRIPTION
yarn 3 isn't happy about being running inside the dist/ directory packages.

switch to using `npm publish` for publishing