### PR TITLE
fix package peerDependancies

### DIFF
--- a/lib/shared/bucketing-test-data/project.json
+++ b/lib/shared/bucketing-test-data/project.json
@@ -22,7 +22,8 @@
       "options": {
         "outputPath": "dist/lib/shared/bucketing-test-data",
         "main": "lib/shared/bucketing-test-data/src/index.ts",
-        "tsConfig": "lib/shared/bucketing-test-data/tsconfig.lib.json"
+        "tsConfig": "lib/shared/bucketing-test-data/tsconfig.lib.json",
+        "buildableProjectDepsInPackageJsonType": "dependencies"
       }
     },
     "build:json": {

--- a/lib/shared/types/project.json
+++ b/lib/shared/types/project.json
@@ -26,6 +26,7 @@
         "outputPath": "dist/lib/shared/types",
         "main": "lib/shared/types/src/index.ts",
         "tsConfig": "lib/shared/types/tsconfig.lib.json",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "assets": [
           "lib/shared/types/*.md"
         ]


### PR DESCRIPTION
set `buildableProjectDepsInPackageJsonType` nx build option for all external packages.