### PR TITLE
fix: use pattern to block dist folders not under node modules

### DIFF
--- a/examples/react/react-native-app/metro.config.js
+++ b/examples/react/react-native-app/metro.config.js
@@ -21,6 +21,7 @@ module.exports = (async () => {
                 assetExts: assetExts.filter((ext) => ext !== 'svg'),
                 sourceExts: [...sourceExts, 'svg'],
                 resolverMainFields: ['sbmodern', 'browser', 'main'],
+                blockList: exclusionList([/^(?!.*node_modules).*\/dist\/.*/]),
             },
         },
         {


### PR DESCRIPTION
- the regex pattern suggested in this issue https://github.com/nrwl/nx/issues/10644 allows us to build the react native example app when the root level dist folder has content