### PR TITLE
feat: add close method to JS SDK to close active resources

### DIFF
--- a/sdk/js/__tests__/EventQueue.spec.js
+++ b/sdk/js/__tests__/EventQueue.spec.js
@@ -90,4 +90,26 @@ describe('EventQueue tests', () => {
             expect(eventArray[1].value).toBe(2)
         })
     })
+
+    describe('close', () => {
+        it('should flush events and clear flush interval', async () => {
+            const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
+            Request.publishEvents.mockResolvedValue({ status: 201 })
+
+            eventQueue.queueEvent({ type: 'test_type' })
+            await eventQueue.close()
+
+            expect(Request.publishEvents).toBeCalledWith(
+                'test_env_key',
+                dvcClient.config,
+                dvcClient.user,
+                expect.any(Object),
+                expect.any(Object)
+            )
+
+            expect(eventQueue.eventQueue).toHaveLength(0)
+
+            expect(clearIntervalSpy).toHaveBeenCalledWith(eventQueue.flushInterval)
+        })
+    })
 })

--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -96,4 +96,9 @@ export class EventQueue {
     private eventsFromAggregateEventMap(): DVCEvent[] {
         return Object.values(this.aggregateEventMap).map((typeMap) => Object.values(typeMap)).flat()
     }
+
+    async close(): Promise<void> {
+        clearInterval(this.flushInterval)
+        await this.flushEvents()
+    }
 }

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -217,6 +217,12 @@ export interface DVCClient {
      * @param callback
      */
     flushEvents(callback?: () => void): Promise<void>
+
+    /**
+     * Close all open connections to DevCycle, flush any pending events and stop any running timers and event handlers.
+     * Use to clean up a client instance that is no longer needed.
+     */
+    close(): Promise<void>
 }
 
 export interface DVCVariable {


### PR DESCRIPTION
- add close method to clsoe active resources such as event flush interval and streaming connection
- wait for event flush to happen
- also prevent new events from being tracked after closing
