### PR TITLE
TAP-8702 report WASM memory usage

### DIFF
--- a/lib/shared/bucketing-assembly-script/index.js
+++ b/lib/shared/bucketing-assembly-script/index.js
@@ -7,11 +7,10 @@ exports.instantiate = async () => {
     const compiled = await (async () => {
         try {
             const source = await globalThis.fetch(url)
-            return await globalThis.WebAssembly.compileStreaming(source);
-        }
-        catch {
+            return await globalThis.WebAssembly.compileStreaming(source)
+        } catch {
             const fs = require('node:fs/promises')
-            return globalThis.WebAssembly.compile(await fs.readFile(url));
+            return globalThis.WebAssembly.compile(await fs.readFile(url))
         }
     })()
 

--- a/lib/shared/bucketing-assembly-script/project.json
+++ b/lib/shared/bucketing-assembly-script/project.json
@@ -53,13 +53,13 @@
       "options": {
         "commands": [
           {
-            "command": "asc assembly/index.ts --target debug --exportRuntime --initialMemory 10000 --maximumMemory 50000 --bindings raw"
+            "command": "asc assembly/index.ts --target debug --exportRuntime --initialMemory 1000 --maximumMemory 10000 --bindings raw"
           },
           {
-            "command": "asc assembly/index.ts --target release --exportRuntime --initialMemory 10000 --maximumMemory 50000 --bindings raw"
+            "command": "asc assembly/index.ts --target release --exportRuntime --initialMemory 1000 --maximumMemory 10000 --bindings raw"
           },
           {
-            "command": "asc assembly/index.ts --target worker --exportRuntime --initialMemory 1000 --maximumMemory 10000 --bindings raw"
+            "command": "asc assembly/index.ts --target worker --exportRuntime --initialMemory 100 --maximumMemory 1000 --bindings raw"
           },
           {
             "command": "sed -i.bu 's/export async function instantiate/exports.instantiate = async function instantiate/g' build/bucketing-lib.release.js"

--- a/lib/shared/types/src/reporter.ts
+++ b/lib/shared/types/src/reporter.ts
@@ -7,13 +7,7 @@ export type FlushResults = {
 
 export type Tags = Record<string, string>
 
-export type MetricName = 
-    'queueLength'
-    | 'flushPayloadSize'
-    | 'flushRequestDuration'
-    | 'jsonParseDuration'
-
 export interface DVCReporter {
     reportFlushResults(results: FlushResults, tags: Tags): void
-    reportMetric(key: MetricName, value: number, tags: Tags): void
+    reportMetric(key: string, value: number, tags: Tags): void
 }

--- a/sdk/nodejs/src/bucketing.ts
+++ b/sdk/nodejs/src/bucketing.ts
@@ -1,8 +1,37 @@
 import { instantiate, Exports } from '@devcycle/bucketing-assembly-script'
+import { DVCLogger, DVCReporter } from '@devcycle/types'
+import { DVCOptions } from './types'
 
 let Bucketing: Exports | null
-export const importBucketingLib = async (): Promise<void> => {
+
+export const importBucketingLib = async (
+    { logger, options }:
+    { logger?: DVCLogger, options?: DVCOptions } = {}
+): Promise<void> => {
     Bucketing = await instantiate()
+    startTrackingMemoryUsage(Bucketing, logger, options?.reporter)
+}
+
+export const startTrackingMemoryUsage = (
+    Bucketing: Exports,
+    logger?: DVCLogger,
+    reporter?: DVCReporter,
+    interval: number = 30 * 1000
+): void => {
+    if (!reporter) return
+    trackMemoryUsage(Bucketing, reporter, logger)
+    setInterval(() => trackMemoryUsage(Bucketing, reporter, logger), interval)
+}
+
+export const trackMemoryUsage = (
+    Bucketing: Exports,
+    reporter: DVCReporter,
+    logger?: DVCLogger,
+): void => {
+    if (!reporter) return
+    const memoryUsageMB = Bucketing.memory.buffer.byteLength / 1e6
+    logger?.debug(`WASM memory usage: ${memoryUsageMB} MB`)
+    reporter.reportMetric('wasmMemoryMB', memoryUsageMB, {})
 }
 
 export const getBucketingLib = (): Exports => {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -43,7 +43,7 @@ export class DVCClient {
             this.logger.info('EdgeDB can only be enabled for the DVC Cloud Client.')
         }
 
-        const initializePromise = importBucketingLib()
+        const initializePromise = importBucketingLib({ options, logger: this.logger })
             .then(() => {
                 this.configHelper = new EnvironmentConfigManager(this.logger, environmentKey, options || {})
                 this.eventQueue = new EventQueue(


### PR DESCRIPTION
- report on WASM memory usage every 30 sec
- allow WebAssembly.MemoryDescriptor to be set as start option
- Change default initial WASM memory to 1,000 pages = 64 mb, max 10,000 pages = 640 mb