### PR TITLE
make variationName and variationKey optional

### DIFF
--- a/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
@@ -95,8 +95,8 @@ export class SDKFeature extends JSON.Obj {
         public type: string,
         public key: string,
         public _variation: string,
-        public variationName: string,
-        public variationKey: string,
+        public variationName: string | null,
+        public variationKey: string | null,
         public evalReason: string | null
     ) {
         super()
@@ -120,8 +120,12 @@ export class SDKFeature extends JSON.Obj {
         json.set('type', this.type)
         json.set('key', this.key)
         json.set('_variation', this._variation)
-        json.set('variationName', this.variationName)
-        json.set('variationKey', this.variationKey)
+        if (this.variationName) {
+            json.set('variationName', this.variationName)
+        }
+        if (this.variationKey) {
+            json.set('variationKey', this.variationKey)
+        }
         if (this.evalReason) {
             json.set('evalReason', this.evalReason)
         }

--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -307,8 +307,8 @@ export type SDKVariable = PublicVariable & {
 
 export type SDKFeature = Pick<PublicFeature, '_id' | 'key' | 'type'> & {
     _variation: string,
-    variationName: string,
-    variationKey: string
+    variationName?: string,
+    variationKey?: string
     evalReason?: unknown
 }
 

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -17,8 +17,8 @@ export type DVCVariableSet = {
 export type DVCFeature = {
     readonly _id: string
     readonly _variation: string
-    readonly variationKey: string
-    readonly variationName: string
+    readonly variationKey?: string
+    readonly variationName?: string
     readonly key: string
     readonly type: string
     readonly evalReason?: any

--- a/sdk/nodejs/src/types.ts
+++ b/sdk/nodejs/src/types.ts
@@ -161,8 +161,8 @@ export interface DVCFeature {
     readonly _id: string
 
     readonly _variation: string
-    readonly variationKey: string
-    readonly variationName: string
+    readonly variationKey?: string
+    readonly variationName?: string
 
     readonly key: string
 


### PR DESCRIPTION
- make variationName and variationKey attributes optional in order to maintain backward compatibility of bucketing-api for older versions of java and android sdks