### PR TITLE
NodeJS SDK: make enableCloudBucketing param optional & add default value

### DIFF
--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -6,7 +6,7 @@ export { DVCClient, DVCCloudClient }
 export * from './types'
 
 type DVCOptionsCloudEnabled = DVCOptions & { enableCloudBucketing: true }
-type DVCOptionsLocalEnabled = DVCOptions & { enableCloudBucketing: false }
+type DVCOptionsLocalEnabled = DVCOptions & { enableCloudBucketing?: false }
 
 export function initialize(environmentKey: string, options: DVCOptionsLocalEnabled): DVCClient
 export function initialize(environmentKey: string, options: DVCOptionsCloudEnabled): DVCCloudClient


### PR DESCRIPTION
- make enableCloudBucketing param optional
- default to false for NodeJS SDK to ensure local bucketing is the default functionality when the option isn't present