### PR TITLE
DVC-3088 set minimum node version to 14, add null checks

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -12,6 +12,6 @@
     "@devcycle/bucketing-assembly-script": "^1.0.11"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   }
 }

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -69,7 +69,7 @@ export class DVCClient {
             })
 
         process.on('exit', () => {
-            this.configHelper.cleanup()
+            this.configHelper?.cleanup()
         })
     }
 
@@ -79,7 +79,7 @@ export class DVCClient {
      *
      * @param onInitialized
      */
-    onClientInitialized(onInitialized?: (err?: Error) => void): Promise<DVCClient> {
+    async onClientInitialized(onInitialized?: (err?: Error) => void): Promise<DVCClient> {
         if (onInitialized && typeof onInitialized === 'function') {
             this.onInitialized
                 .then(() => onInitialized())
@@ -152,7 +152,7 @@ export class DVCClient {
         this.eventQueue.queueEvent(requestUser, event, bucketedConfig)
     }
 
-    flushEvents(callback?: () => void): Promise<void> {
+    async flushEvents(callback?: () => void): Promise<void> {
         return this.eventQueue.flushEvents().then(callback)
     }
 }


### PR DESCRIPTION
- Set the minimum node version to 14, while we sort out issues with node versions < 14
- fix null exception
- mark async functions