### PR TITLE
feat: add cleanup method to nodejs sdk to allow cleaning up of resources

### DIFF
--- a/sdk/nodejs/__tests__/clientCleanup.test.ts
+++ b/sdk/nodejs/__tests__/clientCleanup.test.ts
@@ -1,0 +1,13 @@
+import { exec } from 'node:child_process'
+
+describe('dvcClient cleanup', () => {
+    it('cleans up any open handles when close is called', (done) => {
+        exec('node ' + __dirname + '/testCloseProcess.js', { timeout: 2000 }, (error: unknown) => {
+            if (error) {
+                done(error)
+                return
+            }
+            done()
+        })
+    })
+})

--- a/sdk/nodejs/__tests__/testCloseProcess.js
+++ b/sdk/nodejs/__tests__/testCloseProcess.js
@@ -1,0 +1,5 @@
+const { initialize } = require('../../../dist/sdk/nodejs')
+
+const client = initialize('token')
+
+client.close()

--- a/sdk/nodejs/jest.config.ts
+++ b/sdk/nodejs/jest.config.ts
@@ -9,6 +9,7 @@ export default {
     transform: {
         '^.+\\.[tj]sx?$':  'ts-jest'
     },
+    testEnvironment: 'node',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     collectCoverage: true,
     collectCoverageFrom: [

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -16,7 +16,7 @@ import { EventQueueAS } from './eventQueueAS'
 import { dvcDefaultLogger } from './utils/logger'
 import { DVCPopulatedUser } from './models/populatedUser'
 import * as packageJson from '../package.json'
-import { importBucketingLib, getBucketingLib } from './bucketing'
+import { importBucketingLib, getBucketingLib, cleanupBucketingLib } from './bucketing'
 import { DVCLogger } from '@devcycle/types'
 import os from 'os'
 
@@ -86,7 +86,7 @@ export class DVCClient {
             })
 
         process.on('exit', () => {
-            this.configHelper?.cleanup()
+            this.close()
         })
     }
 
@@ -173,5 +173,12 @@ export class DVCClient {
 
     async flushEvents(callback?: () => void): Promise<void> {
         return this.eventQueue.flushEvents().then(callback)
+    }
+
+    async close(): Promise<void> {
+        await this.onInitialized
+        cleanupBucketingLib()
+        this.configHelper.cleanup()
+        this.eventQueue.cleanup()
     }
 }


### PR DESCRIPTION
- add a method called `close` which will clean up any open handles keeping the node process open
- add a test that fires off a child process and makes sure that it closes properly