### PR TITLE
add @types/validator as a dependency of @devcycle/types

### DIFF
--- a/lib/shared/types/package.json
+++ b/lib/shared/types/package.json
@@ -2,5 +2,8 @@
   "name": "@devcycle/types",
   "version": "1.0.36",
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "@types/validator": "13.7.6"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3006,6 +3006,8 @@ __metadata:
 "@devcycle/types@workspace:lib/shared/types":
   version: 0.0.0-use.local
   resolution: "@devcycle/types@workspace:lib/shared/types"
+  dependencies:
+    "@types/validator": 13.7.6
   languageName: unknown
   linkType: soft
 
@@ -6844,6 +6846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/validator@npm:13.7.6":
+  version: 13.7.6
+  resolution: "@types/validator@npm:13.7.6"
+  checksum: f860dd87bc5f90cc33d2802cf2a4da307ddac63c86d86b858a85dd62d457c8fa42fc8756e05b5d24e741376debc13d46ed14bc700006bf7d0cb910118022492b
+  languageName: node
+  linkType: hard
+
 "@types/warning@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/warning@npm:3.0.0"
@@ -8072,7 +8081,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
+  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- add dependency on `@types/validator` to allow for proper production builds with the NodeJS SDK
- see source issue at https://github.com/nestjs/class-validator/issues/79