### PR TITLE
Fix nodejs sdk startup without options

### DIFF
--- a/examples/nodejs-local/js/src/main.js
+++ b/examples/nodejs-local/js/src/main.js
@@ -17,7 +17,8 @@ app.use(bodyParser.json())
 let dvcClient
 
 async function startDVC() {
-    dvcClient = DVC.initialize('<DVC_SERVER_KEY>', { logLevel: 'info', enableCloudBucketing: true })
+    dvcClient = await DVC.initialize('<DVC_SERVER_KEY>', { logLevel: 'info' }).onClientInitialized()
+    console.log('DVC onClientInitialized')
 
     const user = {
         user_id: 'node_sdk_test',

--- a/examples/nodejs-local/typescript/src/main.ts
+++ b/examples/nodejs-local/typescript/src/main.ts
@@ -32,7 +32,7 @@ async function validateUserFromQueryParams(queryParams: Query): Promise<DVCClien
 }
 
 async function startDVC() {
-    dvcClient = await initialize('<DVC_SERVER_KEY>', { logLevel: 'debug' }).onClientInitialized()
+    dvcClient = await initialize('<DVC_SERVER_KEY>').onClientInitialized()
     console.log('DVC onClientInitialized')
 
     const user = {

--- a/sdk/nodejs/__tests__/initialize.spec.ts
+++ b/sdk/nodejs/__tests__/initialize.spec.ts
@@ -1,0 +1,32 @@
+import { DVCClient, DVCCloudClient, initialize } from '../src/index'
+
+jest.mock('../src/bucketing')
+jest.mock('../src/environmentConfigManager')
+
+describe('NodeJS SDK Initialize', () => {
+    afterAll(() => {
+        jest.clearAllMocks()
+    })
+
+    it('sucessfully calls initialize with no options', async () => {
+        const client: DVCClient = await initialize('token').onClientInitialized()
+        expect(client).toBeDefined()
+    })
+
+    it('fails to initialize in Local Bucketing mode when no token is provided', () => {
+        expect(() => 
+            initialize(undefined as unknown as string)
+        ).toThrow('Missing environment key! Call initialize with a valid environment key')
+    })
+
+    it('sucessfully calls initialize with enableCloudBucketing set to true', () => {
+        const client: DVCCloudClient = initialize('token', { enableCloudBucketing: true })
+        expect(client).toBeDefined()
+    })
+
+    it('fails to initialize in Cloud Bucketing mode when no token is provided', () => {
+        expect(() =>
+            initialize(undefined as unknown as string, { enableCloudBucketing: true })
+        ).toThrow('Missing environment key! Call initialize with a valid environment key')
+    })
+})

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -8,14 +8,14 @@ export * from './types'
 type DVCOptionsCloudEnabled = DVCOptions & { enableCloudBucketing: true }
 type DVCOptionsLocalEnabled = DVCOptions & { enableCloudBucketing?: false }
 
-export function initialize(environmentKey: string, options: DVCOptionsLocalEnabled): DVCClient
+export function initialize(environmentKey: string, options?: DVCOptionsLocalEnabled): DVCClient
 export function initialize(environmentKey: string, options: DVCOptionsCloudEnabled): DVCCloudClient
-export function initialize(environmentKey: string, options: DVCOptions): DVCClient | DVCCloudClient {
+export function initialize(environmentKey: string, options?: DVCOptions): DVCClient | DVCCloudClient {
     if (!environmentKey) {
         throw new Error('Missing environment key! Call initialize with a valid environment key')
     }
 
-    if (options.enableCloudBucketing) {
+    if (options?.enableCloudBucketing) {
         return new DVCCloudClient(environmentKey, options)
     }
     return new DVCClient(environmentKey, options)

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -10,12 +10,12 @@ type DVCOptionsLocalEnabled = DVCOptions & { enableCloudBucketing?: false }
 
 export function initialize(environmentKey: string, options?: DVCOptionsLocalEnabled): DVCClient
 export function initialize(environmentKey: string, options: DVCOptionsCloudEnabled): DVCCloudClient
-export function initialize(environmentKey: string, options?: DVCOptions): DVCClient | DVCCloudClient {
+export function initialize(environmentKey: string, options: DVCOptions = {}): DVCClient | DVCCloudClient {
     if (!environmentKey) {
         throw new Error('Missing environment key! Call initialize with a valid environment key')
     }
 
-    if (options?.enableCloudBucketing) {
+    if (options.enableCloudBucketing) {
         return new DVCCloudClient(environmentKey, options)
     }
     return new DVCClient(environmentKey, options)


### PR DESCRIPTION
- make `options` optional when calling `initialize` on the NodeJS SDK, this makes the NodeJS SDK startup in Local bucketing mode by default
- update NodeJS example apps