### PR TITLE
fix: grep for test harness filtering

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -17,7 +17,7 @@ jobs:
         run: yarn --immutable
       - name: Check affected projects
         run: |
-          if yarn nx print-affected --base=origin/main --select=projects | grep -q '[^-]nodejs'; then
+          if yarn nx print-affected --base=origin/main --select=projects | grep -E '(^nodejs|[^-]nodejs)'; then
             echo "TRIGGER_NODEJS_TEST_HARNESS=true" >> $GITHUB_ENV
           fi
       - uses: convictional/trigger-workflow-and-wait@v1.6.1


### PR DESCRIPTION
- regex wasnt matching properly when nodejs was the first entry on the list of `nx affected`