### PR TITLE
add gh action to startup nodejs example apps for testing

### DIFF
--- a/.github/workflows/nodejs-js-example-app-e2e-tests.yml
+++ b/.github/workflows/nodejs-js-example-app-e2e-tests.yml
@@ -1,0 +1,34 @@
+name: NodeJS JS Local Bucketing SDK Example App Tests
+on:
+  schedule:
+    # Runs at 7am & 3pm every day (see https://crontab.guru)
+    - cron: '0 7,15 * * *'
+  pull_request:
+    branches: [main]
+jobs:
+  run-nodejs-ts-example:
+    runs-on: ubuntu-latest
+    env:
+          DVC_SERVER_TOKEN: ${{ secrets.DVC_NODE_JS_E2E_TEST_TOKEN }}
+
+    steps:
+      - name: Checkout JS-SDK
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+
+      - name: Setup yarn
+        run: npm install -g yarn
+
+      - name: Yarn Install
+        run: yarn --immutable
+
+      - name: Build NodeJS SDK for Example Apps
+        run: yarn nx run nodejs:build
+      
+      - name: Startup Examples - NodeJS JS App
+        run: timeout --signal=SIGINT 5m yarn nx serve example-nodejs-local-js || true

--- a/.github/workflows/nodejs-ts-example-app-e2e-tests.yml
+++ b/.github/workflows/nodejs-ts-example-app-e2e-tests.yml
@@ -1,0 +1,34 @@
+name: NodeJS TypeScript Local Bucketing SDK Example App Tests
+on:
+  schedule:
+    # Runs at 7am & 3pm every day (see https://crontab.guru)
+    - cron: '0 7,15 * * *'
+  pull_request:
+    branches: [main]
+jobs:
+  run-nodejs-ts-example:
+    runs-on: ubuntu-latest
+    env:
+          DVC_SERVER_TOKEN: ${{ secrets.DVC_NODE_JS_E2E_TEST_TOKEN }}
+
+    steps:
+      - name: Checkout JS-SDK
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+
+      - name: Setup yarn
+        run: npm install -g yarn
+
+      - name: Yarn Install
+        run: yarn --immutable
+
+      - name: Build NodeJS SDK for Example Apps
+        run: yarn nx run nodejs:build
+
+      - name: Startup Examples - NodeJS TypeScript App
+        run: timeout --signal=SIGINT 5m yarn nx serve example-nodejs-local-typescript || true

--- a/examples/nodejs-local/js/package.json
+++ b/examples/nodejs-local/js/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "nodejs-example-js",
+  "name": "@devcycle/nodejs-server-sdk-js-example",
   "version": "1.0.0",
+  "description": "DevCycle NodeJS JS Example App",
+  "keywords": [],
+  "license": "MIT",
   "dependencies": {
     "@devcycle/nodejs-server-sdk": "*"
   }

--- a/examples/nodejs-local/typescript/package.json
+++ b/examples/nodejs-local/typescript/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "description": "DevCycle NodeJS Typescript Example App",
   "keywords": [],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@devcycle/nodejs-server-sdk": "*"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6699,7 +6699,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
+  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- run apps for 5 mins and then timeout and gracefully exit
- runs the local bucketing nodejs ts app `yarn nx serve example-nodejs-local-typescript`
- runs the local bucketing nodejs js app `yarn nx serve example-nodejs-local-js`