### PR TITLE
chore: remove date field and only send client date for request events

### DIFF
--- a/sdk/nodejs/__tests__/models/requestEvent.spec.ts
+++ b/sdk/nodejs/__tests__/models/requestEvent.spec.ts
@@ -12,17 +12,16 @@ describe('DVCRequestEvent Unit Tests', () => {
             metaData: { meta: 'data' }
         }, 'user_id', { 'feature': 'vars' })
 
-        expect(requestEvent).toEqual(expect.objectContaining({
+        expect(requestEvent).toEqual({
             type: 'customEvent',
             customType: 'type',
             user_id: 'user_id',
-            date: expect.any(Number),
             clientDate: date,
             target: 'target',
             value: 610,
             featureVars: { 'feature': 'vars' },
             metaData: { meta: 'data' }
-        }))
+        })
     })
 
     it('should construct an event for an internal DVC Event', () => {
@@ -32,7 +31,6 @@ describe('DVCRequestEvent Unit Tests', () => {
         expect(requestEvent).toEqual(expect.objectContaining({
             type: EventTypes.variableEvaluated,
             user_id: 'user_id',
-            date: expect.any(Number),
             clientDate: expect.any(Number)
         }))
     })

--- a/sdk/nodejs/src/models/requestEvent.ts
+++ b/sdk/nodejs/src/models/requestEvent.ts
@@ -7,7 +7,6 @@ export class DVCRequestEvent {
     target?: string
     customType?: string
     user_id: string
-    date: number
     clientDate: number
     value?: number
     featureVars?: Record<string, string>
@@ -25,7 +24,6 @@ export class DVCRequestEvent {
         this.target = target
         this.customType = isCustomEvent ? type : undefined
         this.user_id = user_id
-        this.date = Date.now()
         this.clientDate = date || Date.now()
         this.value = value
         this.featureVars = featureVars


### PR DESCRIPTION
# Changes 

- removed `date` field 