### PR TITLE
Use assemblyscript fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@nrwl/next": "13.8.5",
     "as-wasi": "^0.4.6",
-    "assemblyscript": "^0.20.12",
+    "assemblyscript": "https://github.com/DevCycleHQ/assemblyscript",
     "assemblyscript-json": "https://github.com/DevCycleHQ/assemblyscript-json",
     "assemblyscript-regex": "https://github.com/DevCycleHQ/assemblyscript-regex.git#fix-null-type-errors",
     "async": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@nrwl/next": "13.8.5",
     "as-wasi": "^0.4.6",
-    "assemblyscript": "https://github.com/DevCycleHQ/assemblyscript",
+    "assemblyscript": "https://github.com/DevCycleHQ/assemblyscript#56a01ceccab1f2836505b8cfcdeec366cb78883f",
     "assemblyscript-json": "https://github.com/DevCycleHQ/assemblyscript-json",
     "assemblyscript-regex": "https://github.com/DevCycleHQ/assemblyscript-regex.git#fix-null-type-errors",
     "async": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6724,16 +6724,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assemblyscript@https://github.com/DevCycleHQ/assemblyscript":
+"assemblyscript@https://github.com/DevCycleHQ/assemblyscript#56a01ceccab1f2836505b8cfcdeec366cb78883f":
   version: 0.0.0
-  resolution: "assemblyscript@https://github.com/DevCycleHQ/assemblyscript.git#commit=9aa8a2da4184d2e8869a3c81d4ed30fd26debe6c"
+  resolution: "assemblyscript@https://github.com/DevCycleHQ/assemblyscript.git#commit=56a01ceccab1f2836505b8cfcdeec366cb78883f"
   dependencies:
     binaryen: 109.0.0-nightly.20220813
     long: ^5.2.0
   bin:
     asc: ./bin/asc.js
     asinit: ./bin/asinit.js
-  checksum: 277cf479479a293e6b5cc10a6fdae2fd2749570d224678ccdd638ccea93ec189c37b58bb322207bd6176f2d1b008eaf6cd8c17e60768713bab5e94bd8862044c
+  checksum: aa7259c7bedb66c7c8467736ad009cda7bb226adaeba072a57827edebbb54ff6f2f9e0318defbd7e2140c3d9ff3780e7531c50cbe58cfb49408963cb0d78d9e1
   languageName: node
   linkType: hard
 
@@ -9534,7 +9534,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.18.0
     "@typescript-eslint/parser": 5.18.0
     as-wasi: ^0.4.6
-    assemblyscript: "https://github.com/DevCycleHQ/assemblyscript"
+    assemblyscript: "https://github.com/DevCycleHQ/assemblyscript#56a01ceccab1f2836505b8cfcdeec366cb78883f"
     assemblyscript-json: "https://github.com/DevCycleHQ/assemblyscript-json"
     assemblyscript-regex: "https://github.com/DevCycleHQ/assemblyscript-regex.git#fix-null-type-errors"
     async: ^3.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -6724,16 +6724,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assemblyscript@npm:^0.20.12":
-  version: 0.20.12
-  resolution: "assemblyscript@npm:0.20.12"
+"assemblyscript@https://github.com/DevCycleHQ/assemblyscript":
+  version: 0.0.0
+  resolution: "assemblyscript@https://github.com/DevCycleHQ/assemblyscript.git#commit=9aa8a2da4184d2e8869a3c81d4ed30fd26debe6c"
   dependencies:
-    binaryen: 108.0.0-nightly.20220528
+    binaryen: 109.0.0-nightly.20220813
     long: ^5.2.0
   bin:
-    asc: bin/asc.js
-    asinit: bin/asinit.js
-  checksum: be753945cba13e35ac57aff5411c5b6bd35d461066712d2042d422720c1efda7699bc721a9f50f274cb2a1df1c56e5505be2461ffaa720bd2a64bef12b757d16
+    asc: ./bin/asc.js
+    asinit: ./bin/asinit.js
+  checksum: 277cf479479a293e6b5cc10a6fdae2fd2749570d224678ccdd638ccea93ec189c37b58bb322207bd6176f2d1b008eaf6cd8c17e60768713bab5e94bd8862044c
   languageName: node
   linkType: hard
 
@@ -7218,13 +7218,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binaryen@npm:108.0.0-nightly.20220528":
-  version: 108.0.0-nightly.20220528
-  resolution: "binaryen@npm:108.0.0-nightly.20220528"
+"binaryen@npm:109.0.0-nightly.20220813":
+  version: 109.0.0-nightly.20220813
+  resolution: "binaryen@npm:109.0.0-nightly.20220813"
   bin:
     wasm-opt: bin/wasm-opt
     wasm2js: bin/wasm2js
-  checksum: e5cb8a68db50c8f538b87ad522b7daf69567d71d23904e92a361b4645a128bc5188b507bf3d620e834e68dd72299061bfd70b0b6a05a087c356fdbc3d8d68c0c
+  checksum: e6c9ba5b842c8a4dfba9d1256730b21d14eb3e239a6a4a3e03672b70b43fe4555df6989e239ff180a12af1638fcaf82fde380c9955629f1972e20f7428260172
   languageName: node
   linkType: hard
 
@@ -9534,7 +9534,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.18.0
     "@typescript-eslint/parser": 5.18.0
     as-wasi: ^0.4.6
-    assemblyscript: ^0.20.12
+    assemblyscript: "https://github.com/DevCycleHQ/assemblyscript"
     assemblyscript-json: "https://github.com/DevCycleHQ/assemblyscript-json"
     assemblyscript-regex: "https://github.com/DevCycleHQ/assemblyscript-regex.git#fix-null-type-errors"
     async: ^3.2.1


### PR DESCRIPTION
Origin library makes assumptions about node-fetch versions that are more advanced than what is used in NextJS