### PR TITLE
chore: move otp check in publish script

### DIFF
--- a/scripts/npm-safe-publish.sh
+++ b/scripts/npm-safe-publish.sh
@@ -37,12 +37,6 @@ while :; do
   shift
 done
 
-# check if otp is set
-if [[ -z "$OTP" ]]; then
-  echo "Must specify the NPM one-time password using the --otp option."
-  exit 1
-fi
-
 if [[ "$NPM_SHOW" != "$NPM_LS" ]]; then
   echo "Versions are not the same, (Remote = $NPM_SHOW; Local = $NPM_LS). Checking for publish eligibility."
 
@@ -61,6 +55,12 @@ if [[ "$NPM_SHOW" != "$NPM_LS" ]]; then
   # check if current commit is tagged with the requested version
   if [[ -z "$(git tag --points-at HEAD "$PACKAGE@$NPM_LS")" ]]; then
     echo "Current commit is not tagged with the requested version. Aborting."
+    exit 1
+  fi
+
+  # check if otp is set
+  if [[ -z "$OTP" ]]; then
+    echo "Must specify the NPM one-time password using the --otp option."
     exit 1
   fi
 


### PR DESCRIPTION
- work around Nx bugs by moving the otp check to happen only when we're actually publishing the package
- publish will work as long as `nx affected` sees that all the packages need to be published, because it forwards the `otp` flag to each top-level task that is being executed
- however, if you just try to publish one package that happens to have dependencies which are already published, it will fail because Nx won't forward the `otp` flag to the dependent publish tasks
- these tasks won't do anything anyways since the versions are already published, so allow them to succeed without having the otp flag set by moving that check after the no-op publish check.