### PR TITLE
fix: allow unknown comparators for forwards compatibility

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
@@ -597,6 +597,35 @@ describe('SegmentationManager Unit Test', () => {
             })
         })
 
+        describe('evaluateOperator should handle a new comparator type', () => {
+            const filters = [{
+                type: 'user',
+                subType: 'email',
+                comparator: 'wowNewComparator',
+                values: []
+            }, {
+                type: 'audienceMatch',
+                _audiences: [],
+                comparator: 'wowNewComparator'
+            }]
+
+            const operator = {
+                filters,
+                operator: 'and'
+            }
+
+            const data = {
+                country: 'Canada',
+                email: 'brooks@big.lunch',
+                platformVersion: '2.0.0',
+                platform: 'iOS'
+            }
+
+            it('should fail for user and audienceMatch filters with comparator of myNewFilter', () => {
+                assert.strictEqual(false, evaluateOperator({ data, operator }))
+            })
+        })
+
         it('should work for an AND operator', () => {
             const filters = [
                 { type: 'user', subType: 'country', comparator: '=', values: ['Canada'] },

--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
@@ -54,19 +54,30 @@ function doesUserPassFilter(
     user: DVCPopulatedUser,
     audiences: Map<string, NoIdAudience>
 ): bool {
+    const invalidFilterLog = `
+            [DevCycle] Warning: Invalid filter data ${filter}.
+            To leverage this new filter definition, please update to the latest version of the DevCycle SDK.
+        `
+
     if (filter.type === 'all') return true
     else if (filter.type === 'optIn') return false
     else if (filter.type === 'audienceMatch') {
+        if (!(filter as AudienceMatchFilter).isValid) {
+            console.log(invalidFilterLog)
+            return false
+        }
         return filterForAudienceMatch(filter as AudienceMatchFilter, user, audiences)
     } else if (!(filter instanceof UserFilter)) {
-        console.log(`
-            [DevCycle] Warning: Invalid filter data ${filter}.
-            To leverage this new filter definition, please update to the latest version of the DevCycle SDK.
-        `)
+        console.log(invalidFilterLog)
         return false
     }
 
     const userFilter = filter as UserFilter
+
+    if (!userFilter.isValid) {
+        console.log(invalidFilterLog)
+        return false
+    }
 
     const subType = userFilter.subType
     if (!validSubTypes.includes(subType)) {

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -137,7 +137,7 @@ export class AudienceFilterOrOperator extends JSON.Value {
 
         this.subType = isValidStringOptional(filter, 'subType', validSubTypes, false)
 
-        this.comparator = isValidStringOptional(filter, 'comparator', validComparators)
+        this.comparator = isValidStringOptional(filter, 'comparator', validComparators, false)
 
         this.dataKey = getStringFromJSONOptional(filter, 'dataKey')
 
@@ -194,12 +194,14 @@ export class AudienceMatchFilter extends AudienceFilterOrOperator {
     type: string
     comparator: string
     _audiences: JSON.Arr
+    readonly isValid: bool
 
     constructor(filter: JSON.Obj) {
         super(filter)
         this._audiences = getJSONArrayFromJSON(filter, '_audiences')
         this.type = isValidString(filter, 'type', validTypes, false)
-        this.comparator = isValidString(filter, 'comparator', validAudienceMatchComparators)
+        this.comparator = isValidString(filter, 'comparator', validAudienceMatchComparators, false)
+        this.isValid = validAudienceMatchComparators.includes(this.comparator)
     }
 }
 
@@ -208,13 +210,15 @@ export class UserFilter extends AudienceFilterOrOperator {
     subType: string
     comparator: string
     values: JSON.Arr
+    readonly isValid: bool
 
     constructor(filter: JSON.Obj) {
         super(filter)
         this.values = getJSONArrayFromJSON(filter, 'values')
         this.type = isValidString(filter, 'type', validTypes, false)
         this.subType = isValidString(filter, 'subType', validSubTypes, false)
-        this.comparator = isValidString(filter, 'comparator', validComparators)
+        this.comparator = isValidString(filter, 'comparator', validComparators, false)
+        this.isValid = validComparators.includes(this.comparator)
     }
 }
 


### PR DESCRIPTION
- prevent bucketing logic from throwing on unknown comparators. Instead return false and log a warning
