### PR TITLE
fix entry file path for react native android

### DIFF
--- a/examples/react/react-native-app/android/app/build.gradle
+++ b/examples/react/react-native-app/android/app/build.gradle
@@ -79,7 +79,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "examples/react/react-native-app/src/main.tsx",
+    entryFile: "src/main.tsx",
     enableHermes: false,  // clean and rebuild if changing
 ]
 

--- a/examples/react/react-native-app/android/app/src/main/java/com/reactnativeapp/MainApplication.java
+++ b/examples/react/react-native-app/android/app/src/main/java/com/reactnativeapp/MainApplication.java
@@ -32,7 +32,7 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override
         protected String getJSMainModuleName() {
-          return "examples/react/react-native-app/src/main";
+          return "src/main.tsx";
         }
       };
 


### PR DESCRIPTION
- the command `yarn nx run-android example-react-native-app` wouldn't work because the entry file path was wrong