### PR TITLE
[DVC-3403] variableDefaulted logging

### DIFF
--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -18,3 +18,34 @@ describe('DVCClient', () => {
         })
     })
 })
+
+describe('variable', () => {
+    const user = {
+        user_id: 'node_sdk_test',
+        country: 'CA'
+    }
+    const expectedUser = expect.objectContaining({
+        user_id: 'node_sdk_test',
+        country: 'CA'
+    })
+    
+    describe('variableDefaulted event', () => {
+        test('does not get sent if variable is in bucketed config',async () => {
+            const client = new DVCClient('token')
+
+            await client.onClientInitialized()
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            client.eventQueue.queueAggregateEvent = jest.fn()
+            client.variable(user, 'test-key', false)
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            expect(client.eventQueue.queueAggregateEvent)
+                .toBeCalledWith(expectedUser, 
+                    { type: 'variableEvaluated', target: 'test-key' }, 
+                    { 'variables': { ['test-key']: true } }
+                )
+        })
+    })
+})

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -30,13 +30,20 @@ describe('variable', () => {
     })
     
     describe('variableDefaulted event', () => {
-        test('does not get sent if variable is in bucketed config',async () => {
-            const client = new DVCClient('token')
+        let client: DVCClient
 
+        beforeAll(async () => {
+            client = new DVCClient('token')
             await client.onClientInitialized()
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             client.eventQueue.queueAggregateEvent = jest.fn()
+        })
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+    
+        it('does not get sent if variable is in bucketed config',async () => {
             client.variable(user, 'test-key', false)
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -44,6 +51,17 @@ describe('variable', () => {
             expect(client.eventQueue.queueAggregateEvent)
                 .toBeCalledWith(expectedUser, 
                     { type: 'variableEvaluated', target: 'test-key' }, 
+                    { 'variables': { ['test-key']: true } }
+                )
+        })
+        it('gets sent if variable is not in bucketed config',async () => {
+            client.variable(user, 'test-key-not-in-config', false)
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            expect(client.eventQueue.queueAggregateEvent)
+                .toBeCalledWith(expectedUser, 
+                    { type: 'variableDefaulted', target: 'test-key-not-in-config' }, 
                     { 'variables': { ['test-key']: true } }
                 )
         })

--- a/sdk/nodejs/src/__mocks__/bucketing.ts
+++ b/sdk/nodejs/src/__mocks__/bucketing.ts
@@ -2,7 +2,8 @@ let Bucketing: unknown
 export const importBucketingLib = async (): Promise<void> => {
     Bucketing = await new Promise((resolve) => resolve({
         setConfigData: jest.fn(),
-        setPlatformData: jest.fn()
+        setPlatformData: jest.fn(),
+        generateBucketedConfigForUser: jest.fn().mockReturnValue(JSON.stringify({ variables: { ['test-key']: true } }))
     }))
 }
 

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -108,9 +108,9 @@ export class DVCClient {
         })
 
         const variableEvent = {
-            type: variable.value === variable.defaultValue
-                ? EventTypes.variableDefaulted
-                : EventTypes.variableEvaluated,
+            type: variable.key in bucketedConfig.variables
+                ? EventTypes.variableEvaluated
+                : EventTypes.variableDefaulted,
             target: variable.key
         }
         this.eventQueue.queueAggregateEvent(requestUser, variableEvent, bucketedConfig)


### PR DESCRIPTION
- send `variableDefaulted` event only when variable is NOT in bucketed config