### PR TITLE
fix: specifying libs dir breaks next app builds in Nx

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,7 @@
   "extends": "nx/presets/npm.json",
   "npmScope": "devcycle",
   "workspaceLayout": {
-    "libsDir": "lib",
+    "libsDir": "",
     "appsDir": ""
   },
   "implicitDependencies": {


### PR DESCRIPTION
Working around this Nx bug
https://github.com/nrwl/nx/issues/9317