### PR TITLE
Dvc 5114 js sdk remove id from localstorage on reset

### DIFF
--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -560,6 +560,17 @@ describe('DVCClient tests', () => {
 
             expect(publishEvents).toBeCalled()
         })
+
+        it('should remove anonymous user id from local storage', async () => {
+            const client = new DVCClient('test_env_key', { isAnonymous: true })
+            const oldAnonymousId = client.store.load(StoreKey.AnonUser)
+            expect(oldAnonymousId).toBeTruthy()
+
+            await client.resetUser()
+            const newAnonymousId = client.store.load(StoreKey.AnonUser)
+            expect(oldAnonymousId).not.toEqual(newAnonymousId)
+            expect(client.user.user_id).toEqual(JSON.parse(newAnonymousId))
+        })
     })
 
     describe('allFeatures', () => {

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -227,8 +227,9 @@ export class DVCClient implements Client {
     resetUser(): Promise<DVCVariableSet>
     resetUser(callback: ErrorCallback<DVCVariableSet>): void
     resetUser(callback?: ErrorCallback<DVCVariableSet>): Promise<DVCVariableSet> | void {
+        this.store.remove(StoreKey.AnonUser)
         const anonUser = new DVCPopulatedUser({ isAnonymous: true }, this.options)
-
+        this.store.save(StoreKey.AnonUser, anonUser.user_id)
         const promise = new Promise<DVCVariableSet>((resolve, reject) => {
             this.eventQueue.flushEvents()
 


### PR DESCRIPTION
- remove anonymous user id from local storage on reset
- branch out from and merge after https://github.com/DevCycleHQ/js-sdks/pull/323