### PR TITLE
update skipping config cache checking

### DIFF
--- a/sdk/js/src/CacheStore.ts
+++ b/sdk/js/src/CacheStore.ts
@@ -65,14 +65,14 @@ export abstract class CacheStore {
 
     loadConfig(user: DVCPopulatedUser, configCacheTTL= 604800000): BucketedUserConfig | null {
         const userId = this.loadConfigUserId(user)
-        if (user.user_id !== userId) {
+        if (userId && user.user_id !== userId) {
             this.logger?.debug("Skipping cached config: user ID does not match")
             return null
         }
 
         const cachedFetchDate = this.loadConfigFetchDate(user)
         const isConfigCacheTTLExpired = Date.now() - cachedFetchDate > configCacheTTL
-        if (isConfigCacheTTLExpired) {
+        if (cachedFetchDate && isConfigCacheTTLExpired) {
             this.logger?.debug("Skipping cached config: last fetched date is too old")
             return null
         }

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -402,9 +402,7 @@ export class DVCClient implements Client {
             this.isConfigCached = true
             this.eventEmitter.emitFeatureUpdates({}, cachedConfig.features)
             this.eventEmitter.emitVariableUpdates({}, cachedConfig.variables, this.variableDefaultMap)
-            this.logger.info('Initialized with a cached config')
-        } else {
-            this.logger.info('No cached config found')
+            this.logger.debug('Initialized with a cached config')
         }
     }
 }


### PR DESCRIPTION
- update checking to avoid falling to unreasonable reasons
- e.g. previous logic if no config, it falls to user id not match