### PR TITLE
fix: react useVariable hook will only call the variable method once

### DIFF
--- a/sdk/react/__mocks__/@devcycle/devcycle-js-sdk.ts
+++ b/sdk/react/__mocks__/@devcycle/devcycle-js-sdk.ts
@@ -1,14 +1,17 @@
 const jsSDK: any = jest.genMockFromModule('@devcycle/devcycle-js-sdk')
 
+const mockVariableFunction = jest.fn().mockImplementation((key: string, defaultValue: unknown) => {
+    const variable: any = {
+        value: defaultValue,
+    }
+
+    variable.onUpdate = jest.fn().mockReturnValue(variable)
+
+    return variable
+})
 class Client {
     variable(key: string, defaultValue: unknown) {
-        const variable: any = {
-            value: defaultValue,
-        }
-
-        variable.onUpdate = jest.fn().mockReturnValue(variable)
-
-        return variable
+        return mockVariableFunction(key, defaultValue)
     }
     close() {
         // no-op
@@ -17,6 +20,7 @@ class Client {
 
 module.exports = {
     ...jsSDK,
+    mockVariableFunction,
     initialize: () => {
         return new Client()
     }

--- a/sdk/react/src/useVariable.ts
+++ b/sdk/react/src/useVariable.ts
@@ -1,14 +1,20 @@
-import { useContext, useState } from 'react'
+import { useContext, useRef, useState } from 'react'
 import context from './context'
 import type { DVCVariable, DVCVariableValue } from '@devcycle/devcycle-js-sdk'
 
 export const useVariable = <T extends DVCVariableValue>(key: string, defaultValue: T): DVCVariable<T> => {
     const dvcContext = useContext(context)
     const [_, forceRerender] = useState({})
+    const ref = useRef<DVCVariable<T>>()
 
     if (dvcContext === undefined) throw new Error('useVariable must be used within DVCProvider')
 
-    return dvcContext.client.variable(key, defaultValue).onUpdate(() => forceRerender({}))
+    if (!ref.current) {
+        ref.current = dvcContext?.client.variable(key, defaultValue)
+        ref.current.onUpdate(() => forceRerender({}))
+    }
+
+    return ref.current
 }
 
 export default useVariable

--- a/sdk/react/src/useVariableValue.test.tsx
+++ b/sdk/react/src/useVariableValue.test.tsx
@@ -3,6 +3,9 @@ import { render, renderHook } from '@testing-library/react'
 import DVCProvider from './DVCProvider'
 import type { DVCJSON } from '@devcycle/devcycle-js-sdk'
 import { ReactElement } from 'react'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { mockVariableFunction } from '@devcycle/devcycle-js-sdk' // defined in the mock
 
 jest.mock('@devcycle/devcycle-js-sdk')
 
@@ -13,6 +16,9 @@ const ProviderWrapper = ({ children }: {children: ReactElement}) => {
 }
 
 describe('useVariableValue', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
     it('uses the correct type for string', () => {
         const { result } = renderHook(() => useVariableValue('test', 'default'), { wrapper: ProviderWrapper })
         expect(result.current).toEqual('default')
@@ -51,5 +57,13 @@ describe('useVariableValue', () => {
         // @ts-expect-error this indicates wrong type
         const _testNumber: number = result.current
         const _testJSON: DVCJSON = result.current
+    })
+
+    it('calls the variable method on the SDK once per hook instance, not per invocation', () => {
+        const { result, rerender } = renderHook(() => useVariableValue('test', 'default'), { wrapper: ProviderWrapper })
+        expect(result.current).toEqual('default')
+        rerender()
+        expect(result.current).toEqual('default')
+        expect(mockVariableFunction).toHaveBeenCalledTimes(1)
     })
 })


### PR DESCRIPTION
Using `useVariable` will now only call the underlying JS SDK's `variable` method once, and store the result in a ref. It will still correctly re-render when onUpdate is called.

This prevents every render of a component that is using the `useVariable` hook from sending another variableEvaluated event (which could result in thousands of events)