### PR TITLE
fix: flush events before config is ready

### DIFF
--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -31,11 +31,6 @@ export class EventQueue {
     }
 
     async flushEvents(): Promise<void> {
-        if (!this.client.config) {
-            console.log('DVC Client not initialized to flush events!')
-            return
-        }
-
         const eventsToFlush = [ ...this.eventQueue ]
         const aggregateEventsToFlush = this.eventsFromAggregateEventMap()
         eventsToFlush.push(...aggregateEventsToFlush)
@@ -52,7 +47,7 @@ export class EventQueue {
         try {
             const res = await publishEvents(
                 this.environmentKey,
-                this.client.config,
+                this.client.config || null,
                 this.client.user,
                 eventsToFlush
             )

--- a/sdk/js/src/Request.ts
+++ b/sdk/js/src/Request.ts
@@ -87,7 +87,7 @@ export const patch = async (
 
 export const publishEvents = async (
     envKey: string | null,
-    config: BucketedUserConfig,
+    config: BucketedUserConfig | null,
     user: DVCPopulatedUser,
     events: DVCEvent[]
 ): Promise<AxiosResponse> => {

--- a/sdk/js/src/RequestEvent.ts
+++ b/sdk/js/src/RequestEvent.ts
@@ -22,7 +22,7 @@ export class DVCRequestEvent implements DVCEvent {
         this.user_id = user_id
         this.clientDate = date || Date.now()
         this.value = value
-        this.featureVars = featureVars
+        this.featureVars = featureVars || {}
         this.metaData = metaData
     }
 }

--- a/sdk/js/src/utils.ts
+++ b/sdk/js/src/utils.ts
@@ -46,13 +46,13 @@ export const checkParamType = (name: string, param: unknown, type: string): void
 }
 
 export function generateEventPayload(
-    config: BucketedUserConfig,
+    config: BucketedUserConfig | null,
     user: DVCPopulatedUser,
     events: DVCEvent[]
 ): SDKEventRequestBody {
     return {
         events: events.map((event) => {
-            return new DVCRequestEvent(event, user.user_id, config.featureVariationMap)
+            return new DVCRequestEvent(event, user.user_id, config?.featureVariationMap)
         }),
         user
     }


### PR DESCRIPTION
- allows `variableDefaulted` events and other custom tracked events to be flushed before the config is ready
- events are associated with `user_id` but have no `featureVars`