### PR TITLE
Enable EdgeDB for NodeJS SDK

### DIFF
--- a/sdk/nodejs/__tests__/cloudClient.spec.ts
+++ b/sdk/nodejs/__tests__/cloudClient.spec.ts
@@ -11,7 +11,7 @@ const user = {
 const badUser = { user_id: 'bad' }
 const emptyUser = { user_id: 'empty' }
 
-describe('DVCCloudClient', () => {
+describe('DVCCloudClient without EdgeDB', () => {
     beforeAll(async () => {
         client = DVC.initialize('token', { logLevel: 'error', enableCloudBucketing: true })
         server.listen()
@@ -144,6 +144,101 @@ describe('DVCCloudClient', () => {
             expect(async () => await client.track(user, badEvent as unknown as DVCEvent))
             .rejects
             .toThrow('Invalid Event')
+        })
+    })
+})
+
+describe('DVCCloudClient with EdgeDB Enabled', () => {
+    beforeAll(async () => {
+        client = DVC.initialize('token', { logLevel: 'error', enableCloudBucketing: true, enableEdgeDB: true })
+        server.listen()
+    })
+    afterEach(() => server.resetHandlers())
+    afterAll(() => server.close())
+
+    describe('variable', () => {
+        it('to return a Value and not be defaulted', async () => {
+            const res = await client.variable(user, 'test-key', false)
+            expect(res.key).toContain('edgedb')
+            expect(res.value).toBe(true)
+            expect(res.isDefaulted).toBe(false)
+        })
+
+        it('to return the Default Value and be defaulted', async () => {
+            const res = await client.variable(user, 'test-key-not-in-config', false)
+            expect(res.key).not.toContain('edgedb')
+            expect(res.value).toBe(false)
+            expect(res.isDefaulted).toBe(true)
+        })
+
+        it('to throw an error if key is not defined', async () => {
+            try {
+                await client.variable(user, undefined as unknown as string, false)
+            } catch (ex) {
+                expect(ex.message).toBe(
+                    'Missing parameter: key'
+                )
+            }
+        })
+
+        it('to throw an error if defaultValue is not defined', async () => {
+            try {
+                await client.variable(user, 'test-key', undefined as unknown as string)
+            } catch (ex) {
+                expect(ex.message).toBe(
+                    'Missing parameter: defaultValue'
+                )
+            }
+        })
+    })
+
+    describe('allVariables', () => {
+        it('to return all variables', async () => {
+            const res = await client.allVariables(user)
+            expect(res).toEqual({
+                'test-key-edgedb': {
+                    key: 'test-key-edgedb',
+                    value: true,
+                    type: 'Boolean',
+                    defaultValue: false
+                }
+            })
+        })
+
+        it('to return no variables when allVariables call succeeds but user has no variables', async () => {
+            const res = await client.allVariables(emptyUser)
+            expect(res).toEqual({})
+        })
+
+        it('to return no variables when allVariables call fails', async () => {
+            const res = await client.allVariables(badUser)
+            expect(res).toEqual({})
+        })
+    })
+
+    describe('allFeatures', () => {
+        it('to return all features', async () => {
+            const res = await client.allFeatures(user)
+            expect(res).toEqual({
+                'test-feature-edgedb': {
+                    _id: 'test-id',
+                    _variation: 'variation-id',
+                    variationKey: 'variationKey',
+                    variationName: 'Variation Name',
+                    key: 'test-feature-edgedb',
+                    type: 'release',
+                }
+            })
+        })
+
+        it('to return no features when allFeatures call succeeds but user has no features', async () => {
+            const res = await client.allFeatures(emptyUser)
+            expect(res).toEqual({})
+        })
+
+        it('to return no features when allFeatures call fails', async () => {
+            const res = await client.allFeatures(badUser)
+            expect(res).toEqual({})
         })
     })
 })

--- a/sdk/nodejs/__tests__/cloudClient.spec.ts
+++ b/sdk/nodejs/__tests__/cloudClient.spec.ts
@@ -24,6 +24,7 @@ describe('DVCCloudClient without EdgeDB', () => {
             const res = await client.variable(user, 'test-key', false)
             expect(res.value).toBe(true)
             expect(res.isDefaulted).toBe(false)
+            expect(res.key).not.toContain('edgedb')
         })
 
         it('to return the Default Value and be defaulted', async () => {

--- a/sdk/nodejs/src/__mocks__/handlers.ts
+++ b/sdk/nodejs/src/__mocks__/handlers.ts
@@ -8,44 +8,33 @@ export const handlers = [
     )
   }),
   rest.post('https://bucketing-api.devcycle.com/v1/variables/test-key', (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({
-        key: 'test-key',
-        value: true,
-        type: 'Boolean',
-        defaultValue: false
-      })
-    )
-  }),
-  rest.post('https://bucketing-api.devcycle.com/v1/variables', (req, res, ctx) => {
-    const { user_id } = req.body as Record<string, any>
+    const enableEdgeDB = req.url.searchParams.get('enableEdgeDB')
 
-    if (user_id === 'bad') {
-      return res(
-        ctx.status(401)
-      )
-    } else if (user_id === 'empty') {
+    if (enableEdgeDB) {
       return res(
         ctx.status(200),
-        ctx.json({})
+        ctx.json({
+          key: 'test-key-edgedb',
+          value: true,
+          type: 'Boolean',
+          defaultValue: false
+        })
       )
     } else {
       return res(
         ctx.status(200),
         ctx.json({
-          'test-key': {
-            key: 'test-key',
-            value: true,
-            type: 'Boolean',
-            defaultValue: false
-          }
+          key: 'test-key',
+          value: true,
+          type: 'Boolean',
+          defaultValue: false
         })
       )
     }
   }),
-  rest.post('https://bucketing-api.devcycle.com/v1/features', (req, res, ctx) => {
+  rest.post('https://bucketing-api.devcycle.com/v1/variables', (req, res, ctx) => {
     const { user_id } = req.body as Record<string, any>
+    const enableEdgeDB = req.url.searchParams.get('enableEdgeDB')
 
     if (user_id === 'bad') {
       return res(
@@ -57,19 +46,76 @@ export const handlers = [
         ctx.json({})
       )
     } else {
+      if (enableEdgeDB) {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            'test-key-edgedb': {
+              key: 'test-key-edgedb',
+              value: true,
+              type: 'Boolean',
+              defaultValue: false
+            }
+          })
+        )
+      } else {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            'test-key': {
+              key: 'test-key',
+              value: true,
+              type: 'Boolean',
+              defaultValue: false
+            }
+          })
+        )
+      }
+    }
+  }),
+  rest.post('https://bucketing-api.devcycle.com/v1/features', (req, res, ctx) => {
+    const { user_id } = req.body as Record<string, any>
+    const enableEdgeDB = req.url.searchParams.get('enableEdgeDB')
+
+    if (user_id === 'bad') {
+      return res(
+        ctx.status(401)
+      )
+    } else if (user_id === 'empty') {
       return res(
         ctx.status(200),
-        ctx.json({
-          'test-feature': {
-            _id: 'test-id',
-            _variation: 'variation-id',
-            variationKey: 'variationKey',
-            variationName: 'Variation Name',
-            key: 'test-feature',
-            type: 'release',
-          }
-        })
+        ctx.json({})
       )
+    } else {
+      if (enableEdgeDB) {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            'test-feature-edgedb': {
+              _id: 'test-id',
+              _variation: 'variation-id',
+              variationKey: 'variationKey',
+              variationName: 'Variation Name',
+              key: 'test-feature-edgedb',
+              type: 'release',
+            }
+          })
+        )
+      } else {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            'test-feature': {
+              _id: 'test-id',
+              _variation: 'variation-id',
+              variationKey: 'variationKey',
+              variationName: 'Variation Name',
+              key: 'test-feature',
+              type: 'release',
+            }
+          })
+        )
+      }
     }
   }),
   rest.post('https://bucketing-api.devcycle.com/v1/track', (req, res, ctx) => {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -40,6 +40,10 @@ export class DVCClient {
         this.options = options
         this.logger = options?.logger || dvcDefaultLogger({ level: options?.logLevel })
 
+        if (options?.enableEdgeDB) {
+            this.logger.info('EdgeDB can only be enabled for the DVC Cloud Client.')
+        }
+
         const initializePromise = importBucketingLib()
             .then(() => {
                 this.configHelper = new EnvironmentConfigManager(this.logger, environmentKey, options || {})

--- a/sdk/nodejs/src/cloudClient.ts
+++ b/sdk/nodejs/src/cloudClient.ts
@@ -19,10 +19,12 @@ import { AxiosError, AxiosResponse } from 'axios'
 export class DVCCloudClient {
     private environmentKey: string
     private logger: DVCLogger
+    private options: DVCOptions
 
     constructor(environmentKey: string, options: DVCOptions) {
         this.environmentKey = environmentKey
         this.logger = options.logger || dvcDefaultLogger({ level: options.logLevel })
+        this.options = options
         this.logger.info(`Running DevCycle NodeJS SDK in Cloud Bucketing mode`)
     }
 
@@ -32,7 +34,7 @@ export class DVCCloudClient {
         checkParamDefined('key', key)
         checkParamDefined('defaultValue', defaultValue)
 
-        return getVariable(requestUser, this.environmentKey, key)
+        return getVariable(requestUser, this.environmentKey, key, this.options.enableEdgeDB)
             .then((res: AxiosResponse) => {
                 return new DVCVariable({
                     ...res.data,
@@ -50,7 +52,7 @@ export class DVCCloudClient {
 
     allVariables(user: DVCUser): Promise<DVCVariableSet> {
         const requestUser = new DVCPopulatedUser(user)
-        return getAllVariables(requestUser, this.environmentKey)
+        return getAllVariables(requestUser, this.environmentKey, this.options.enableEdgeDB)
             .then((res: AxiosResponse) => {
                 return res.data || {}
             })
@@ -62,7 +64,7 @@ export class DVCCloudClient {
 
     allFeatures(user: DVCUser): Promise<DVCFeatureSet> {
         const requestUser = new DVCPopulatedUser(user)
-        return getAllFeatures(requestUser, this.environmentKey)
+        return getAllFeatures(requestUser, this.environmentKey, this.options.enableEdgeDB)
             .then((res: AxiosResponse) => {
                 return res.data || {}
             })
@@ -78,6 +80,6 @@ export class DVCCloudClient {
         }
         checkParamDefined('type', event.type)
         const requestUser = new DVCPopulatedUser(user)
-        postTrack(requestUser, event, this.environmentKey, this.logger)
+        postTrack(requestUser, event, this.environmentKey, this.logger, this.options.enableEdgeDB)
     }
 }

--- a/sdk/nodejs/src/request.ts
+++ b/sdk/nodejs/src/request.ts
@@ -15,6 +15,7 @@ const VARIABLES_PATH = '/v1/variables'
 const FEATURES_PATH = '/v1/features'
 const TRACK_PATH = '/v1/track'
 const BUCKETING_URL = `${BUCKETING_BASE}${HOST}`
+const EDGE_DB_QUERY_PARAM = '?enableEdgeDB='
 
 export async function publishEvents(
     logger: DVCLogger,
@@ -54,24 +55,44 @@ export async function getEnvironmentConfig(
     })
 }
 
-export async function getAllFeatures(user: DVCPopulatedUser, envKey: string): Promise<AxiosResponse> {
+export async function getAllFeatures(
+    user: DVCPopulatedUser,
+    envKey: string,
+    enableEdgeDB: boolean = false
+): Promise<AxiosResponse> {
+    const baseUrl = `${BUCKETING_URL}${FEATURES_PATH}`
+    const postUrl = baseUrl.concat(enableEdgeDB ? EDGE_DB_QUERY_PARAM.concat('true') : '')
     return await post({
-        url: `${BUCKETING_URL}${FEATURES_PATH}`,
+        url: postUrl,
         data: user
     },
         envKey)
 }
 
-export async function getAllVariables(user: DVCPopulatedUser, envKey: string): Promise<AxiosResponse> {
+export async function getAllVariables(
+    user: DVCPopulatedUser,
+    envKey: string,
+    enableEdgeDB: boolean = false
+): Promise<AxiosResponse> {
+    const baseUrl = `${BUCKETING_URL}${VARIABLES_PATH}`
+    const postUrl = baseUrl.concat(enableEdgeDB ? EDGE_DB_QUERY_PARAM.concat('true') : '')
     return await post({
-        url: `${BUCKETING_URL}${VARIABLES_PATH}`,
+        url: postUrl,
+        headers: { 'Authorization': envKey, 'Content-Type': 'application/json' },
         data: user
     }, envKey)
 }
 
-export async function getVariable(user: DVCPopulatedUser, envKey: string, variableKey: string): Promise<AxiosResponse> {
+export async function getVariable(
+    user: DVCPopulatedUser,
+    envKey: string,
+    variableKey: string,
+    enableEdgeDB: boolean = false
+): Promise<AxiosResponse> {
+    const baseUrl = `${BUCKETING_URL}${VARIABLES_PATH}/${variableKey}`
+    const postUrl = baseUrl.concat(enableEdgeDB ? EDGE_DB_QUERY_PARAM.concat('true') : '')
     return await post({
-        url: `${BUCKETING_URL}${VARIABLES_PATH}/${variableKey}`,
+        url: postUrl,
         data: user
     }, envKey)
 }
@@ -80,11 +101,14 @@ export async function postTrack(
     user: DVCPopulatedUser,
     event: DVCEvent,
     envKey: string,
-    logger: DVCLogger
-): Promise<void> {
+    logger: DVCLogger,
+    enableEdgeDB: boolean = false
+    ): Promise<void> {
+    const baseUrl = `${BUCKETING_URL}${TRACK_PATH}`
+    const postUrl = baseUrl.concat(enableEdgeDB ? EDGE_DB_QUERY_PARAM.concat('true') : '')
     try {
         await post({
-            url: `${BUCKETING_URL}${TRACK_PATH}`,
+            url: postUrl,
             data: {
                 user,
                 events: [event]

--- a/sdk/nodejs/src/types.ts
+++ b/sdk/nodejs/src/types.ts
@@ -93,6 +93,12 @@ export interface DVCOptions {
      * Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.
      */
     enableCloudBucketing?: boolean
+
+    /**
+     * Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle.
+     * NOTE: This is only available with Cloud Bucketing.
+     */
+    enableEdgeDB?: boolean
 }
 
 export type DVCVariableValue = string | number | boolean | JSON


### PR DESCRIPTION
- adds `enableEdgeDB` to DVCOptions
- checks is `enableEdgeDB` option is set to true && `enableCloudBucketing` is set to true, to pass through Enable EdgeDB to Bucketing API
  - creates INFO level log, if `enableEdgeDB` is set to true without Cloud Bucketing