### PR TITLE
fix identify user  call on JS SDK for anonymous users

### DIFF
--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -493,11 +493,13 @@ describe('DVCClient tests', () => {
 
             const client = new DVCClient('test_env_key', { isAnonymous: true })
 
+            const originalAnonUserId = client.user.user_id
             await client.onClientInitialized()
             await client.identifyUser({ isAnonymous: true })
-            const anonUser = client.store.load(StoreKey.AnonUserId)
+            const anonUserId = client.store.load(StoreKey.AnonUserId)
 
-            expect(anonUser).not.toBe(null)
+            expect(anonUserId).toBe(originalAnonUserId)
+            expect(anonUserId).not.toBe(null)
         })
 
     })

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -203,7 +203,8 @@ export class DVCClient implements Client {
             if (user.user_id === this.user.user_id) {
                 updatedUser = this.user.updateUser(user, this.options)
             } else {
-                updatedUser = new DVCPopulatedUser(user, this.options)
+                const storedAnonymousId = this.store.loadAnonUserId()
+                updatedUser = new DVCPopulatedUser(user, this.options, undefined, storedAnonymousId ?? undefined)
             }
 
             this.onInitialized.then(() =>


### PR DESCRIPTION
reuses cached anonymous user id if no user_id is provided