### PR TITLE
feat: add client custom data to user custom data when tracking events

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
@@ -485,7 +485,6 @@ describe('SegmentationManager Unit Test', () => {
                     { data, operator: parentOperator, audiences }))
             })
 
-
             it('should not pass seg when referenced audience does not exist', () => {
                 assert.strictEqual(false, evaluateOperator(
                     { data, operator: audienceMatchOperator, audiences: {} }))
@@ -769,7 +768,6 @@ describe('SegmentationManager Unit Test', () => {
             }
             assert.strictEqual(true, evaluateOperator({ data, operator }))
         })
-
 
         it('should work for an AND operator containing a custom data filter', () => {
             const filters = [

--- a/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
@@ -105,7 +105,7 @@ export function queueEvent(sdkKey: string, userStr: string, eventStr: string): v
     const eventQueue = getEventQueue(sdkKey)
     const dvcUser = DVCPopulatedUser.fromJSONString(userStr)
     const event = DVCEvent.fromJSONString(eventStr)
-
+    dvcUser.mergeClientCustomData(_getClientCustomData(sdkKey))
     const bucketedConfig = _generateBucketedConfig(_getConfigData(sdkKey), dvcUser, _getClientCustomData(sdkKey))
     eventQueue.queueEvent(dvcUser, event, bucketedConfig.featureVariationMap)
 }

--- a/lib/shared/bucketing-assembly-script/assembly/types/dvcUser.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/dvcUser.ts
@@ -147,6 +147,19 @@ export class DVCPopulatedUser extends JSON.Value implements DVCUserInterface {
         return this.combinedCustomData
     }
 
+    mergeClientCustomData(clientCustomData: JSON.Obj): void {
+        if (!this.customData && clientCustomData.keys.length > 0) {
+            this.customData = new JSON.Obj()
+        }
+
+        for (let i = 0; i < clientCustomData.keys.length; i++) {
+            if (!this.customData!.has(clientCustomData.keys[i])
+                    && (this.privateCustomData && !this.privateCustomData!.has(clientCustomData.keys[i]))) {
+                this.customData!.set(clientCustomData.keys[i], clientCustomData.get(clientCustomData.keys[i]))
+            }
+        }
+    }
+
     stringify(): string {
         const json = new JSON.Obj()
         json.set('user_id', this.user_id)

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -81,7 +81,7 @@ export class AudienceFilterOrOperator extends JSON.Value {
         if (this.filterClass !== null) {
             return (this.filterClass as AudienceFilter).stringify()
         }
-        return ""
+        return ''
     }
 }
 
@@ -192,7 +192,6 @@ export class AudienceMatchFilter extends AudienceFilter {
         return json.stringify()
     }
 }
-
 
 export class UserFilter extends AudienceFilter {
     subType: string


### PR DESCRIPTION
When a custom event is tracked, merge the current clientCustomData into the user's customData field when logging the event.

Do not merge in fields that are conflicted by an existing "privateCustomData" field.