### PR TITLE
DVC-4286 hostname support

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
@@ -37,7 +37,8 @@ const initSDK = (envKey: string, eventOptions: unknown = {}) => {
         platform: 'NodeJS',
         platformVersion: '16.0',
         sdkType: 'server',
-        sdkVersion: '1.0.0'
+        sdkVersion: '1.0.0',
+        hostname: 'host.name'
     }))
     setConfigData(envKey, JSON.stringify(config))
 }
@@ -128,7 +129,7 @@ describe('EventQueueManager Tests', () => {
                             'date': expect.any(Number),
                             'target': 'variableKey',
                             'type': 'customEvent',
-                            'user_id': 'aggregate',
+                            'user_id': 'host.name',
                             'value': 1
                         }],
                         'user': {
@@ -138,7 +139,7 @@ describe('EventQueueManager Tests', () => {
                             'platformVersion': '16.0',
                             'sdkType': 'server',
                             'sdkVersion': '1.0.0',
-                            'user_id': 'aggregate'
+                            'user_id': 'host.name'
                         }
                     }]
                 }
@@ -409,7 +410,7 @@ describe('EventQueueManager Tests', () => {
                     'date': expect.any(Number),
                     'target': 'testey_test',
                     'type': 'customEvent',
-                    'user_id': 'aggregate',
+                    'user_id': 'host.name',
                     'value': 36
                 }, {
                     'clientDate': expect.any(Number),
@@ -417,14 +418,14 @@ describe('EventQueueManager Tests', () => {
                     'date': expect.any(Number),
                     'target': 'swageyTest',
                     'type': 'customEvent',
-                    'user_id': 'aggregate',
+                    'user_id': 'host.name',
                     'value': 11
                 }, {
                     'clientDate': expect.any(Number),
                     'date': expect.any(Number),
                     'target': 'test',
                     'type': 'aggVariableEvaluated',
-                    'user_id': 'aggregate',
+                    'user_id': 'host.name',
                     'metaData': {
                         '614ef6aa473928459060721a.6153553b8cf4e45e0464268d': 36
                     }
@@ -433,13 +434,13 @@ describe('EventQueueManager Tests', () => {
                     'date': expect.any(Number),
                     'target': 'swagTest',
                     'type': 'aggVariableEvaluated',
-                    'user_id': 'aggregate',
+                    'user_id': 'host.name',
                     'metaData': {
                         '614ef6aa473928459060721a.6153553b8cf4e45e0464268d': 11
                     }
                 }
             ])
-            expect(payloads[0].records[0].user.user_id).toEqual('aggregate')
+            expect(payloads[0].records[0].user.user_id).toEqual('host.name')
         })
     })
 })

--- a/lib/shared/bucketing-assembly-script/__tests__/setPlatformData.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/setPlatformData.ts
@@ -5,7 +5,8 @@ const defaultPlatformData = {
     platformVersion: '',
     sdkType: 'server',
     sdkVersion: '1.0.0',
-    deviceModel: ''
+    deviceModel: '',
+    hostname: 'host.name'
 }
 
 export const setPlatformDataJSON = (data: unknown = defaultPlatformData): void => {

--- a/lib/shared/bucketing-assembly-script/__tests__/types/platformData.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/platformData.test.ts
@@ -1,0 +1,28 @@
+import { testPlatformDataClass } from '../../build/bucketing-lib.debug'
+
+const testPlatformData = (data: unknown): unknown => {
+    return JSON.parse(testPlatformDataClass(JSON.stringify(data)))
+}
+
+describe('PlatformData Model Tests', () => {
+    it('should test PlatformData JSON parsing', () => {
+        const platformData = {
+            platform: 'platform',
+            platformVersion: '1.0.0',
+            sdkType: 'server',
+            sdkVersion: '3.3.3',
+            hostname: 'host.name'
+        }
+        expect(testPlatformData(platformData)).toEqual(platformData)
+    })
+
+    it('should test PlatformData non-optional JSON parsing', () => {
+        const platformData = {
+            platform: 'platform',
+            platformVersion: '1.0.0',
+            sdkType: 'server',
+            sdkVersion: '3.3.3'
+        }
+        expect(testPlatformData(platformData)).toEqual(platformData)
+    })
+})

--- a/lib/shared/bucketing-assembly-script/assembly/eventQueue/requestPayloadManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/eventQueue/requestPayloadManager.ts
@@ -8,6 +8,7 @@ import {
 } from '../types'
 import { jsonObjFromMap } from '../helpers/jsonHelpers'
 import { JSON } from 'assemblyscript-json/assembly'
+import { _getPlatformData } from '../managers/platformDataManager'
 
 /**
  * This RequestPayloadManager Class handles all the logic for creating event flushing payloads,
@@ -50,8 +51,9 @@ export class RequestPayloadManager {
     ): void {
         const aggEventQueueKeys = aggEventQueue.keys()
         const aggEvents: DVCRequestEvent[] = []
-        // TODO: Implement hostName support
-        const user_id = 'aggregate'
+
+        const platformData = _getPlatformData()
+        const user_id = platformData.hostname ? platformData.hostname as string : 'aggregate'
 
         for (let i = 0; i < aggEventQueueKeys.length; i++) {
             const type = aggEventQueueKeys[i]

--- a/lib/shared/bucketing-assembly-script/assembly/test.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/test.ts
@@ -17,6 +17,8 @@ import {
 } from './bucketing'
 import { SortingArray, sortObjectsByString } from './helpers/arrayHelpers'
 
+export { testPlatformDataClass } from './types'
+
 export function checkNumbersFilterFromJSON(number: string, filterStr: string): bool {
     const filterJSON = JSON.parse(filterStr)
     const parsedNumber = JSON.parse(number)

--- a/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
@@ -1,11 +1,15 @@
 import { JSON } from 'assemblyscript-json/assembly'
-import { getStringFromJSON } from '../helpers/jsonHelpers'
+import {
+    getStringFromJSON,
+    getStringFromJSONOptional
+} from '../helpers/jsonHelpers'
 
 export class PlatformData extends JSON.Obj {
     platform: string
     platformVersion: string
     sdkType: string
     sdkVersion: string
+    hostname: string | null
 
     constructor(str: string) {
         super()
@@ -17,6 +21,7 @@ export class PlatformData extends JSON.Obj {
         this.platformVersion = getStringFromJSON(jsonObj, 'platformVersion')
         this.sdkType = getStringFromJSON(jsonObj, 'sdkType')
         this.sdkVersion = getStringFromJSON(jsonObj, 'sdkVersion')
+        this.hostname = getStringFromJSONOptional(jsonObj, 'hostname')
     }
 
     stringify(): string {
@@ -25,6 +30,13 @@ export class PlatformData extends JSON.Obj {
         json.set('platformVersion', this.platformVersion)
         json.set('sdkType', this.sdkType)
         json.set('sdkVersion', this.sdkVersion)
+        if (this.hostname) json.set('hostname', this.hostname)
         return json.stringify()
     }
 }
+
+export function testPlatformDataClass(dataStr: string): string {
+    const platformData = new PlatformData(dataStr)
+    return platformData.stringify()
+}
+

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -1,5 +1,6 @@
 import { getBucketingLib } from '../src/bucketing'
 import { DVCClient } from '../src/client'
+
 jest.mock('../src/bucketing')
 jest.mock('../src/environmentConfigManager')
 
@@ -14,7 +15,8 @@ describe('DVCClient', () => {
             platform: 'NodeJS',
             platformVersion: expect.any(String),
             sdkVersion: expect.any(String),
-            sdkType: 'server'
+            sdkType: 'server',
+            hostname: expect.any(String)
         })
     })
 })
@@ -28,7 +30,7 @@ describe('variable', () => {
         user_id: 'node_sdk_test',
         country: 'CA'
     })
-    
+
     describe('variableDefaulted event', () => {
         let client: DVCClient
 
@@ -42,15 +44,15 @@ describe('variable', () => {
         beforeEach(() => {
             jest.clearAllMocks()
         })
-    
+
         it('does not get sent if variable is in bucketed config',async () => {
             client.variable(user, 'test-key', false)
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             expect(client.eventQueue.queueAggregateEvent)
-                .toBeCalledWith(expectedUser, 
-                    { type: 'variableEvaluated', target: 'test-key' }, 
+                .toBeCalledWith(expectedUser,
+                    { type: 'variableEvaluated', target: 'test-key' },
                     { 'variables': { ['test-key']: true } }
                 )
         })
@@ -60,8 +62,8 @@ describe('variable', () => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             expect(client.eventQueue.queueAggregateEvent)
-                .toBeCalledWith(expectedUser, 
-                    { type: 'variableDefaulted', target: 'test-key-not-in-config' }, 
+                .toBeCalledWith(expectedUser,
+                    { type: 'variableDefaulted', target: 'test-key-not-in-config' },
                     { 'variables': { ['test-key']: true } }
                 )
         })

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -19,12 +19,14 @@ import { DVCPopulatedUser } from './models/populatedUser'
 import * as packageJson from '../package.json'
 import { importBucketingLib, getBucketingLib } from './bucketing'
 import { DVCLogger } from '@devcycle/types'
+import os from 'os'
 
 interface IPlatformData {
     platform: string
     platformVersion: string
     sdkType: string
-    sdkVersion: string
+    sdkVersion: string,
+    hostname?: string
 }
 
 export class DVCClient {
@@ -64,7 +66,8 @@ export class DVCClient {
                     platform: 'NodeJS',
                     platformVersion: process.version,
                     sdkType: 'server',
-                    sdkVersion: packageJson.version
+                    sdkVersion: packageJson.version,
+                    hostname: os.hostname()
                 }
 
                 getBucketingLib().setPlatformData(JSON.stringify(platformData))


### PR DESCRIPTION
Pass in `hostname` as part of platformData, use for `user_id` of aggregated events.