### PR TITLE
fix: js sdk now calls onUpdate once instead of twice

### DIFF
--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -244,28 +244,32 @@ describe('DVCClient tests', () => {
             expect(callback).not.toHaveBeenCalled()
         })
 
-        it('should call onUpdate after variable updates are emitted', (done) => {
+        it('should call onUpdate after variable updates are emitted', async () => {
             client = createClientWithConfigImplementation(() => {
                 return Promise.resolve(testConfig)
             })
+            await client.onClientInitialized()
             const variable = new DVCVariable({
                 _id: 'id',
                 key: 'key',
                 value: 'my-value',
                 defaultValue: 'default-value'
             })
-            function onUpdate(value) {
+
+            const onUpdate = jest.fn().mockImplementation(function(value) {
                 expect(value).toBe('my-new-value')
                 expect(this).toBe(variable)
-                done()
-            }
+            })
+
             variable.onUpdate(onUpdate)
-            client.eventEmitter.emitVariableUpdates({ 'key': variable }, {
+            client.eventEmitter.emitVariableUpdates({ 'key': {...variable} }, {
                 'key': {
                     ...variable,
                     value: 'my-new-value'
                 }
             }, { 'key': { 'default-value': variable } })
+
+            expect(onUpdate).toBeCalledTimes(1)
         })
 
     })

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -74,9 +74,9 @@ export class EventEmitter {
     emitVariableUpdates(
         oldVariableSet: DVCVariableSet,
         newVariableSet: DVCVariableSet,
-        variableDefaultMap: { [key: string]: { [key: string]: DVCVariable } }
+        variableDefaultMap: { [key: string]: { [defaultValue: string]: DVCVariable } }
     ): void {
-        const keys = Object.keys(oldVariableSet).concat(Object.keys(newVariableSet))
+        const keys = new Set(Object.keys(oldVariableSet).concat(Object.keys(newVariableSet)))
         let newVariables = false
         keys.forEach((key) => {
             const oldVariableValue = oldVariableSet[key] && oldVariableSet[key].value


### PR DESCRIPTION
- iterate over the unique set of variable keys to avoid double-calling onUpdate
