### PR TITLE
DVC-5923 rename envKey to sdkKey in NodeJS SDK

### DIFF
--- a/examples/nodejs-cloud/js/src/main.js
+++ b/examples/nodejs-cloud/js/src/main.js
@@ -17,7 +17,7 @@ app.use(bodyParser.json())
 let dvcClient
 
 async function startDVC() {
-    dvcClient = DVC.initialize('<DVC_SERVER_KEY>', { logLevel: 'info', enableCloudBucketing: true })
+    dvcClient = DVC.initialize('<DVC_SERVER_SDK_KEY>', { logLevel: 'info', enableCloudBucketing: true })
     console.log('DVC Cloud Bucketing JS Client Ready')
 
     const user = {

--- a/examples/nodejs-cloud/typescript/src/main.ts
+++ b/examples/nodejs-cloud/typescript/src/main.ts
@@ -32,7 +32,7 @@ async function validateUserFromQueryParams(queryParams: Query): Promise<DVCClien
 }
 
 async function startDVC() {
-    dvcClient = initialize('<DVC_SERVER_KEY>', { logLevel: 'info', enableCloudBucketing: true })
+    dvcClient = initialize('<DVC_SERVER_SDK_KEY>', { logLevel: 'info', enableCloudBucketing: true })
     console.log('DVC Cloud Bucketing TypeScript Client Ready')
 
     const user = {

--- a/examples/nodejs-local/js/src/main.js
+++ b/examples/nodejs-local/js/src/main.js
@@ -17,7 +17,7 @@ app.use(bodyParser.json())
 let dvcClient
 
 async function startDVC() {
-    dvcClient = await DVC.initialize('<DVC_SERVER_KEY>', { logLevel: 'info' }).onClientInitialized()
+    dvcClient = await DVC.initialize('<DVC_SERVER_SDK_KEY>', { logLevel: 'info' }).onClientInitialized()
     console.log('DVC Local Bucketing JS Client Initialized')
 
     const user = {

--- a/examples/nodejs-local/typescript/src/main.ts
+++ b/examples/nodejs-local/typescript/src/main.ts
@@ -38,7 +38,7 @@ async function startDVC() {
     const user = {
         user_id: 'node_sdk_test',
         country: 'CA'
-    }
+    }g
 
     const partyTime = dvcClient.variable(user, 'elliot-test', false)
     if (partyTime.value) {

--- a/examples/nodejs-local/typescript/src/main.ts
+++ b/examples/nodejs-local/typescript/src/main.ts
@@ -32,13 +32,13 @@ function validateUserFromQueryParams(queryParams: Query): DVCClientAPIUser {
 }
 
 async function startDVC() {
-    dvcClient = await initialize('<DVC_SERVER_KEY>', { logLevel: 'info' }).onClientInitialized()
+    dvcClient = await initialize('<DVC_SERVER_SDK_KEY>', { logLevel: 'info' }).onClientInitialized()
     console.log('DVC Local Bucketing TypeScript Client Initialized')
 
     const user = {
         user_id: 'node_sdk_test',
         country: 'CA'
-    }g
+    }
 
     const partyTime = dvcClient.variable(user, 'elliot-test', false)
     if (partyTime.value) {

--- a/sdk/nodejs/__tests__/environmentConfigManager.spec.ts
+++ b/sdk/nodejs/__tests__/environmentConfigManager.spec.ts
@@ -41,7 +41,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
     it('should build manager from constructor', async () => {
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 200 }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {
             configPollingIntervalMS: 1000,
             configPollingTimeoutMS: 1000
         })
@@ -49,10 +49,10 @@ describe('EnvironmentConfigManager Unit Tests', () => {
         expect(setInterval_mock).toHaveBeenCalledTimes(1)
 
         await envConfig._fetchConfig()
-        expect(getBucketingLib().setConfigData).toHaveBeenCalledWith('envKey', '{}')
+        expect(getBucketingLib().setConfigData).toHaveBeenCalledWith('sdkKey', '{}')
 
         expect(envConfig).toEqual(expect.objectContaining({
-            environmentKey: 'envKey',
+            sdkKey: 'sdkKey',
             fetchConfigPromise: expect.any(Promise),
             pollingIntervalMS: 1000,
             requestTimeoutMS: 1000
@@ -63,7 +63,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
     it('should override the configPollingIntervalMS and configPollingTimeoutMS settings', async () => {
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 200 }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {
             configPollingIntervalMS: 10,
             configPollingTimeoutMS: 10000
         })
@@ -73,7 +73,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
         await envConfig._fetchConfig()
 
         expect(envConfig).toEqual(expect.objectContaining({
-            environmentKey: 'envKey',
+            sdkKey: 'sdkKey',
             fetchConfigPromise: expect.any(Promise),
             pollingIntervalMS: 1000,
             requestTimeoutMS: 1000
@@ -84,7 +84,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
     it('should call fetch config on the interval period time', async () => {
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 200 }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {
             configPollingIntervalMS: 1000,
             configPollingTimeoutMS: 1000
         })
@@ -99,7 +99,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
 
         envConfig.cleanup()
         expect(envConfig).toEqual(expect.objectContaining({
-            environmentKey: 'envKey',
+            sdkKey: 'sdkKey',
             fetchConfigPromise: expect.any(Promise),
             pollingIntervalMS: 1000,
             requestTimeoutMS: 1000
@@ -110,14 +110,14 @@ describe('EnvironmentConfigManager Unit Tests', () => {
     it('should throw error fetching config fails with 500 error', () => {
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 500 }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {})
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {})
         expect(envConfig.fetchConfigPromise).rejects.toThrow('Failed to download DevCycle config.')
     })
 
     it('should throw invalid sdk key fetching config fails with 403 error', () => {
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 403 }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {})
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {})
         expect(envConfig.fetchConfigPromise).rejects.toThrow('Invalid SDK key provided:')
         expect(setInterval_mock).toHaveBeenCalledTimes(0)
     })
@@ -125,7 +125,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
     it('should throw error fetching config throws', () => {
         getEnvironmentConfig_mock.mockRejectedValue(new Error('Error'))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {})
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {})
         expect(envConfig.fetchConfigPromise).rejects.toThrow('Failed to download DevCycle config.')
     })
 
@@ -133,7 +133,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
         const config = { config: {} }
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 200, data: config }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {
             configPollingIntervalMS: 1000,
             configPollingTimeoutMS: 1000
         })
@@ -151,7 +151,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
     it('should start interval if initial config fails', async () => {
         getEnvironmentConfig_mock.mockImplementation(async () => mockFetchResponse({ status: 500 }))
 
-        const envConfig = new EnvironmentConfigManager(logger, 'envKey', {})
+        const envConfig = new EnvironmentConfigManager(logger, 'sdkKey', {})
         await expect(envConfig.fetchConfigPromise).rejects.toThrow()
         expect(setInterval_mock).toHaveBeenCalledTimes(1)
     })

--- a/sdk/nodejs/__tests__/request.spec.ts
+++ b/sdk/nodejs/__tests__/request.spec.ts
@@ -15,7 +15,7 @@ describe('request.ts Unit Tests', () => {
     })
 
     describe('publishEvents', () => {
-        it('should throw errors for missing envKey / config', async () => {
+        it('should throw errors for missing sdkKey / config', async () => {
             await expect(() => publishEvents(logger, null, []))
                 .rejects.toThrow('DevCycle is not yet initialized to publish events.')
         })

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -1,7 +1,7 @@
 import { DVCOptions } from './types'
 import { DVCClient } from './client'
 import { DVCCloudClient } from './cloudClient'
-import { isValidServerEnvKey } from './utils/paramUtils'
+import { isValidServerSDKKey } from './utils/paramUtils'
 
 export { DVCClient, DVCCloudClient }
 export * from './types'
@@ -11,18 +11,18 @@ export { DVCUser } from './models/user'
 type DVCOptionsCloudEnabled = DVCOptions & { enableCloudBucketing: true }
 type DVCOptionsLocalEnabled = DVCOptions & { enableCloudBucketing?: false }
 
-export function initialize(environmentKey: string, options?: DVCOptionsLocalEnabled): DVCClient
-export function initialize(environmentKey: string, options: DVCOptionsCloudEnabled): DVCCloudClient
-export function initialize(environmentKey: string, options?: DVCOptions): DVCClient | DVCCloudClient
-export function initialize(environmentKey: string, options: DVCOptions = {}): DVCClient | DVCCloudClient {
-    if (!environmentKey) {
+export function initialize(sdkKey: string, options?: DVCOptionsLocalEnabled): DVCClient
+export function initialize(sdkKey: string, options: DVCOptionsCloudEnabled): DVCCloudClient
+export function initialize(sdkKey: string, options?: DVCOptions): DVCClient | DVCCloudClient
+export function initialize(sdkKey: string, options: DVCOptions = {}): DVCClient | DVCCloudClient {
+    if (!sdkKey) {
         throw new Error('Missing environment key! Call initialize with a valid environment key')
-    } else if (!isValidServerEnvKey(environmentKey)) {
+    } else if (!isValidServerSDKKey(sdkKey)) {
         throw new Error('Invalid environment key provided. Please call initialize with a valid server environment key')
     }
 
     if (options.enableCloudBucketing) {
-        return new DVCCloudClient(environmentKey, options)
+        return new DVCCloudClient(sdkKey, options)
     }
-    return new DVCClient(environmentKey, options)
+    return new DVCClient(sdkKey, options)
 }

--- a/sdk/nodejs/src/request.ts
+++ b/sdk/nodejs/src/request.ts
@@ -64,17 +64,17 @@ const handleResponse = async (res: Response) => {
 
 export async function publishEvents(
     logger: DVCLogger,
-    envKey: string | null,
+    sdkKey: string | null,
     eventsBatch: SDKEventBatchRequestBody,
     eventsBaseURLOverride?: string
 ): Promise<Response> {
-    if (!envKey) {
+    if (!sdkKey) {
         throw new Error('DevCycle is not yet initialized to publish events.')
     }
     const url = eventsBaseURLOverride ? `${eventsBaseURLOverride}${EVENTS_PATH}` : `${EVENT_URL}${HOST}${EVENTS_PATH}`
     return await post(url, {
         body: JSON.stringify({ batch: eventsBatch })
-    }, envKey)
+    }, sdkKey)
 }
 
 export async function getEnvironmentConfig(
@@ -92,7 +92,7 @@ export async function getEnvironmentConfig(
 
 export async function getAllFeatures(
     user: DVCPopulatedUser,
-    envKey: string,
+    sdkKey: string,
     options: DVCOptions
 ): Promise<Response> {
     const baseUrl = `${options.bucketingAPIURI || BUCKETING_URL}${FEATURES_PATH}`
@@ -100,12 +100,12 @@ export async function getAllFeatures(
     return await post(postUrl, {
         body: JSON.stringify(user),
         retries: 5
-    }, envKey)
+    }, sdkKey)
 }
 
 export async function getAllVariables(
     user: DVCPopulatedUser,
-    envKey: string,
+    sdkKey: string,
     options: DVCOptions
 ): Promise<Response> {
     const baseUrl = `${options.bucketingAPIURI || BUCKETING_URL}${VARIABLES_PATH}`
@@ -114,12 +114,12 @@ export async function getAllVariables(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(user),
         retries: 5
-    }, envKey)
+    }, sdkKey)
 }
 
 export async function getVariable(
     user: DVCPopulatedUser,
-    envKey: string,
+    sdkKey: string,
     variableKey: string,
     options: DVCOptions
 ): Promise<Response> {
@@ -128,13 +128,13 @@ export async function getVariable(
     return await post(postUrl, {
         body: JSON.stringify(user),
         retries: 5
-    }, envKey)
+    }, sdkKey)
 }
 
 export async function postTrack(
     user: DVCPopulatedUser,
     event: DVCEvent,
-    envKey: string,
+    sdkKey: string,
     options: DVCOptions
 ): Promise<void> {
     const baseUrl = `${options.bucketingAPIURI || BUCKETING_URL}${TRACK_PATH}`
@@ -145,16 +145,16 @@ export async function postTrack(
             events: [event]
         }),
         retries: 5
-    }, envKey)
+    }, sdkKey)
 }
 
 export async function post(
     url: string,
     requestConfig: RequestInit | RequestInitWithRetry,
-    envKey: string
+    sdkKey: string
 ): Promise<Response> {
     const [_fetch, config] = await getFetchAndConfig(requestConfig)
-    const postHeaders = { ...config.headers, 'Authorization': envKey, 'Content-Type': 'application/json' }
+    const postHeaders = { ...config.headers, 'Authorization': sdkKey, 'Content-Type': 'application/json' }
     const res = await _fetch(url, {
         ...config,
         headers: postHeaders,

--- a/sdk/nodejs/src/utils/paramUtils.ts
+++ b/sdk/nodejs/src/utils/paramUtils.ts
@@ -36,6 +36,6 @@ export function checkParamString(name: string, param: unknown): string {
     return param as string
 }
 
-export function isValidServerEnvKey(envKey: string): boolean {
-    return envKey?.startsWith('server') || envKey?.startsWith('dvc_server')
+export function isValidServerSDKKey(sdkKey: string): boolean {
+    return sdkKey?.startsWith('server') || sdkKey?.startsWith('dvc_server')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8202,7 +8202,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
+  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- rename `envKey` / `token` to `sdkKey` in NodeJS SDK to improve consistency across our SDKs