### PR TITLE
fix: nodejs should always set type field on variable instance

### DIFF
--- a/lib/shared/types/src/utils.ts
+++ b/lib/shared/types/src/utils.ts
@@ -6,9 +6,12 @@ import { DVCLogger } from './logger'
 export type ArrayElement<ArrayType extends readonly unknown[]> =
     ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 
-export const getVariableTypeFromValue = (
-    value: VariableValue, key: string, logger: DVCLogger, shouldThrow?: boolean
-): VariableType | null => {
+export function getVariableTypeFromValue(value: VariableValue, key: string,
+    logger: DVCLogger, shouldThrow?: false): VariableType | null
+export function getVariableTypeFromValue(value: VariableValue, key: string,
+                                         logger: DVCLogger, shouldThrow: true): VariableType
+export function getVariableTypeFromValue(value: VariableValue, key: string,
+    logger: DVCLogger, shouldThrow?: boolean): VariableType | null {
     if (typeof value === 'boolean') {
         return VariableType.boolean
     } else if (typeof value === 'number') {

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -49,6 +49,7 @@ describe('variable', () => {
     it('returns a valid variable object for a variable that is in the config', () => {
         const variable = client.variable(user, 'test-key', false)
         expect(variable.value).toEqual(true)
+        expect(variable.type).toEqual('Boolean')
     })
 
     it('returns a valid variable object for a variable that is in the config with a DVCUser instance', () => {
@@ -75,6 +76,7 @@ describe('variable', () => {
         variable.value.concat()
         // should allow assignment to different string
         variable.value = 'test2'
+        expect(variable.type).toEqual('String')
     })
 
     it('returns a variable with the correct type for number', () => {

--- a/sdk/nodejs/__tests__/cloudClient.spec.ts
+++ b/sdk/nodejs/__tests__/cloudClient.spec.ts
@@ -25,6 +25,7 @@ describe('DVCCloudClient without EdgeDB', () => {
             expect(res.value).toBe(true)
             expect(res.isDefaulted).toBe(false)
             expect(res.key).not.toContain('edgedb')
+            expect(res.type).toEqual('Boolean')
         })
 
         it('to return default if type doesnt align with the type of defaultValue', async () => {
@@ -32,12 +33,14 @@ describe('DVCCloudClient without EdgeDB', () => {
             expect(res.value).toBe('string')
             expect(res.isDefaulted).toBe(true)
             expect(res.key).not.toContain('edgedb')
+            expect(res.type).toEqual('String')
         })
 
         it('to return the Default Value and be defaulted', async () => {
             const res = await client.variable(user, 'test-key-not-in-config', false)
             expect(res.value).toBe(false)
             expect(res.isDefaulted).toBe(true)
+            expect(res.type).toEqual('Boolean')
         })
 
         it('to throw an error if key is not defined', async () => {

--- a/sdk/nodejs/__tests__/models/variable.spec.ts
+++ b/sdk/nodejs/__tests__/models/variable.spec.ts
@@ -1,4 +1,5 @@
 import { DVCVariable } from '../../src/models/variable'
+import { VariableType } from '@devcycle/types'
 
 describe('DVCVariable Unit Tests', () => {
 
@@ -7,6 +8,7 @@ describe('DVCVariable Unit Tests', () => {
             key: 'key',
             defaultValue: false,
             value: true,
+            type: VariableType.boolean,
             evalReason: 'reason'
         })
         expect(variable).toEqual({
@@ -14,6 +16,7 @@ describe('DVCVariable Unit Tests', () => {
             isDefaulted: false,
             value: true,
             defaultValue: false,
+            type: 'Boolean',
             evalReason: 'reason'
         })
     })
@@ -29,11 +32,13 @@ describe('DVCVariable Unit Tests', () => {
     it('should set isDefaulted properly', () => {
         const variable = new DVCVariable({
             key: 'key',
-            defaultValue: false
+            defaultValue: false,
+            type: VariableType.boolean
         })
         expect(variable).toEqual(expect.objectContaining({
             key: 'key',
             value: false,
+            type: 'Boolean',
             defaultValue: false,
             isDefaulted: true
         }))
@@ -42,6 +47,7 @@ describe('DVCVariable Unit Tests', () => {
     it('should lowercase key name', () => {
         const variable = new DVCVariable({
             key: 'camelCaseKey',
+            type: VariableType.boolean,
             defaultValue: false
         })
         expect(variable.key).toBe('camelcasekey')

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -106,23 +106,24 @@ export class DVCClient {
 
     variable<T extends DVCVariableValue>(user: DVCUser, key: string, defaultValue: T): DVCVariable<T> {
         const incomingUser = castIncomingUser(user)
+        // this will throw if type is invalid
+        const type = getVariableTypeFromValue(defaultValue, key, this.logger, true)
 
         if (!this.initialized) {
             this.logger.warn('variable called before DVCClient initialized, returning default value')
             return new DVCVariable({
                 defaultValue,
+                type,
                 key
             })
         }
-
-        // this will throw if type is invalid
-        const type = getVariableTypeFromValue(defaultValue, key, this.logger, true)
 
         const populatedUser = DVCPopulatedUser.fromDVCUser(incomingUser)
         const bucketedConfig = bucketUserForConfig(populatedUser, this.environmentKey)
 
         const options: VariableParam<T> = {
             key,
+            type,
             defaultValue
         }
         const configVariable = bucketedConfig?.variables?.[key]

--- a/sdk/nodejs/src/cloudClient.ts
+++ b/sdk/nodejs/src/cloudClient.ts
@@ -51,6 +51,7 @@ export class DVCCloudClient {
                     )
                     return new DVCVariable({
                         defaultValue,
+                        type,
                         key
                     })
                 }
@@ -63,6 +64,7 @@ export class DVCCloudClient {
                 this.logger.error(`Request to get variable: ${key} failed with response message: ${err.message}`)
                 return new DVCVariable({
                     defaultValue,
+                    type,
                     key
                 })
             })

--- a/sdk/nodejs/src/models/variable.ts
+++ b/sdk/nodejs/src/models/variable.ts
@@ -1,11 +1,12 @@
-import { VariableTypeAlias } from '@devcycle/types'
+import { VariableType, VariableTypeAlias } from '@devcycle/types'
 import { DVCVariable as DVCVariableInterface, DVCVariableValue } from '../types'
 import { checkParamDefined, checkParamType, typeEnum } from '../utils/paramUtils'
 
 export type VariableParam<T extends DVCVariableValue> = {
     key: string,
     defaultValue: T,
-    value?: VariableTypeAlias<T>
+    value?: VariableTypeAlias<T>,
+    type: VariableType
     evalReason?: unknown
 }
 
@@ -14,11 +15,11 @@ export class DVCVariable<T extends DVCVariableValue> implements DVCVariableInter
     value: VariableTypeAlias<T>
     readonly defaultValue: T
     readonly isDefaulted: boolean
-    readonly type?: 'String' | 'Number' | 'Boolean' | 'JSON'
+    readonly type: 'String' | 'Number' | 'Boolean' | 'JSON'
     readonly evalReason?: unknown
 
     constructor(variable: VariableParam<T>) {
-        const { key, defaultValue, value, evalReason } = variable
+        const { key, defaultValue, value, evalReason, type } = variable
         checkParamDefined('key', key)
         checkParamDefined('defaultValue', defaultValue)
         checkParamType('key', key, typeEnum.string)
@@ -29,5 +30,6 @@ export class DVCVariable<T extends DVCVariableValue> implements DVCVariableInter
             : value
         this.defaultValue = defaultValue
         this.evalReason = evalReason
+        this.type = type
     }
 }


### PR DESCRIPTION
- ensure type field is always set on DVCVariable instances in NodeJS
- field will be set to the type determined by the defaultValue passed to the variable call