### PR TITLE
fix: import type properly

### DIFF
--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/class-validator'
 import { Transform, Type } from 'class-transformer'
 import 'reflect-metadata'
-import { DVCJSON, IsDVCJSONObject } from '../../validators/dvcJSON'
+import { IsDVCJSONObject } from '../../validators/dvcJSON'
+import type { DVCJSON } from '../../validators/dvcJSON'
 import { IsNotBlank } from '../../validators/isNotBlank'
 import { IsISO6391 } from '../../validators/isIso6391'
 


### PR DESCRIPTION
# Summary

Fix this error when `isolatedModules` is enabled in a project:

```
Type error: A type referenced in a decorated signature must be imported with 'import type' or a namespace import when 'isolatedModules' and 'emitDecoratorMetadata' are enabled.
```