### PR TITLE
feat: added a max event queue size for storing events

### DIFF
--- a/lib/shared/types/src/types/config/models/project.ts
+++ b/lib/shared/types/src/types/config/models/project.ts
@@ -12,6 +12,9 @@ export class Project<IdType = string> {
     settings: {
         edgeDB: {
             enabled: boolean
+        },
+        sdkSettings?: {
+            eventQueueLimit: 1000
         }
     }
 }


### PR DESCRIPTION
# Changes

- added function to find equivalent event queue size for aggregate events and user events
- drops events and aggregate events from queueing if max event queue size limit is reached
- add type for future use of configurable event queue size from bucketed config