### PR TITLE
Dvc 3528 add variationKey to bucketed features and remove from variable 

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
@@ -157,7 +157,8 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature1',
                     'type': 'release',
                     '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2'
+                    'variationName': 'variation 2',
+                    'variationKey': 'variation-2-key',
                 }
             },
             'featureVariationMap': {
@@ -170,8 +171,6 @@ describe('Config Parsing and Generating', () => {
                     'type': 'String',
                     'value': 'YEEEEOWZA',
                     '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2',
-                    'featureKey': 'feature1',
                 }
             }
         }
@@ -214,14 +213,16 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature1',
                     'type': 'release',
                     '_variation': '6153553b8cf4e45e0464268d',
-                    'variationName': 'variation 1'
+                    'variationName': 'variation 1',
+                    'variationKey': 'variation-1-key',
                 },
                 'feature2': {
                     '_id': '614ef6aa475928459060721a',
                     'key': 'feature2',
                     'type': 'release',
                     '_variation': '615382338424cb11646d7668',
-                    'variationName': 'feature 2 variation'
+                    'variationName': 'feature 2 variation',
+                    'variationKey': 'variation-feature-2-key',
                 }
             },
             'featureVariationMap': {
@@ -234,36 +235,28 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature2.cool',
                     'type': 'String',
                     'value': 'multivar first',
-                    '_variation': '615382338424cb11646d7668',
-                    'variationName': 'feature 2 variation',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7668'
                 },
                 'feature2.hello': {
                     '_id': '61538237b0a70b58ae6af71h',
                     'key': 'feature2.hello',
                     'type': 'String',
                     'value': 'multivar last',
-                    '_variation': '615382338424cb11646d7668',
-                    'variationName': 'feature 2 variation',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7668'
                 },
                 'swagTest': {
                     '_id': '615356f120ed334a6054564c',
                     'key': 'swagTest',
                     'type': 'String',
                     'value': 'man',
-                    '_variation': '6153553b8cf4e45e0464268d',
-                    'variationName': 'variation 1',
-                    'featureKey': 'feature1',
+                    '_variation': '6153553b8cf4e45e0464268d'
                 },
                 'test': {
                     '_id': '614ef6ea475129459160721a',
                     'key': 'test',
                     'type': 'String',
                     'value': 'scat',
-                    '_variation': '6153553b8cf4e45e0464268d',
-                    'variationName': 'variation 1',
-                    'featureKey': 'feature1',
+                    '_variation': '6153553b8cf4e45e0464268d'
                 }
             }
         }
@@ -309,7 +302,8 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature2',
                     'type': 'release',
                     '_variation': '615382338424cb11646d7667',
-                    'variationName': 'variation 1 aud 2'
+                    'variationName': 'variation 1 aud 2',
+                    'variationKey': 'variation-1-aud-2-key',
                 }
             },
             'featureVariationMap': {
@@ -321,9 +315,7 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature2Var',
                     'type': 'String',
                     'value': 'Var 1 aud 2',
-                    '_variation': '615382338424cb11646d7667',
-                    'variationName': 'variation 1 aud 2',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7667'
                 }
             }
         }
@@ -366,7 +358,8 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature1',
                     'type': 'release',
                     '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2'
+                    'variationName': 'variation 2',
+                    'variationKey': 'variation-2-key',
                 },
                 'feature2': {
                     '_id': '614ef6aa475928459060721a',
@@ -374,6 +367,7 @@ describe('Config Parsing and Generating', () => {
                     'type': 'release',
                     '_variation': '615382338424cb11646d7667',
                     'variationName': 'variation 1 aud 2',
+                    'variationKey': 'variation-1-aud-2-key',
                 }
             },
             'featureVariationMap': {
@@ -386,18 +380,14 @@ describe('Config Parsing and Generating', () => {
                     'key': 'swagTest',
                     'type': 'String',
                     'value': 'YEEEEOWZA',
-                    '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2',
-                    'featureKey': 'feature1',
+                    '_variation': '615357cf7e9ebdca58446ed0'
                 },
                 'feature2Var': {
                     '_id': '61538237b0a70b58ae6af71f',
                     'key': 'feature2Var',
                     'type': 'String',
                     'value': 'Var 1 aud 2',
-                    '_variation': '615382338424cb11646d7667',
-                    'variationName': 'variation 1 aud 2',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7667'
 
                 }
             }

--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/bucketing.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/bucketing.ts
@@ -221,6 +221,7 @@ export function _generateBucketedConfig(
             feature.key,
             variation_id,
             variation.name,
+            variation.key,
             null
         ))
         featureVariationMap.set(feature._id, variation_id)
@@ -247,8 +248,6 @@ export function _generateBucketedConfig(
                 variable.key,
                 variationVar.value,
                 variation._id,
-                variation.name,
-                feature.key,
                 null
             )
             variableMap.set(variable.key, newVar)

--- a/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
@@ -96,6 +96,7 @@ export class SDKFeature extends JSON.Obj {
         public key: string,
         public _variation: string,
         public variationName: string,
+        public variationKey: string,
         public evalReason: string | null
     ) {
         super()
@@ -108,6 +109,7 @@ export class SDKFeature extends JSON.Obj {
             getStringFromJSON(feature, 'key'),
             getStringFromJSON(feature, '_variation'),
             getStringFromJSON(feature, 'variationName'),
+            getStringFromJSON(feature, 'variationKey'),
             getStringFromJSONOptional(feature, 'evalReason')
         )
     }
@@ -119,6 +121,7 @@ export class SDKFeature extends JSON.Obj {
         json.set('key', this.key)
         json.set('_variation', this._variation)
         json.set('variationName', this.variationName)
+        json.set('variationKey', this.variationKey)
         if (this.evalReason) {
             json.set('evalReason', this.evalReason)
         }
@@ -133,8 +136,6 @@ export class SDKVariable extends JSON.Obj {
         public key: string,
         public value: JSON.Value,
         public _variation: string,
-        public variationName: string,
-        public featureKey: string, 
         public evalReason: string | null,
     ) {
         super()
@@ -147,8 +148,6 @@ export class SDKVariable extends JSON.Obj {
             getStringFromJSON(variable, 'key'),
             getJSONValueFromJSON(variable, 'value'),
             getStringFromJSON(variable, '_variation'),
-            getStringFromJSON(variable, 'variationName'),
-            getStringFromJSON(variable, 'featureKey'),
             getStringFromJSONOptional(variable, 'evalReason')
         )
     }
@@ -160,8 +159,6 @@ export class SDKVariable extends JSON.Obj {
         json.set('key', this.key)
         json.set('value', this.value)
         json.set('_variation', this._variation)
-        json.set('variationName', this.variationName)
-        json.set('featureKey', this.featureKey)
         if (this.evalReason) {
             json.set('evalReason', this.evalReason)
         }

--- a/lib/shared/bucketing-assembly-script/assembly/types/feature.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/feature.ts
@@ -47,6 +47,7 @@ export class Feature extends JSON.Value {
 export class Variation extends JSON.Value {
     _id: string
     name: string
+    key: string
     variables: Array<VariationVariable>
 
     constructor(variation: JSON.Obj) {
@@ -54,6 +55,7 @@ export class Variation extends JSON.Value {
         this._id = getStringFromJSON(variation, '_id')
 
         this.name = getStringFromJSON(variation, 'name')
+        this.key = getStringFromJSON(variation, 'key')
 
         const variables = getJSONArrayFromJSON(variation, 'variables')
         this.variables = variables.valueOf().map<VariationVariable>((variable) => {
@@ -65,6 +67,7 @@ export class Variation extends JSON.Value {
         const json = new JSON.Obj()
         json.set('_id', this._id)
         json.set('name', this.name)
+        json.set('key', this.key)
         json.set('variables', jsonArrFromValueArray(this.variables))
 
         return json.stringify()

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -141,6 +141,7 @@ export const variations: PublicVariation[] = [
     {
         _id: '6153553b8cf4e45e0464268d',
         name: 'variation 1',
+        key: 'variation-1-key',
         variables: [{
             _var: variables[0]._id,
             value: 'scat'
@@ -152,6 +153,7 @@ export const variations: PublicVariation[] = [
     }, {
         _id: '615357cf7e9ebdca58446ed0',
         name: 'variation 2',
+        key: 'variation-2-key',
         variables: [
             {
                 _var: variables[1]._id,
@@ -161,6 +163,7 @@ export const variations: PublicVariation[] = [
     {
         _id: '615382338424cb11646d7667',
         name: 'variation 1 aud 2',
+        key: 'variation-1-aud-2-key',
         variables: [
             {
                 _var: variables[2]._id,
@@ -170,6 +173,7 @@ export const variations: PublicVariation[] = [
     {
         _id: '615382338424cb11646d7668',
         name: 'feature 2 variation',
+        key: 'variation-feature-2-key',
         variables: [
             {
                 _var: variables[3]._id,
@@ -184,6 +188,7 @@ export const variations: PublicVariation[] = [
     {
         _id: '615382338424cb11646d7668',
         name: 'feature 2 never used variation',
+        key: 'variation-never-used-key',
         variables: [
             {
                 _var: variables[3]._id,
@@ -198,6 +203,7 @@ export const variations: PublicVariation[] = [
     {
         _id: '615382338424cb11646d7660',
         name: 'feature 2 never used variation, bool',
+        key: 'variation-bool-key',
         variables: [
             {
                 _var: variables[3]._id,
@@ -212,6 +218,7 @@ export const variations: PublicVariation[] = [
     {
         _id: '615382338424cb11646d7661',
         name: 'feature 2 never used variation, number',
+        key: 'variation-number-key',
         variables: [
             {
                 _var: variables[3]._id,

--- a/lib/shared/bucketing/__test__/bucketing.test.ts
+++ b/lib/shared/bucketing/__test__/bucketing.test.ts
@@ -105,6 +105,7 @@ describe('Config Parsing and Generating', () => {
                     'type': FeatureType.release,
                     '_variation': '615357cf7e9ebdca58446ed0',
                     'variationName': 'variation 2',
+                    "variationKey": "variation-2-key",
                 }
             },
             'featureVariationMap': {
@@ -117,8 +118,6 @@ describe('Config Parsing and Generating', () => {
                     'type': 'String',
                     'value': 'YEEEEOWZA',
                     '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2',
-                    'featureKey': 'feature1',
                 }
             }
         }
@@ -162,6 +161,7 @@ describe('Config Parsing and Generating', () => {
                     'type': FeatureType.release,
                     '_variation': '6153553b8cf4e45e0464268d',
                     'variationName': 'variation 1',
+                    "variationKey": "variation-1-key",
                 },
                 'feature2': {
                     '_id': '614ef6aa475928459060721a',
@@ -169,6 +169,7 @@ describe('Config Parsing and Generating', () => {
                     'type': FeatureType.release,
                     '_variation': '615382338424cb11646d7668',
                     'variationName': 'feature 2 variation',
+                    "variationKey": "variation-feature-2-key",
                 }
             },
             'featureVariationMap': {
@@ -181,36 +182,28 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature2.cool',
                     'type': 'String',
                     'value': 'multivar first',
-                    '_variation': '615382338424cb11646d7668',
-                    'variationName': 'feature 2 variation',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7668'
                 },
                 'feature2.hello': {
                     '_id': '61538237b0a70b58ae6af71h',
                     'key': 'feature2.hello',
                     'type': 'String',
                     'value': 'multivar last',
-                    '_variation': '615382338424cb11646d7668',
-                    'variationName': 'feature 2 variation',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7668'
                 },
                 'swagTest': {
                     '_id': '615356f120ed334a6054564c',
                     'key': 'swagTest',
                     'type': 'String',
                     'value': 'man',
-                    '_variation': '6153553b8cf4e45e0464268d',
-                    'variationName': 'variation 1',
-                    'featureKey': 'feature1',
+                    '_variation': '6153553b8cf4e45e0464268d'
                 },
                 'test': {
                     '_id': '614ef6ea475129459160721a',
                     'key': 'test',
                     'type': 'String',
                     'value': 'scat',
-                    '_variation': '6153553b8cf4e45e0464268d',
-                    'variationName': 'variation 1',
-                    'featureKey': 'feature1',
+                    '_variation': '6153553b8cf4e45e0464268d'
                 }
             }
         }
@@ -257,6 +250,7 @@ describe('Config Parsing and Generating', () => {
                     'type': FeatureType.release,
                     '_variation': '615382338424cb11646d7667',
                     'variationName': 'variation 1 aud 2',
+                    "variationKey": "variation-1-aud-2-key",
                 }
             },
             'featureVariationMap': {
@@ -268,9 +262,7 @@ describe('Config Parsing and Generating', () => {
                     'key': 'feature2Var',
                     'type': 'String',
                     'value': 'Var 1 aud 2',
-                    '_variation': '615382338424cb11646d7667',
-                    'variationName': 'variation 1 aud 2',
-                    'featureKey': 'feature2',
+                    '_variation': '615382338424cb11646d7667'
                 }
             }
         }
@@ -314,6 +306,7 @@ describe('Config Parsing and Generating', () => {
                     'type': FeatureType.release,
                     '_variation': '615357cf7e9ebdca58446ed0',
                     'variationName': 'variation 2',
+                    "variationKey": "variation-2-key",
                 },
                 'feature2': {
                     '_id': '614ef6aa475928459060721a',
@@ -321,6 +314,7 @@ describe('Config Parsing and Generating', () => {
                     'type': FeatureType.release,
                     '_variation': '615382338424cb11646d7667',
                     'variationName': 'variation 1 aud 2',
+                    "variationKey": "variation-1-aud-2-key",
                 }
             },
             'featureVariationMap': {
@@ -334,8 +328,6 @@ describe('Config Parsing and Generating', () => {
                     'type': 'String',
                     'value': 'YEEEEOWZA',
                     '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2',
-                    'featureKey': 'feature1',
                 },
                 'feature2Var': {
                     '_id': '61538237b0a70b58ae6af71f',
@@ -343,8 +335,6 @@ describe('Config Parsing and Generating', () => {
                     'type': 'String',
                     'value': 'Var 1 aud 2',
                     '_variation': '615382338424cb11646d7667',
-                    'variationName': 'variation 1 aud 2',
-                    'featureKey': 'feature2',
                 }
             }
         }

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -180,7 +180,8 @@ export const generateBucketedConfig = (
             key,
             type,
             _variation: variation_id,
-            variationName: variation.name
+            variationName: variation.name,
+            variationKey: variation.key
         }
         featureVariationMap[_id] = variation_id
         variation.variables.forEach(({ _var, value }) => {
@@ -190,10 +191,8 @@ export const generateBucketedConfig = (
             }
             variableMap[variable.key] = { 
                 ...variable, 
-                value, 
-                variationName: variation.name, 
+                value,
                 _variation: variation._id,
-                featureKey: key
             }
         })
     })

--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -303,14 +303,13 @@ export class DVCClientAPIUser implements DVCAPIUser {
 export type SDKVariable = PublicVariable & {
     value: VariableValue
     _variation: string
-    variationName: string
-    featureKey: string
     evalReason?: unknown
 }
 
 export type SDKFeature = Pick<PublicFeature, '_id' | 'key' | 'type'> & {
     _variation: string,
     variationName: string,
+    variationKey: string
     evalReason?: unknown
 }
 

--- a/lib/shared/types/src/types/config/models/feature.ts
+++ b/lib/shared/types/src/types/config/models/feature.ts
@@ -14,6 +14,7 @@ export class Variation<IdType = string> {
     _id: IdType
 
     name: string
+    key: string
 
     /**
      * Defining variable values.


### PR DESCRIPTION
Final result is variationKey and variationName added to the features in the bucketed config (so getAllFeatures in SDKs will include those keys), and no changes made to variations in the bucketed config

We talked about adding feature name as well, but that requires a config service change as well so i'm going to get this merged first and then separate the name-related changes into their own commit / PR