### PR TITLE
fix: type definitions for example apps, write tests and change JSON type export

### DIFF
--- a/examples/react/next-js-app/.eslintrc.json
+++ b/examples/react/next-js-app/.eslintrc.json
@@ -7,7 +7,8 @@
   ],
   "ignorePatterns": [
     "!**/*",
-    "node_modules/*"
+    "node_modules/*",
+    ".next/*"
   ],
   "overrides": [
     {

--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -2,7 +2,7 @@ import isString from 'lodash/isString'
 import {
     PublicEnvironment, PublicFeature, PublicProject, PublicVariable
 } from '../../config/configBody'
-import { VariableValue } from '../../config/models'
+import type { DVCJSON, VariableValue } from '../../config/models'
 import {
     IsDate, IsOptional, IsNumber, IsBoolean,
     IsString, IsIn, IsNotEmpty, IsISO31661Alpha2
@@ -10,7 +10,6 @@ import {
 import { Transform, Type } from 'class-transformer'
 import 'reflect-metadata'
 import { IsDVCJSONObject } from '../../validators/dvcJSON'
-import type { DVCJSON } from '../../validators/dvcJSON'
 import { IsNotBlank } from '../../validators/isNotBlank'
 import { IsISO6391 } from '../../validators/isIso6391'
 

--- a/lib/shared/types/src/types/config/models/variable.ts
+++ b/lib/shared/types/src/types/config/models/variable.ts
@@ -39,14 +39,14 @@ export enum VariableType {
 /**
  * Supported variable values
  */
-export type VariableValue = string | boolean | number | JSON
-type JSON = { [key: string]: string | boolean | number }
+export type DVCJSON = { [key: string]: string | boolean | number }
+export type VariableValue = string | boolean | number | DVCJSON
 
 // alias to resolve a generic type constrained by `VariableValue` back into its original type
 export type VariableTypeAlias<T> = T extends boolean ? boolean : (
         T extends number ? number : (
             T extends string ? string : (
-                T extends JSON ? JSON : never
+                T extends DVCJSON ? DVCJSON : never
                 )
             )
         )

--- a/lib/shared/types/src/types/validators/dvcJSON.ts
+++ b/lib/shared/types/src/types/validators/dvcJSON.ts
@@ -6,8 +6,6 @@ import isNull from 'lodash/isNull'
 import isUndefined from 'lodash/isUndefined'
 import { registerDecorator, ValidationOptions } from '@nestjs/class-validator'
 
-export type DVCJSON = { [key: string]: string | number | boolean }
-
 /**
  * Validates that JSON Object is a valid JSON Object with only
  * top-level string / number / boolean values.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@react-native-community/cli": "^9.0.0",
     "@react-native-community/cli-platform-android": "^9.0.0",
     "@react-native-community/cli-platform-ios": "^9.0.0",
-    "@testing-library/react": "^13.3.0",
+    "@testing-library/react": "^13.4.0",
     "@types/async": "^3.2.8",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "28.1.8",

--- a/sdk/js/src/User.ts
+++ b/sdk/js/src/User.ts
@@ -1,4 +1,4 @@
-import { DVCOptions, DVCUser, JSON } from './types'
+import { DVCOptions, DVCUser, DVCJSON } from './types'
 import { v4 as uuidv4 } from 'uuid'
 import * as packageJson from '../package.json'
 import UAParser from 'ua-parser-js'
@@ -15,8 +15,8 @@ export class DVCPopulatedUser implements DVCUser {
     readonly country?: string
     readonly appVersion?: string
     readonly appBuild?: number
-    readonly customData?: JSON
-    readonly privateCustomData?: JSON
+    readonly customData?: DVCJSON
+    readonly privateCustomData?: DVCJSON
     readonly lastSeenDate: Date
 
     readonly createdDate: Date

--- a/sdk/js/src/Variable.ts
+++ b/sdk/js/src/Variable.ts
@@ -1,4 +1,4 @@
-import { DVCVariable as Variable, DVCVariableValue, JSON } from './types'
+import { DVCVariable as Variable, DVCVariableValue, DVCJSON } from './types'
 import { checkParamDefined, checkParamType } from './utils'
 import { VariableTypeAlias } from '@devcycle/types'
 

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -2,7 +2,6 @@ import {
     DVCOptions,
     DVCUser
 } from './types'
-import { DVCPopulatedUser } from './User'
 import { DVCClient } from './Client'
 
 export * from './types'

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -1,7 +1,7 @@
-import { DVCLogger, DVCDefaultLogLevel, VariableTypeAlias } from '@devcycle/types'
+import { DVCLogger, DVCDefaultLogLevel, VariableTypeAlias, VariableValue, DVCJSON } from '@devcycle/types'
 
-export type DVCVariableValue = string | number | boolean | JSON
-export type JSON = Record<string, string | number | boolean>
+export type DVCVariableValue = VariableValue
+export type { DVCJSON }
 
 export interface ErrorCallback<T> {
     (err: Error, result?: null | undefined): void
@@ -99,14 +99,14 @@ export interface DVCUser {
      * Custom JSON data used for audience segmentation, must be limited to __kb in size.
      * Values will be logged to DevCycle's servers and available in the dashboard to view.
      */
-    customData?: JSON
+    customData?: DVCJSON
 
     /**
      * Private Custom JSON data used for audience segmentation, must be limited to __kb in size.
      * Values will not be logged to DevCycle's servers and
      * will not be available in the dashboard.
      */
-    privateCustomData?: JSON
+    privateCustomData?: DVCJSON
 }
 
 export interface DVCClient {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -17,7 +17,6 @@ import * as packageJson from '../package.json'
 import { importBucketingLib, getBucketingLib, cleanupBucketingLib } from './bucketing'
 import { DVCLogger, getVariableTypeFromValue, VariableTypeAlias } from '@devcycle/types'
 import os from 'os'
-import { JSON } from '@devcycle/devcycle-js-sdk'
 
 interface IPlatformData {
     platform: string

--- a/sdk/nodejs/src/models/populatedUser.ts
+++ b/sdk/nodejs/src/models/populatedUser.ts
@@ -1,4 +1,4 @@
-import { JSON, DVCUser } from '../types'
+import { DVCJSON, DVCUser } from '../types'
 import * as packageJson from '../../package.json'
 import { checkParamType, typeEnum } from '../utils/paramUtils'
 
@@ -10,8 +10,8 @@ export class DVCPopulatedUser implements DVCUser {
     country?: string
     appVersion?: string
     appBuild?: number
-    customData?: JSON
-    privateCustomData?: JSON
+    customData?: DVCJSON
+    privateCustomData?: DVCJSON
     readonly lastSeenDate: Date
     readonly createdDate: Date
     readonly platform: string

--- a/sdk/nodejs/src/models/variable.ts
+++ b/sdk/nodejs/src/models/variable.ts
@@ -1,5 +1,5 @@
 import { VariableTypeAlias } from '@devcycle/types'
-import { DVCVariable as DVCVariableInterface, DVCVariableValue, JSON } from '../types'
+import { DVCVariable as DVCVariableInterface, DVCVariableValue } from '../types'
 import { checkParamDefined, checkParamType, typeEnum } from '../utils/paramUtils'
 
 export type VariableParam<T extends DVCVariableValue> = {

--- a/sdk/nodejs/src/types.ts
+++ b/sdk/nodejs/src/types.ts
@@ -1,4 +1,4 @@
-import { DVCLogger, DVCDefaultLogLevel, DVCReporter } from '@devcycle/types'
+import { DVCLogger, DVCDefaultLogLevel, DVCReporter, DVCJSON, VariableValue } from '@devcycle/types'
 
 export interface DVCUser {
     /**
@@ -42,14 +42,14 @@ export interface DVCUser {
      * Custom JSON data used for audience segmentation, must be limited to __kb in size.
      * Values will be logged to DevCycle's servers and available in the dashboard to view.
      */
-    customData?: JSON
+    customData?: DVCJSON
 
     /**
      * Private Custom JSON data used for audience segmentation, must be limited to __kb in size.
      * Values will not be logged to DevCycle's servers and
      * will not be available in the dashboard.
      */
-    privateCustomData?: JSON
+    privateCustomData?: DVCJSON
 }
 
 /**
@@ -126,8 +126,9 @@ export interface DVCOptions {
     apiProxyURL?: string
 }
 
-export type DVCVariableValue = string | number | boolean | JSON
-export type JSON = { [key: string]: string | number | boolean }
+export type DVCVariableValue = VariableValue
+export type JSON = DVCJSON
+export type { DVCJSON }
 
 export type DVCVariableSet = Record<string,
     Omit<DVCVariable, 'defaultValue' | 'isDefaulted'> & { _id: string }

--- a/sdk/react/__mocks__/@devcycle/devcycle-js-sdk.ts
+++ b/sdk/react/__mocks__/@devcycle/devcycle-js-sdk.ts
@@ -1,0 +1,23 @@
+const jsSDK: any = jest.genMockFromModule('@devcycle/devcycle-js-sdk')
+
+class Client {
+    variable(key: string, defaultValue: unknown) {
+        const variable: any = {
+            value: defaultValue,
+        }
+
+        variable.onUpdate = jest.fn().mockReturnValue(variable)
+
+        return variable
+    }
+    close() {
+        // no-op
+    }
+}
+
+module.exports = {
+    ...jsSDK,
+    initialize: () => {
+        return new Client()
+    }
+}

--- a/sdk/react/jest.config.ts
+++ b/sdk/react/jest.config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 export default {
     displayName: 'react-lib',
-
+    testEnvironment: 'jsdom',
     transform: {
         '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/react/babel'] }]
     },

--- a/sdk/react/src/useVariableValue.test.tsx
+++ b/sdk/react/src/useVariableValue.test.tsx
@@ -1,0 +1,55 @@
+import { useVariableValue } from './useVariableValue'
+import { render, renderHook } from '@testing-library/react'
+import DVCProvider from './DVCProvider'
+import type { DVCJSON } from '@devcycle/devcycle-js-sdk'
+import { ReactElement } from 'react'
+
+jest.mock('@devcycle/devcycle-js-sdk')
+
+const ProviderWrapper = ({ children }: {children: ReactElement}) => {
+    return <DVCProvider config={{ user: { user_id: 'test', isAnonymous: false }, envKey: 'test' }}>
+        {children}
+    </DVCProvider>
+}
+
+describe('useVariableValue', () => {
+    it('uses the correct type for string', () => {
+        const { result } = renderHook(() => useVariableValue('test', 'default'), { wrapper: ProviderWrapper })
+        expect(result.current).toEqual('default')
+
+        const _testString: string = result.current
+        // @ts-expect-error this indicates wrong type
+        const _testNumber: number = result.current
+    })
+
+    it('uses the correct type for number', () => {
+        const { result } = renderHook(() => useVariableValue('test', 2), { wrapper: ProviderWrapper })
+        expect(result.current).toEqual(2)
+
+        // @ts-expect-error this indicates wrong type
+        const _testString: string = result.current
+        const _testNumber: number = result.current
+    })
+
+    it('uses the correct type for boolean', () => {
+        const { result } = renderHook(() => useVariableValue('test', true), { wrapper: ProviderWrapper })
+        expect(result.current).toEqual(true)
+
+        // @ts-expect-error this indicates wrong type
+        const _testString: string = result.current
+        // @ts-expect-error this indicates wrong type
+        const _testNumber: number = result.current
+        const _testBoolean: boolean = result.current
+    })
+
+    it('uses the correct type for JSON', () => {
+        const { result } = renderHook(() => useVariableValue('test', { key: 'test' }), { wrapper: ProviderWrapper })
+        expect(result.current).toEqual({ key: 'test' })
+
+        // @ts-expect-error this indicates wrong type
+        const _testString: string = result.current
+        // @ts-expect-error this indicates wrong type
+        const _testNumber: number = result.current
+        const _testJSON: DVCJSON = result.current
+    })
+})

--- a/sdk/react/src/useVariableValue.ts
+++ b/sdk/react/src/useVariableValue.ts
@@ -1,9 +1,8 @@
 import { useVariable } from './'
 import type { DVCVariableValue } from '@devcycle/devcycle-js-sdk'
+import { VariableTypeAlias } from '@devcycle/types'
 
-export const useVariableValue = <T extends DVCVariableValue>(
-    key: string, defaultValue: T
-): ReturnType<typeof useVariable<T>>['value'] => {
+export const useVariableValue = <T extends DVCVariableValue>(key: string, defaultValue: T): VariableTypeAlias<T> => {
     return useVariable(key, defaultValue).value
 }
 

--- a/sdk/react/tsconfig.lib.json
+++ b/sdk/react/tsconfig.lib.json
@@ -19,6 +19,7 @@
     "**/*.test.js",
     "**/*.spec.jsx",
     "**/*.test.jsx",
+    "**/__mocks__/**/*.ts",
     "jest.config.ts"
   ],
   "include": [

--- a/sdk/react/tsconfig.spec.json
+++ b/sdk/react/tsconfig.spec.json
@@ -18,6 +18,7 @@
     "**/*.test.jsx",
     "**/*.spec.jsx",
     "**/*.d.ts",
+    "**/__mocks__/**/*.ts",
     "jest.config.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6222,7 +6222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^13.3.0":
+"@testing-library/react@npm:^13.4.0":
   version: 13.4.0
   resolution: "@testing-library/react@npm:13.4.0"
   dependencies:
@@ -8164,7 +8164,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
+  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
   languageName: node
   linkType: hard
 
@@ -11038,7 +11038,7 @@ __metadata:
     "@react-native-community/cli": ^9.0.0
     "@react-native-community/cli-platform-android": ^9.0.0
     "@react-native-community/cli-platform-ios": ^9.0.0
-    "@testing-library/react": ^13.3.0
+    "@testing-library/react": ^13.4.0
     "@types/async": ^3.2.8
     "@types/hoist-non-react-statics": ^3.3.1
     "@types/jest": 28.1.8


### PR DESCRIPTION
- fix React type definition to work in example apps
- write tests for useVariableValue to test types
- rename `JSON` type to `DVCJSON` to prevent conflicts with global JSON