### PR TITLE
chore: adding extra logic to refetch when type is refetchConfig

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -305,10 +305,12 @@ export class DVCClient implements Client {
             if (!messageData) {
                 return
             }
-            if (messageData.etag !== this.config?.etag || !this.config?.etag) {
-                this.refetchConfig().catch((e) => {
-                    this.logger.error('Failed to refetch config', e)
-                })
+            if (!messageData.type || messageData.type === 'refetchConfig') {
+                if (!this.config?.etag || messageData.etag !== this.config?.etag) {
+                    this.refetchConfig().catch((e) => {
+                        this.logger.error('Failed to refetch config', e)
+                    })
+                }
             }
         } catch (e) {
             this.logger.error('Streaming Connection: Unparseable message', e)


### PR DESCRIPTION
# Summary

Added if statement to future proof future messages by refetching only when type is `refetchConfig`, or if type is `undefined`.