### PR TITLE
fix: change initializeDVCClient to return client instead of promise

### DIFF
--- a/sdk/react/src/DVCProvider.tsx
+++ b/sdk/react/src/DVCProvider.tsx
@@ -1,8 +1,7 @@
 import { ProviderConfig } from './types'
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useEffect, useMemo, useState } from 'react'
 import initializeDVCClient from './initializeDVCClient'
 import { Provider } from './context'
-import type { DVCClient } from '@devcycle/devcycle-js-sdk'
 
 type Props = {
   config: ProviderConfig
@@ -11,12 +10,8 @@ type Props = {
 
 export default function DVCProvider(props: Props): React.ReactElement {
     const { envKey, user, options } = props.config
-    const [client, setClient] = useState<DVCClient>(undefined!)
+    const client = useMemo(() => initializeDVCClient(envKey, user, options), [envKey, user, options])
     const [_, forceRerender] = useState({})
-
-    if (!client) {
-        setClient(initializeDVCClient(envKey, user, options))
-    }
 
     useEffect(() => {
         client.subscribe('variableUpdated:*', () => {

--- a/sdk/react/src/DVCProvider.tsx
+++ b/sdk/react/src/DVCProvider.tsx
@@ -11,13 +11,15 @@ type Props = {
 
 export default function DVCProvider(props: Props): React.ReactElement {
     const { envKey, user, options } = props.config
-    const [client, setClient] = useState<DVCClient | undefined>(undefined)
+    const [client, setClient] = useState<DVCClient>(undefined!)
     const [_, forceRerender] = useState({})
+
+    if (!client) {
+        setClient(initializeDVCClient(envKey, user, options))
+    }
 
     useEffect(() => {
         (async () => {
-            const client = await initializeDVCClient(envKey, user, options)
-            setClient(client)
             client.subscribe('variableUpdated:*', () => {
                 forceRerender({})
             })

--- a/sdk/react/src/DVCProvider.tsx
+++ b/sdk/react/src/DVCProvider.tsx
@@ -19,11 +19,9 @@ export default function DVCProvider(props: Props): React.ReactElement {
     }
 
     useEffect(() => {
-        (async () => {
-            client.subscribe('variableUpdated:*', () => {
-                forceRerender({})
-            })
-        })()
+        client.subscribe('variableUpdated:*', () => {
+            forceRerender({})
+        })
     }, [])
   
     return (

--- a/sdk/react/src/context.ts
+++ b/sdk/react/src/context.ts
@@ -1,11 +1,11 @@
 import { createContext } from 'react'
-import type { DVCClient, DVCVariable } from '@devcycle/devcycle-js-sdk'
+import type { DVCClient } from '@devcycle/devcycle-js-sdk'
 
 interface DVCContext {
-  client?: DVCClient
+  client: DVCClient
 }
 
-const context = createContext<DVCContext>({ client: undefined })
+const context = createContext<DVCContext | undefined>(undefined)
 const { Provider, Consumer } = context
 
 export { Provider, Consumer }

--- a/sdk/react/src/context.ts
+++ b/sdk/react/src/context.ts
@@ -2,10 +2,10 @@ import { createContext } from 'react'
 import type { DVCClient, DVCVariable } from '@devcycle/devcycle-js-sdk'
 
 interface DVCContext {
-  client: DVCClient
+  client?: DVCClient
 }
 
-const context = createContext<DVCContext>({ client: undefined! })
+const context = createContext<DVCContext>({ client: undefined })
 const { Provider, Consumer } = context
 
 export { Provider, Consumer }

--- a/sdk/react/src/context.ts
+++ b/sdk/react/src/context.ts
@@ -2,10 +2,10 @@ import { createContext } from 'react'
 import type { DVCClient, DVCVariable } from '@devcycle/devcycle-js-sdk'
 
 interface DVCContext {
-  client?: DVCClient
+  client: DVCClient
 }
 
-const context = createContext<DVCContext>({ client: undefined })
+const context = createContext<DVCContext>({ client: undefined! })
 const { Provider, Consumer } = context
 
 export { Provider, Consumer }

--- a/sdk/react/src/initializeDVCClient.ts
+++ b/sdk/react/src/initializeDVCClient.ts
@@ -1,13 +1,12 @@
 import { DVCOptions, initialize } from '@devcycle/devcycle-js-sdk'
 import type { DVCUser, DVCClient } from '@devcycle/devcycle-js-sdk'
 
-const initializeDVCClient = async (
+const initializeDVCClient = (
     environmentKey: string,
     user: DVCUser = { isAnonymous: true },
     options?: DVCOptions,
-): Promise<DVCClient> => {
-    const client = initialize(environmentKey, user, options)
-    return client.onClientInitialized()
+): DVCClient => {
+    return initialize(environmentKey, user, options)
 }
 
 export default initializeDVCClient

--- a/sdk/react/src/useDVCClient.ts
+++ b/sdk/react/src/useDVCClient.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import context from './context'
 import { DVCClient } from '@devcycle/devcycle-js-sdk'
 
-export const useDVCClient = (): DVCClient | undefined => {
+export const useDVCClient = (): DVCClient => {
     const { client } = useContext(context)
 
     return client

--- a/sdk/react/src/useDVCClient.ts
+++ b/sdk/react/src/useDVCClient.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import context from './context'
 import { DVCClient } from '@devcycle/devcycle-js-sdk'
 
-export const useDVCClient = (): DVCClient => {
+export const useDVCClient = (): DVCClient | undefined => {
     const { client } = useContext(context)
 
     return client

--- a/sdk/react/src/useDVCClient.ts
+++ b/sdk/react/src/useDVCClient.ts
@@ -2,10 +2,12 @@ import { useContext } from 'react'
 import context from './context'
 import { DVCClient } from '@devcycle/devcycle-js-sdk'
 
-export const useDVCClient = (): DVCClient | undefined => {
-    const { client } = useContext(context)
+export const useDVCClient = (): DVCClient => {
+    const dvcContext = useContext(context)
 
-    return client
+    if (dvcContext === undefined) throw new Error('useDVCClient must be used within DVCProvider')
+
+    return dvcContext.client
 }
 
 export default useDVCClient

--- a/sdk/react/src/useVariable.ts
+++ b/sdk/react/src/useVariable.ts
@@ -3,8 +3,11 @@ import context from './context'
 import type { DVCVariable, DVCVariableValue } from '@devcycle/devcycle-js-sdk'
 
 export const useVariable = (key: string, defaultValue: DVCVariableValue): DVCVariable => {
-    const { client } = useContext(context)
-    return client ? client.variable(key, defaultValue) : {
+    const dvcContext = useContext(context)
+
+    if (dvcContext === undefined) throw new Error('useVariable must be used within DVCProvider')
+
+    return dvcContext.client ? dvcContext.client.variable(key, defaultValue) : {
         value: defaultValue,
         defaultValue: defaultValue,
         isDefaulted: true,


### PR DESCRIPTION
- `initializeDVCClient` returns the client object instead of a promise
- update context typing so the client is not undefined in `useDVCClient`: https://medium.com/@rivoltafilippo/typing-react-context-to-avoid-an-undefined-default-value-2c7c5a7d5947