### PR TITLE
fix: remove user argument from configConsolidator.queue call in refetchConfig

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -263,7 +263,7 @@ export class DVCClient implements Client {
 
     private async refetchConfig() {
         await this.onInitialized
-        await this.requestConsolidator.queue(this.user)
+        await this.requestConsolidator.queue()
     }
 
     private handleConfigReceived(config: BucketedUserConfig, user: DVCPopulatedUser) {


### PR DESCRIPTION
# Changes
* remove `user` argument from `configConsolidator.queue` call in `refetchConfig` so that it isn't called with a stale user. This is to handle the following case:
```[sdk is already initialized and has config for user 1]
identify call made with user 2
realtime update received to refresh config
config "refetch" triggered
[identify call operation finishes and new config received, current user is set to user 2]
[config refetch operation that was queued should now execute with user 2]```