### PR TITLE
fix: react sdk properly unmounts and closes client

### DIFF
--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -223,6 +223,11 @@ export interface DVCClient {
      * Use to clean up a client instance that is no longer needed.
      */
     close(): Promise<void>
+
+    /**
+     * Reflects whether `close()` has been called on the client instance.
+     */
+    closing: boolean
 }
 
 export interface DVCVariable {

--- a/sdk/react/src/DVCProvider.tsx
+++ b/sdk/react/src/DVCProvider.tsx
@@ -1,24 +1,35 @@
 import { ProviderConfig } from './types'
-import React, { ReactNode, useEffect, useMemo, useState } from 'react'
+import React, { ReactNode, useEffect, useState } from 'react'
 import initializeDVCClient from './initializeDVCClient'
 import { Provider } from './context'
+import { DVCClient } from '@devcycle/devcycle-js-sdk'
 
 type Props = {
   config: ProviderConfig
   children: ReactNode
 }
 
+let client: DVCClient | undefined
+
 export default function DVCProvider(props: Props): React.ReactElement {
     const { envKey, user, options } = props.config
-    const client = useMemo(() => initializeDVCClient(envKey, user, options), [envKey, user, options])
     const [_, forceRerender] = useState({})
 
-    useEffect(() => {
+    if (!client) {
+        client = initializeDVCClient(envKey, user, options)
         client.subscribe('newVariables', () => {
             forceRerender({})
         })
+    }
+
+    useEffect(() => {
+        return () => {
+            client?.unsubscribe('newVariables')
+            client?.close()
+            client = undefined
+        }
     }, [])
-  
+
     return (
         <Provider value={{ client }}>{props.children}</Provider>
     )


### PR DESCRIPTION
- add proper unmount for react provider
- ensure provider only creates one client at a time and cleans itself up
