### PR TITLE
adds bash script to be run by vercel

### DIFF
--- a/should-vercel-build.sh
+++ b/should-vercel-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "main"  ]] ; then
+  # Proceed with the build
+    echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
this prevents vercel from running preview builds

https://vercel.com/support/articles/how-do-i-use-the-ignored-build-step-field-on-vercel