### PR TITLE
DVC-2495: add value, type, and _variable to event metadata

### DIFF
--- a/lib/shared/types/.babelrc
+++ b/lib/shared/types/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -123,6 +123,11 @@ export class DVCClient implements Client {
                     ? EventTypes.variableDefaulted
                     : EventTypes.variableEvaluated,
                 target: variable.key,
+                metaData: {
+                    value: variable.value,
+                    type: typeof(variable.defaultValue),
+                    _variable: this.config?.variables?.[key]._id
+                }
             })
         } catch (e) {
             this.eventEmitter.emitError(e)


### PR DESCRIPTION
- mongo object Id is only available for the `variableEvaluated` events