### PR TITLE
Add DVCOptInUser type for opt-in APIs

### DIFF
--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -319,6 +319,13 @@ export class DVCClientAPIUser implements DVCAPIUser {
         isDebug?: boolean
 }
 
+export class DVCOptInUser {
+    @IsString()
+    @IsNotBlank()
+    @IsNotEmpty()
+    user_id: string
+}
+
 export type SDKVariable = PublicVariable & {
     value: VariableValue
     evalReason?: unknown


### PR DESCRIPTION
Currently the opt-on APIs are requiring the full user object when they should only require the user_id

This will be used by the /v1/optInConfig APIs