### PR TITLE
save the updated user to edgedb

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -148,7 +148,7 @@ export class DVCClient implements Client {
                     this.config = config as BucketedUserConfig
 
                     if (checkIfEdgeEnabled(this.options?.enableEdgeDB, this.config)) {
-                        saveEntity(this.user, this.environmentKey)
+                        saveEntity(updatedUser, this.environmentKey)
                             .then((res) => console.log(`Saved response entity! ${res}`))
                     }
 


### PR DESCRIPTION
The identifyUser function was saving the old user to edgeDB, rather than the updated version which is, at this point in the code, only saved in the `updatedUser` variable