### PR TITLE
DVC-6473 add variableForUser() method to WASM code

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
@@ -17,7 +17,6 @@ import { FlushPayload } from '../../assembly/types'
 import testData from '@devcycle/bucketing-test-data/json-data/testData.json'
 const { config } = testData
 import random_JSON from './random_json_2kb.json'
-import { FeatureType } from '@devcycle/types'
 
 let currentSDKKey: string | null = null
 const initEventQueue = (sdkKey: unknown, options: unknown) => {
@@ -65,7 +64,7 @@ const initSDK = (sdkKey: string, eventOptions: unknown = {}) => {
 
 describe('EventQueueManager Tests', () => {
     afterEach(() => {
-        clearPlatformData('')
+        clearPlatformData()
         if (currentSDKKey) {
             cleanupEventQueue(currentSDKKey)
             setClientCustomData(currentSDKKey, '{}')
@@ -509,48 +508,10 @@ describe('EventQueueManager Tests', () => {
     })
 
     describe('queueVariableEvaluatedEvent', () => {
-        const bucketedConfig = {
-            'environment': {
-                '_id': '6153553b8cf4e45e0464268d',
-                'key': 'test-environment'
-            },
-            'knownVariableKeys': [],
-            'project': {
-                '_id': '61535533396f00bab586cb17',
-                'a0_organization': 'org_12345612345',
-                'key': 'test-project',
-                'settings': {
-                    'edgeDB': {
-                        enabled: false
-                    }
-                }
-            },
-            'features': {
-                'feature1': {
-                    '_id': '614ef6aa473928459060721a',
-                    'key': 'feature1',
-                    'type': FeatureType.release,
-                    '_variation': '615357cf7e9ebdca58446ed0',
-                    'variationName': 'variation 2',
-                    'variationKey': 'variation-2-key',
-                },
-            },
-            'featureVariationMap': {
-                '614ef6aa473928459060721a': '615357cf7e9ebdca58446ed0',
-            },
-            'variableVariationMap': {
-                'swagTest': {
-                    _feature: '614ef6aa473928459060721a',
-                    _variation: '615357cf7e9ebdca58446ed0'
-                }
-            },
-            'variables': {
-                'swagTest': {
-                    '_id': '615356f120ed334a6054564c',
-                    'key': 'swagTest',
-                    'type': 'String',
-                    'value': 'YEEEEOWZA',
-                }
+        const varVariationMap = {
+            swagTest: {
+                _feature: '614ef6aa473928459060721a',
+                _variation: '615357cf7e9ebdca58446ed0'
             }
         }
 
@@ -564,7 +525,7 @@ describe('EventQueueManager Tests', () => {
             const sdkKey = 'sdk_key_queueVariableEvaluatedEvent_test'
             initSDK(sdkKey)
 
-            queueVariableEvaluatedEvent(sdkKey, bucketedConfig, variable, 'swagTest')
+            queueVariableEvaluatedEvent(sdkKey, varVariationMap, variable, 'swagTest')
             expect(eventQueueSize(sdkKey)).toEqual(1)
         })
 
@@ -572,7 +533,7 @@ describe('EventQueueManager Tests', () => {
             const sdkKey = 'sdk_key_queueVariableEvaluatedEvent_test'
             initSDK(sdkKey)
 
-            queueVariableEvaluatedEvent(sdkKey, bucketedConfig, null, 'unknownVariable')
+            queueVariableEvaluatedEvent(sdkKey, varVariationMap, null, 'unknownVariable')
             expect(eventQueueSize(sdkKey)).toEqual(1)
         })
     })

--- a/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
@@ -10,12 +10,14 @@ import {
     queueAggregateEvent as queueAggregateEvent_AS,
     cleanupEventQueue,
     eventQueueSize as eventQueueSize_AS,
-    setClientCustomData
+    setClientCustomData,
+    queueVariableEvaluatedEvent_JSON
 } from '../bucketingImportHelper'
 import { FlushPayload } from '../../assembly/types'
 import testData from '@devcycle/bucketing-test-data/json-data/testData.json'
 const { config } = testData
 import random_JSON from './random_json_2kb.json'
+import { FeatureType } from '@devcycle/types'
 
 let currentSDKKey: string | null = null
 const initEventQueue = (sdkKey: unknown, options: unknown) => {
@@ -34,6 +36,15 @@ const queueEvent = (sdkKey: string, user: unknown, event: unknown) => {
 
 const queueAggregateEvent = (sdkKey: string, event: unknown, variableVariationMap: unknown) => {
     return queueAggregateEvent_AS(sdkKey, JSON.stringify(event), JSON.stringify(variableVariationMap))
+}
+
+const queueVariableEvaluatedEvent = (sdkKey: string, config: unknown, variable: unknown, variableKey: string) => {
+    return queueVariableEvaluatedEvent_JSON(
+        sdkKey,
+        JSON.stringify(config),
+        variable ? JSON.stringify(variable) : null,
+        variableKey
+    )
 }
 
 const eventQueueSize = (sdkKey: string): number => {
@@ -494,6 +505,75 @@ describe('EventQueueManager Tests', () => {
                 sdkVersion: '1.0.0'
             }))
             expect(() => queueEvent(sdkKey, dvcUser, event)).toThrow('Config data is not set.')
+        })
+    })
+
+    describe('queueVariableEvaluatedEvent', () => {
+        const bucketedConfig = {
+            'environment': {
+                '_id': '6153553b8cf4e45e0464268d',
+                'key': 'test-environment'
+            },
+            'knownVariableKeys': [],
+            'project': {
+                '_id': '61535533396f00bab586cb17',
+                'a0_organization': 'org_12345612345',
+                'key': 'test-project',
+                'settings': {
+                    'edgeDB': {
+                        enabled: false
+                    }
+                }
+            },
+            'features': {
+                'feature1': {
+                    '_id': '614ef6aa473928459060721a',
+                    'key': 'feature1',
+                    'type': FeatureType.release,
+                    '_variation': '615357cf7e9ebdca58446ed0',
+                    'variationName': 'variation 2',
+                    'variationKey': 'variation-2-key',
+                },
+            },
+            'featureVariationMap': {
+                '614ef6aa473928459060721a': '615357cf7e9ebdca58446ed0',
+            },
+            'variableVariationMap': {
+                'swagTest': {
+                    _feature: '614ef6aa473928459060721a',
+                    _variation: '615357cf7e9ebdca58446ed0'
+                }
+            },
+            'variables': {
+                'swagTest': {
+                    '_id': '615356f120ed334a6054564c',
+                    'key': 'swagTest',
+                    'type': 'String',
+                    'value': 'YEEEEOWZA',
+                }
+            }
+        }
+
+        it('should log aggVariableEvaluated event', () => {
+            const variable = {
+                '_id': '615356f120ed334a6054564c',
+                'key': 'swagTest',
+                'type': 'String',
+                'value': 'YEEEEOWZA',
+            }
+            const sdkKey = 'sdk_key_queueVariableEvaluatedEvent_test'
+            initSDK(sdkKey)
+
+            queueVariableEvaluatedEvent(sdkKey, bucketedConfig, variable, 'swagTest')
+            expect(eventQueueSize(sdkKey)).toEqual(1)
+        })
+
+        it('should log aggVariableDefaulted event', () => {
+            const sdkKey = 'sdk_key_queueVariableEvaluatedEvent_test'
+            initSDK(sdkKey)
+
+            queueVariableEvaluatedEvent(sdkKey, bucketedConfig, null, 'unknownVariable')
+            expect(eventQueueSize(sdkKey)).toEqual(1)
         })
     })
 

--- a/lib/shared/bucketing-assembly-script/__tests__/setPlatformData.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/setPlatformData.ts
@@ -1,4 +1,11 @@
-import { setPlatformData } from './bucketingImportHelper'
+import {
+    initEventQueue,
+    setPlatformData,
+    setConfigData,
+    cleanupEventQueue,
+    clearPlatformData,
+    setClientCustomData
+} from './bucketingImportHelper'
 
 const defaultPlatformData = {
     platform: 'NodeJS',
@@ -11,4 +18,22 @@ const defaultPlatformData = {
 
 export const setPlatformDataJSON = (data: unknown = defaultPlatformData): void => {
     setPlatformData(JSON.stringify(data))
+}
+
+export const initSDK = (sdkKey: string, config: unknown = {}, eventOptions: unknown = {}): void => {
+    initEventQueue(sdkKey, JSON.stringify(eventOptions))
+    setPlatformData(JSON.stringify({
+        platform: 'NodeJS',
+        platformVersion: '16.0',
+        sdkType: 'server',
+        sdkVersion: '1.0.0',
+        hostname: 'host.name'
+    }))
+    setConfigData(sdkKey, JSON.stringify(config))
+}
+
+export const cleanupSDK = (sdkKey: string): void => {
+    clearPlatformData()
+    cleanupEventQueue(sdkKey)
+    setClientCustomData(sdkKey, '{}')
 }

--- a/lib/shared/bucketing-assembly-script/__tests__/variable.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/variable.test.ts
@@ -9,11 +9,11 @@ import { SDKVariable } from '../assembly/types'
 const { config } = testData
 
 const variableForUser = (
-    { config, user, variableKey }:
-    { config: unknown, user: unknown, variableKey: string }
+    { config, user, variableKey, variableType }:
+    { config: unknown, user: unknown, variableKey: string, variableType: string }
 ): SDKVariable | null => {
     setConfigData('sdkKey', JSON.stringify(config))
-    const variableJSON = variableForUser_AS('sdkKey', JSON.stringify(user), variableKey)
+    const variableJSON = variableForUser_AS('sdkKey', JSON.stringify(user), variableKey, variableType)
     return variableJSON ? JSON.parse(variableJSON) as SDKVariable : null
 }
 
@@ -39,7 +39,7 @@ describe('variableForUser tests', () => {
             user_id: 'asuh',
             email: 'test'
         }
-        const variable = variableForUser({ config, user, variableKey: 'swagTest' })
+        const variable = variableForUser({ config, user, variableKey: 'swagTest', variableType: 'String' })
         expect(variable).toEqual({
             _id: '615356f120ed334a6054564c',
             key: 'swagTest',
@@ -54,7 +54,7 @@ describe('variableForUser tests', () => {
             user_id: 'asuh',
             email: 'test'
         }
-        const variable = variableForUser({ config, user, variableKey: 'unknownKey' })
+        const variable = variableForUser({ config, user, variableKey: 'unknownKey', variableType: 'String' })
         expect(variable).toBeNull()
     })
 })

--- a/lib/shared/bucketing-assembly-script/__tests__/variable.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/variable.test.ts
@@ -1,0 +1,60 @@
+import {
+    setPlatformData,
+    setConfigData,
+    variableForUser as variableForUser_AS,
+    initEventQueue
+} from './bucketingImportHelper'
+import testData from '@devcycle/bucketing-test-data/json-data/testData.json'
+import { SDKVariable } from '../assembly/types'
+const { config } = testData
+
+const variableForUser = (
+    { config, user, variableKey }:
+    { config: unknown, user: unknown, variableKey: string }
+): SDKVariable | null => {
+    setConfigData('sdkKey', JSON.stringify(config))
+    const variableJSON = variableForUser_AS('sdkKey', JSON.stringify(user), variableKey)
+    return variableJSON ? JSON.parse(variableJSON) as SDKVariable : null
+}
+
+const initSDK = () => {
+    const sdkKey = 'sdkKey'
+    initEventQueue(sdkKey as string, JSON.stringify({}))
+    setPlatformData(JSON.stringify({
+        platform: 'NodeJS',
+        platformVersion: '16.0',
+        sdkType: 'server',
+        sdkVersion: '1.0.0',
+        hostname: 'host.name'
+    }))
+    setConfigData(sdkKey, JSON.stringify(config))
+}
+
+describe('variableForUser tests', () => {
+    beforeAll(() => initSDK())
+
+    it('generates variable object for user', () => {
+        const user = {
+            country: 'canada',
+            user_id: 'asuh',
+            email: 'test'
+        }
+        const variable = variableForUser({ config, user, variableKey: 'swagTest' })
+        expect(variable).toEqual({
+            _id: '615356f120ed334a6054564c',
+            key: 'swagTest',
+            type: 'String',
+            value: 'YEEEEOWZA',
+        })
+    })
+
+    it('returns null if variable does not exist', () => {
+        const user = {
+            country: 'canada',
+            user_id: 'asuh',
+            email: 'test'
+        }
+        const variable = variableForUser({ config, user, variableKey: 'unknownKey' })
+        expect(variable).toBeNull()
+    })
+})

--- a/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
@@ -6,7 +6,6 @@ import {
     UserEventsBatchRecord,
     FeatureVariation
 } from '../types'
-import {jsonObjFromMap} from "../helpers/jsonHelpers";
 
 export type VariationAggMap = Map<string, i64>
 export type FeatureAggMap = Map<string, VariationAggMap>

--- a/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
@@ -6,6 +6,7 @@ import {
     UserEventsBatchRecord,
     FeatureVariation
 } from '../types'
+import {jsonObjFromMap} from "../helpers/jsonHelpers";
 
 export type VariationAggMap = Map<string, i64>
 export type FeatureAggMap = Map<string, VariationAggMap>
@@ -129,6 +130,9 @@ export class EventQueue {
             featureVarAggMap = new Map<string, VariationAggMap>()
             variableFeatureVarAggMap.set(target, featureVarAggMap)
         }
+
+        console.log(`queueAggregateEvent, type: ${type}, target: ${target ? target : 'null'}, aggByVariation: ${aggByVariation}`)
+        console.log(`variableVariationMap: ${jsonObjFromMap(variableVariationMap).stringify()}`)
 
         if (aggByVariation) {
             if (!variableVariationMap.has(target)) {

--- a/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
@@ -26,7 +26,7 @@ EventTypesSet.add('aggVariableDefaulted')
 
 export class EventQueue {
     private sdkKey: string
-    private options: EventQueueOptions
+    options: EventQueueOptions
 
     /**
      * Map<user_id, UserEventsBatchRecord>
@@ -71,7 +71,7 @@ export class EventQueue {
         return { userEventQueue, aggEventQueue }
     }
 
-    private checkIfEventLoggingDisabled(event: DVCEvent): bool {
+    checkIfEventLoggingDisabled(event: DVCEvent): bool {
         if (!EventTypesSet.has(event.type)) {
             return this.options.disableCustomEventLogging
         } else {

--- a/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/eventQueue/eventQueue.ts
@@ -131,9 +131,6 @@ export class EventQueue {
             variableFeatureVarAggMap.set(target, featureVarAggMap)
         }
 
-        console.log(`queueAggregateEvent, type: ${type}, target: ${target ? target : 'null'}, aggByVariation: ${aggByVariation}`)
-        console.log(`variableVariationMap: ${jsonObjFromMap(variableVariationMap).stringify()}`)
-
         if (aggByVariation) {
             if (!variableVariationMap.has(target)) {
                 throw new Error(`Missing variableVariationMap mapping for target: ${target} to aggregate by variation`)

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -42,6 +42,8 @@ export function variableForUser(
         return null
     }
 
+    queueVariableEvaluatedEvent(sdkKey, bucketedConfig, variable, variableKey)
+
     return variable ? variable.stringify() : null
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -35,11 +35,11 @@ export function variableForUser(
     const user = DVCPopulatedUser.fromJSONString(userStr)
 
     const bucketedConfig = _generateBucketedConfig(config, user, _getClientCustomData(sdkKey))
-    const variable = bucketedConfig.variables.has(variableKey)
+    let variable = bucketedConfig.variables.has(variableKey)
         ? bucketedConfig.variables.get(variableKey)
         : null
     if (variable && variable.type !== variableType) {
-        return null
+        variable = null
     }
 
     queueVariableEvaluatedEvent(sdkKey, bucketedConfig, variable, variableKey)

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -25,7 +25,12 @@ export function generateBucketedConfigForUser(sdkKey: string, userStr: string): 
     return bucketedConfig.stringify()
 }
 
-export function variableForUser(sdkKey: string, userStr: string, variableKey: string): string | null {
+export function variableForUser(
+    sdkKey: string,
+    userStr: string,
+    variableKey: string,
+    variableType: string
+): string | null {
     const config = _getConfigData(sdkKey)
     const user = DVCPopulatedUser.fromJSONString(userStr)
 
@@ -33,6 +38,9 @@ export function variableForUser(sdkKey: string, userStr: string, variableKey: st
     const variable = bucketedConfig.variables.has(variableKey)
         ? bucketedConfig.variables.get(variableKey)
         : null
+    if (variable && variable.type !== variableType) {
+        return null
+    }
 
     return variable ? variable.stringify() : null
 }

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -7,6 +7,7 @@ import { ConfigBody, DVCPopulatedUser, PlatformData } from './types'
 import { _clearPlatformData, _setPlatformData } from './managers/platformDataManager'
 import { _getConfigData, _setConfigData } from './managers/configDataManager'
 import { _getClientCustomData, _setClientCustomData } from './managers/clientCustomDataManager'
+import { queueVariableEvaluatedEvent } from './managers/eventQueueManager'
 
 export function generateBoundedHashesFromJSON(user_id: string, target_id: string): string {
     const boundedHash = _generateBoundedHashes(user_id, target_id)
@@ -22,6 +23,20 @@ export function generateBucketedConfigForUser(sdkKey: string, userStr: string): 
 
     const bucketedConfig = _generateBucketedConfig(config, user, _getClientCustomData(sdkKey))
     return bucketedConfig.stringify()
+}
+
+export function variableForUser(sdkKey: string, userStr: string, variableKey: string): string | null {
+    const config = _getConfigData(sdkKey)
+    const user = DVCPopulatedUser.fromJSONString(userStr)
+
+    const bucketedConfig = _generateBucketedConfig(config, user, _getClientCustomData(sdkKey))
+    const variable = bucketedConfig.variables.has(variableKey)
+        ? bucketedConfig.variables.get(variableKey)
+        : null
+
+    queueVariableEvaluatedEvent(sdkKey, bucketedConfig, variable, variableKey)
+
+    return variable ? variable.stringify() : null
 }
 
 export function setPlatformData(platformDataStr: string): void {

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -34,8 +34,6 @@ export function variableForUser(sdkKey: string, userStr: string, variableKey: st
         ? bucketedConfig.variables.get(variableKey)
         : null
 
-    queueVariableEvaluatedEvent(sdkKey, bucketedConfig, variable, variableKey)
-
     return variable ? variable.stringify() : null
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
@@ -4,7 +4,6 @@ import {
     DVCPopulatedUser,
     DVCEvent,
     FeatureVariation,
-    BucketedUserConfig,
     SDKVariable
 } from '../types'
 import { JSON } from 'assemblyscript-json/assembly'
@@ -128,22 +127,38 @@ export function queueAggregateEvent(sdkKey: string, eventStr: string, variableVa
     eventQueue.queueAggregateEvent(event, variableVariationMap, aggByVariation)
 }
 
+/**
+ * Use for testing to pass in JSON strings to be parsed and call queueVariableEvaluatedEvent() with.
+ */
 export function queueVariableEvaluatedEvent_JSON(
     sdkKey: string,
-    bucketedConfig: string,
+    varVariationMapString: string,
     variable: string | null,
     variableKey: string
 ): void {
+    const varVariationMapJSON = JSON.parse(varVariationMapString)
+    if (!varVariationMapJSON.isObj) throw new Error('varVariationMap is not a JSON Object')
+    const varVariationObj = varVariationMapJSON as JSON.Obj
+
+    const varVariationMap = new Map<string, FeatureVariation>()
+    for (let i = 0; i < varVariationObj.keys.length; i++) {
+        const key = varVariationObj.keys[i]
+        const value = varVariationObj.get(key)
+        if (!value || !value.isObj) throw new Error('FeatureVariation value is not a JSON Object')
+        varVariationMap.set(key, FeatureVariation.fromJSONObj(value as JSON.Obj))
+    }
+
     return queueVariableEvaluatedEvent(
         sdkKey,
-        BucketedUserConfig.fromJSONString(bucketedConfig),
+        varVariationMap,
         (variable !== null) ? SDKVariable.fromJSONString(variable) : null,
         variableKey
     )
 }
+
 export function queueVariableEvaluatedEvent(
     sdkKey: string,
-    bucketedConfig: BucketedUserConfig,
+    variableVariationMap: Map<string, FeatureVariation>,
     variable: SDKVariable | null,
     variableKey: string
 ): void {
@@ -163,7 +178,7 @@ export function queueVariableEvaluatedEvent(
     )
 
     const aggByVariation = (eventType === 'aggVariableEvaluated')
-    eventQueue.queueAggregateEvent(event, bucketedConfig.variableVariationMap, aggByVariation)
+    eventQueue.queueAggregateEvent(event, variableVariationMap, aggByVariation)
 }
 
 export function cleanupEventQueue(sdkKey: string): void {

--- a/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
@@ -3,7 +3,9 @@ import {
     EventQueueOptions,
     DVCPopulatedUser,
     DVCEvent,
-    FeatureVariation
+    FeatureVariation,
+    BucketedUserConfig,
+    SDKVariable
 } from '../types'
 import { JSON } from 'assemblyscript-json/assembly'
 import { _getConfigData } from './configDataManager'
@@ -122,6 +124,28 @@ export function queueAggregateEvent(sdkKey: string, eventStr: string, variableVa
 
     const aggByVariation = (event.type === 'aggVariableEvaluated')
     eventQueue.queueAggregateEvent(event, variableVariationMap, aggByVariation)
+}
+
+export function queueVariableEvaluatedEvent(
+    sdkKey: string,
+    bucketedConfig: BucketedUserConfig,
+    variable: SDKVariable | null,
+    variableKey: string
+): void {
+    const eventType = (variable !== null)
+        ? 'aggVariableEvaluated'
+        : 'aggVariableDefaulted'
+
+    const event = new DVCEvent(
+        eventType,
+        variableKey,
+        null,
+        NaN,
+        null
+    )
+
+    const eventQueue = getEventQueue(sdkKey)
+    eventQueue.queueAggregateEvent(event, bucketedConfig.variableVariationMap, true)
 }
 
 export function cleanupEventQueue(sdkKey: string): void {

--- a/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
@@ -114,6 +114,8 @@ export function queueEvent(sdkKey: string, userStr: string, eventStr: string): v
 
 export function queueAggregateEvent(sdkKey: string, eventStr: string, variableVariationMapStr: string): void {
     const eventQueue = getEventQueue(sdkKey)
+    if (eventQueue.options.disableAutomaticEventLogging) return
+
     const event = DVCEvent.fromJSONString(eventStr)
 
     const variableVariationMapJSON = JSON.parse(variableVariationMapStr)
@@ -132,6 +134,9 @@ export function queueVariableEvaluatedEvent(
     variable: SDKVariable | null,
     variableKey: string
 ): void {
+    const eventQueue = getEventQueue(sdkKey)
+    if (eventQueue.options.disableAutomaticEventLogging) return
+
     const eventType = (variable !== null)
         ? 'aggVariableEvaluated'
         : 'aggVariableDefaulted'
@@ -144,7 +149,6 @@ export function queueVariableEvaluatedEvent(
         null
     )
 
-    const eventQueue = getEventQueue(sdkKey)
     const aggByVariation = (eventType === 'aggVariableEvaluated')
     eventQueue.queueAggregateEvent(event, bucketedConfig.variableVariationMap, aggByVariation)
 }

--- a/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
@@ -128,6 +128,19 @@ export function queueAggregateEvent(sdkKey: string, eventStr: string, variableVa
     eventQueue.queueAggregateEvent(event, variableVariationMap, aggByVariation)
 }
 
+export function queueVariableEvaluatedEvent_JSON(
+    sdkKey: string,
+    bucketedConfig: string,
+    variable: string | null,
+    variableKey: string
+): void {
+    return queueVariableEvaluatedEvent(
+        sdkKey,
+        BucketedUserConfig.fromJSONString(bucketedConfig),
+        (variable !== null) ? SDKVariable.fromJSONString(variable) : null,
+        variableKey
+    )
+}
 export function queueVariableEvaluatedEvent(
     sdkKey: string,
     bucketedConfig: BucketedUserConfig,

--- a/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/eventQueueManager.ts
@@ -145,7 +145,8 @@ export function queueVariableEvaluatedEvent(
     )
 
     const eventQueue = getEventQueue(sdkKey)
-    eventQueue.queueAggregateEvent(event, bucketedConfig.variableVariationMap, true)
+    const aggByVariation = (eventType === 'aggVariableEvaluated')
+    eventQueue.queueAggregateEvent(event, bucketedConfig.variableVariationMap, aggByVariation)
 }
 
 export function cleanupEventQueue(sdkKey: string): void {

--- a/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
@@ -186,6 +186,15 @@ export class SDKVariable extends JSON.Obj {
         super()
     }
 
+    static fromJSONString(userConfigStr: string): SDKVariable {
+        const configJSON = JSON.parse(userConfigStr)
+        if (!configJSON.isObj) {
+            throw new Error('SDKVariable not a JSON Object')
+        }
+        const configJSONObj = configJSON as JSON.Obj
+        return SDKVariable.fromJSONObj(configJSONObj)
+    }
+
     static fromJSONObj(variableObj: JSON.Obj): SDKVariable {
         return new SDKVariable(
             getStringFromJSON(variableObj, '_id'),

--- a/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
@@ -12,8 +12,8 @@ import { PublicProject, PublicEnvironment } from './configBody'
 
 export class FeatureVariation extends JSON.Obj {
     constructor(
-        public _feature: string,
-        public _variation: string
+        public readonly _feature: string,
+        public readonly _variation: string
     ) {
         super()
     }
@@ -50,13 +50,13 @@ export class FeatureVariation extends JSON.Obj {
 
 export class BucketedUserConfig extends JSON.Obj {
     constructor(
-        public project: PublicProject,
-        public environment: PublicEnvironment,
-        public features: Map<string, SDKFeature>,
-        public featureVariationMap: Map<string, string>,
-        public variableVariationMap: Map<string, FeatureVariation>,
-        public variables: Map<string, SDKVariable>,
-        public knownVariableKeys: i64[]
+        public readonly project: PublicProject,
+        public readonly environment: PublicEnvironment,
+        public readonly features: Map<string, SDKFeature>,
+        public readonly featureVariationMap: Map<string, string>,
+        public readonly variableVariationMap: Map<string, FeatureVariation>,
+        public readonly variables: Map<string, SDKVariable>,
+        public readonly knownVariableKeys: i64[]
     ) {
         super()
     }
@@ -137,13 +137,13 @@ export class BucketedUserConfig extends JSON.Obj {
 
 export class SDKFeature extends JSON.Obj {
     constructor(
-        public _id: string,
-        public type: string,
-        public key: string,
-        public _variation: string,
-        public variationName: string,
-        public variationKey: string,
-        public evalReason: string | null
+        public readonly _id: string,
+        public readonly type: string,
+        public readonly key: string,
+        public readonly _variation: string,
+        public readonly variationName: string,
+        public readonly variationKey: string,
+        public readonly evalReason: string | null
     ) {
         super()
     }
@@ -177,11 +177,11 @@ export class SDKFeature extends JSON.Obj {
 
 export class SDKVariable extends JSON.Obj {
     constructor(
-        public _id: string,
-        public type: string,
-        public key: string,
-        public value: JSON.Value,
-        public evalReason: string | null,
+        public readonly _id: string,
+        public readonly type: string,
+        public readonly key: string,
+        public readonly value: JSON.Value,
+        public readonly evalReason: string | null,
     ) {
         super()
     }

--- a/lib/shared/bucketing-assembly-script/assembly/types/dvcEvent.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/dvcEvent.ts
@@ -26,27 +26,27 @@ export class DVCEvent extends JSON.Value {
         /**
          * type of the event
          */
-        public type: string,
+        public readonly type: string,
 
         /**
          * target / subject of event. Contextual to event type
          */
-        public target: string | null,
+        public readonly target: string | null,
 
         /**
          * date event occurred according to client stored as time since epoch
          */
-        public date: Date | null,
+        public readonly date: Date | null,
 
         /**
          * value for numerical events. Contextual to event type
          */
-        public value: f64,
+        public readonly value: f64,
 
         /**
          * extra metadata for event. Contextual to event type
          */
-        public metaData: JSON.Obj | null
+        public readonly metaData: JSON.Obj | null
     ) {
         super()
     }
@@ -84,35 +84,35 @@ export class DVCRequestEvent extends JSON.Value {
     /**
      * type of the event
      */
-    type: string
+    readonly type: string
 
     /**
      * target / subject of event. Contextual to event type
      */
-    target: string | null
+    readonly target: string | null
 
-    customType: string | null
+    readonly customType: string | null
 
-    user_id: string
+    readonly user_id: string
 
     /**
      * date event occurred according to client stored as time since epoch
      */
-    date: Date
+    readonly date: Date
 
-    clientDate: Date
+    readonly clientDate: Date
 
     /**
      * value for numerical events. Contextual to event type
      */
-    value: f64
+    readonly value: f64
 
-    featureVars: Map<string, string>
+    readonly featureVars: Map<string, string>
 
     /**
      * extra metadata for event. Contextual to event type
      */
-    metaData: JSON.Obj | null
+    readonly metaData: JSON.Obj | null
 
     constructor(event: DVCEvent, user_id: string, featureVars: Map<string, string>) {
         super()
@@ -167,7 +167,7 @@ export class UserEventsBatchRecord extends JSON.Value {
 }
 
 export class FlushPayload extends JSON.Value {
-    public payloadId: string
+    public readonly payloadId: string
     public status: string
 
     constructor(

--- a/lib/shared/bucketing-assembly-script/assembly/types/dvcUser.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/dvcUser.ts
@@ -19,16 +19,16 @@ interface DVCUserInterface {
 
 export class DVCUser extends JSON.Obj implements DVCUserInterface {
     constructor(
-        public user_id: string,
-        public email: string | null,
-        public name: string | null,
-        public language: string | null,
-        public country: string | null,
-        public appBuild: f64,
-        public appVersion: string | null,
-        public deviceModel: string | null,
-        public customData: JSON.Obj | null,
-        public privateCustomData: JSON.Obj | null
+        public readonly user_id: string,
+        public readonly email: string | null,
+        public readonly name: string | null,
+        public readonly language: string | null,
+        public readonly country: string | null,
+        public readonly appBuild: f64,
+        public readonly appVersion: string | null,
+        public readonly deviceModel: string | null,
+        public readonly customData: JSON.Obj | null,
+        public readonly privateCustomData: JSON.Obj | null
     ) {
         super()
     }
@@ -79,25 +79,25 @@ export class DVCUser extends JSON.Obj implements DVCUserInterface {
 }
 
 export class DVCPopulatedUser extends JSON.Value implements DVCUserInterface {
-    user_id: string
-    email: string | null
-    name: string | null
-    language: string | null
-    country: string | null
-    appVersion: string | null
-    appBuild: f64
+    readonly user_id: string
+    readonly email: string | null
+    readonly name: string | null
+    readonly language: string | null
+    readonly country: string | null
+    readonly appVersion: string | null
+    readonly appBuild: f64
     customData: JSON.Obj | null
     privateCustomData: JSON.Obj | null
-    private combinedCustomData: JSON.Obj
-    deviceModel: string | null
+    private _combinedCustomData: JSON.Obj
+    readonly deviceModel: string | null
 
-    createdDate: Date
-    lastSeenDate: Date
-    platform: string
-    platformVersion: string
-    sdkType: string
-    sdkVersion: string
-    hostname: string | null
+    readonly createdDate: Date
+    readonly lastSeenDate: Date
+    readonly platform: string
+    readonly platformVersion: string
+    readonly sdkType: string
+    readonly sdkVersion: string
+    readonly hostname: string | null
 
     constructor(user: DVCUser) {
         super()
@@ -129,7 +129,7 @@ export class DVCPopulatedUser extends JSON.Value implements DVCUserInterface {
                 combinedCustomData.set(key, privateCustomData.get(key))
             }
         }
-        this.combinedCustomData = combinedCustomData
+        this._combinedCustomData = combinedCustomData
 
         this.createdDate = new Date(Date.now())
         this.lastSeenDate = new Date(Date.now())
@@ -148,7 +148,7 @@ export class DVCPopulatedUser extends JSON.Value implements DVCUserInterface {
     }
 
     getCombinedCustomData(): JSON.Obj {
-        return this.combinedCustomData
+        return this._combinedCustomData
     }
 
     mergeClientCustomData(clientCustomData: JSON.Obj): void {

--- a/lib/shared/bucketing-assembly-script/assembly/types/featureConfiguration.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/featureConfiguration.ts
@@ -10,11 +10,11 @@ import {
 import { Target } from './target'
 
 export class FeatureConfiguration extends JSON.Value {
-    _id: string
-    prerequisites: FeaturePrerequisites[] | null
-    winningVariation: FeatureWinningVariation | null
-    forcedUsers: Map<string, string> | null
-    targets: Target[]
+    readonly _id: string
+    readonly prerequisites: FeaturePrerequisites[] | null
+    readonly winningVariation: FeatureWinningVariation | null
+    readonly forcedUsers: Map<string, string> | null
+    readonly targets: Target[]
 
     constructor(featureConfig: JSON.Obj) {
         super()
@@ -55,8 +55,8 @@ export class FeatureConfiguration extends JSON.Value {
 const comparatorValues = ['=', '!=']
 
 export class FeaturePrerequisites extends JSON.Value {
-    _feature: string
-    comparator: string
+    readonly _feature: string
+    readonly comparator: string
 
     constructor(featurePrerequisites: JSON.Obj) {
         super()
@@ -75,8 +75,8 @@ export class FeaturePrerequisites extends JSON.Value {
 }
 
 export class FeatureWinningVariation extends JSON.Value {
-    _variation: string
-    updatedAt: Date
+    readonly _variation: string
+    readonly updatedAt: Date
 
     constructor(winningVar: JSON.Obj) {
         super()

--- a/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
@@ -5,11 +5,11 @@ import {
 } from '../helpers/jsonHelpers'
 
 export class PlatformData extends JSON.Obj {
-    platform: string
-    platformVersion: string
-    sdkType: string
-    sdkVersion: string
-    hostname: string | null
+    readonly platform: string
+    readonly platformVersion: string
+    readonly sdkType: string
+    readonly sdkVersion: string
+    readonly hostname: string | null
 
     constructor(str: string) {
         super()

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -1,20 +1,22 @@
 import { JSON } from 'assemblyscript-json/assembly'
 import {
-    getArrayFromJSONOptional,
     getDateFromJSON,
-    getF64FromJSONObj, getF64FromJSONOptional,
+    getF64FromJSONObj,
+    getF64FromJSONOptional,
     getJSONArrayFromJSON,
     getJSONObjFromJSON,
-    getStringFromJSON, getStringFromJSONOptional,
+    getStringFromJSON,
+    getStringFromJSONOptional,
     isValidString,
-    isValidStringOptional, jsonArrFromValueArray
+    isValidStringOptional,
+    jsonArrFromValueArray
 } from '../helpers/jsonHelpers'
 
 export class Target extends JSON.Value {
-    _id: string
-    _audience: Audience
-    rollout: Rollout | null
-    distribution: TargetDistribution[]
+    readonly _id: string
+    readonly _audience: Audience
+    readonly rollout: Rollout | null
+    readonly distribution: TargetDistribution[]
 
     constructor(target: JSON.Obj) {
         super()
@@ -48,7 +50,6 @@ export class AudienceFilter extends JSON.Value {
     constructor(filter: JSON.Obj) {
         super()
         this.type = isValidString(filter, 'type', validTypes, false)
-
     }
 
     stringify(): string {
@@ -64,8 +65,8 @@ export class AudienceFilter extends JSON.Value {
 // or a base level filter. This is used to support the recursive nature of nested filters.
 // The config is returned to its original form when stringified.
 export class AudienceFilterOrOperator extends JSON.Value {
-    operatorClass: AudienceOperator | null
-    filterClass: AudienceFilter | null
+    readonly operatorClass: AudienceOperator | null
+    readonly filterClass: AudienceFilter | null
 
     constructor(filter: JSON.Obj) {
         super()
@@ -86,8 +87,8 @@ export class AudienceFilterOrOperator extends JSON.Value {
 }
 
 export class AudienceOperator extends JSON.Value {
-    operator: string
-    filters: AudienceFilterOrOperator[]
+    readonly operator: string
+    readonly filters: AudienceFilterOrOperator[]
 
     constructor(filter: JSON.Obj) {
         super()
@@ -116,7 +117,7 @@ export class AudienceOperator extends JSON.Value {
 }
 
 export class NoIdAudience extends JSON.Value {
-    filters: AudienceOperator
+    readonly filters: AudienceOperator
 
     constructor(audience: JSON.Obj) {
         super()
@@ -132,7 +133,7 @@ export class NoIdAudience extends JSON.Value {
 }
 
 export class Audience extends NoIdAudience {
-    _id: string
+    readonly _id: string
 
     constructor(audience: JSON.Obj) {
         super(audience)
@@ -166,8 +167,8 @@ const validDataKeyTypes = [
 ]
 
 export class AudienceMatchFilter extends AudienceFilter {
-    _audiences: JSON.Arr
-    comparator: string
+    readonly _audiences: JSON.Arr
+    readonly comparator: string
     readonly isValid: bool
 
     constructor(filter: JSON.Obj) {
@@ -194,9 +195,9 @@ export class AudienceMatchFilter extends AudienceFilter {
 }
 
 export class UserFilter extends AudienceFilter {
-    subType: string
-    values: JSON.Arr
-    comparator: string
+    readonly subType: string
+    readonly values: JSON.Arr
+    readonly comparator: string
     readonly isValid: bool
 
     constructor(filter: JSON.Obj) {
@@ -225,8 +226,8 @@ export class UserFilter extends AudienceFilter {
 }
 
 export class CustomDataFilter extends UserFilter {
-    dataKeyType: string
-    dataKey: string
+    readonly dataKeyType: string
+    readonly dataKey: string
 
     constructor(filter: JSON.Obj) {
         super(filter)
@@ -273,10 +274,10 @@ function initializeFilterClass(filter: JSON.Obj): AudienceFilter {
 const validRolloutTypes = ['schedule', 'gradual', 'stepped']
 
 export class Rollout extends JSON.Value {
-    type: string
-    startPercentage: f64
-    startDate: Date
-    stages: RolloutStage[] | null
+    readonly type: string
+    readonly startPercentage: f64
+    readonly startDate: Date
+    readonly stages: RolloutStage[] | null
 
     constructor(rollout: JSON.Obj) {
         super()
@@ -308,9 +309,9 @@ export class Rollout extends JSON.Value {
 const validRolloutStages = ['linear', 'discrete']
 
 export class RolloutStage extends JSON.Value {
-    type: string
-    date: Date
-    percentage: f64
+    readonly type: string
+    readonly date: Date
+    readonly percentage: f64
 
     constructor(stage: JSON.Obj) {
         super()
@@ -329,8 +330,8 @@ export class RolloutStage extends JSON.Value {
 }
 
 export class TargetDistribution extends JSON.Value {
-    _variation: string
-    percentage: f64
+    readonly _variation: string
+    readonly percentage: f64
 
     constructor(distribution: JSON.Obj) {
         super()

--- a/lib/shared/bucketing-assembly-script/index.js
+++ b/lib/shared/bucketing-assembly-script/index.js
@@ -1,7 +1,8 @@
-const { instantiate } = require('./build/bucketing-lib.release')
 
 exports.instantiate = async (debug = false) => {
-    const url = new URL(`file://${__dirname}/build/bucketing-lib.${debug ? 'debug' : 'release'}.wasm`)
+    const releaseStr = debug ? 'debug' : 'release'
+    const { instantiate } = require(`./build/bucketing-lib.${releaseStr}`)
+    const url = new URL(`file://${__dirname}/build/bucketing-lib.${releaseStr}.wasm`)
 
     // asynchronously compile the webassembly source
     const compiled = await (async () => {

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -221,7 +221,7 @@ export const variations: PublicVariation[] = [
         ]
     },
     {
-        _id: '615382338424cb11646d7668',
+        _id: '615382338424cb11646d7669',
         name: 'feature 2 never used variation',
         key: 'variation-never-used-key',
         variables: [
@@ -414,7 +414,7 @@ export const barrenConfig: ConfigBody = {
                     _audience: audiences[0],
                     distribution: []
                 },{
-                    _id: '61536f3bc838a705c105eb62',
+                    _id: '61536f3bc838a705c105eb63',
                     _audience: audiences[2],
                     distribution: [{
                         _variation: variations[2]._id,

--- a/lib/shared/bucketing/__test__/bucketing.test.ts
+++ b/lib/shared/bucketing/__test__/bucketing.test.ts
@@ -251,7 +251,7 @@ describe('Config Parsing and Generating', () => {
                 'feature1': {
                     '_id': '614ef6aa473928459060721a',
                     'key': 'feature1',
-                    "settings": undefined,
+                    'settings': undefined,
                     'type': FeatureType.release,
                     '_variation': '615357cf7e9ebdca58446ed0',
                     'variationName': 'variation 2',

--- a/sdk/nodejs/__tests__/eventQueue.test.ts
+++ b/sdk/nodejs/__tests__/eventQueue.test.ts
@@ -293,6 +293,45 @@ describe('EventQueue Unit Tests', () => {
         }
     )
 
+    it('should save aggVariableDefaulted event', async () => {
+        publishEvents_mock.mockResolvedValue(mockFetchResponse({ status: 201 }))
+
+        const eventQueue = initEventQueue('sdkKey')
+        const user1 = new DVCPopulatedUser({ user_id: 'user1' })
+        eventQueue.queueAggregateEvent(
+            user1,
+            { type: EventTypes.aggVariableDefaulted, target: 'unknown_key' },
+            bucketedUserConfig
+        )
+        await eventQueue.flushEvents()
+        eventQueue.cleanup()
+
+        expect(publishEvents_mock).toBeCalledWith(defaultLogger, 'sdkKey', [
+            {
+                'events':  [
+                    {
+                        'clientDate': expect.any(String),
+                        'date': expect.any(String),
+                        'featureVars':  {},
+                        'target': 'unknown_key',
+                        'type': 'aggVariableDefaulted',
+                        'user_id': 'host.name',
+                        'value': 1,
+                    },
+                ],
+                'user': {
+                    'createdDate': expect.any(String),
+                    'lastSeenDate': expect.any(String),
+                    'platform': 'NodeJS',
+                    'platformVersion': '16.10.0',
+                    'sdkType': 'server',
+                    'sdkVersion': '1.0.0',
+                    'user_id': 'host.name',
+                },
+            },
+        ], undefined)
+    })
+
     it('should save multiple events from multiple users with aggregated values', async () => {
         publishEvents_mock.mockResolvedValue(mockFetchResponse({ status: 201 }))
 

--- a/sdk/nodejs/__tests__/eventQueue.test.ts
+++ b/sdk/nodejs/__tests__/eventQueue.test.ts
@@ -327,6 +327,7 @@ describe('EventQueue Unit Tests', () => {
                     'sdkType': 'server',
                     'sdkVersion': '1.0.0',
                     'user_id': 'host.name',
+                    'hostname': 'host.name'
                 },
             },
         ], undefined)

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -6,7 +6,7 @@ import {
     DVCEvent
 } from './types'
 import { EnvironmentConfigManager } from './environmentConfigManager'
-import { bucketUserForConfig, variableForUser } from './utils/userBucketingHelper'
+import { bucketUserForConfig } from './utils/userBucketingHelper'
 import { DVCVariable, VariableParam } from './models/variable'
 import { checkParamDefined } from './utils/paramUtils'
 import { EventQueue, EventTypes } from './eventQueue'
@@ -132,25 +132,38 @@ export class DVCClient {
             })
         }
 
-        const configVariable = variableForUser(this.sdkKey, populatedUser, key)
+        const bucketedConfig = bucketUserForConfig(populatedUser, this.sdkKey)
 
         const options: VariableParam<T> = {
             key,
             type,
             defaultValue
         }
+        const configVariable = bucketedConfig?.variables?.[key]
+        let eventType = EventTypes.aggVariableEvaluated
         if (configVariable) {
             if (type === configVariable.type) {
                 options.value = configVariable.value as VariableTypeAlias<T>
                 options.evalReason = configVariable.evalReason
             } else {
+                eventType = EventTypes.aggVariableDefaulted
                 this.logger.error(
                     `Type mismatch for variable ${key}. Expected ${type}, got ${configVariable.type}`
                 )
             }
+        } else {
+            eventType = EventTypes.aggVariableDefaulted
         }
 
-        return new DVCVariable(options)
+        const variable = new DVCVariable(options)
+
+        const variableEvent = {
+            type: eventType,
+            target: variable.key
+        }
+        this.eventQueue.queueAggregateEvent(populatedUser, variableEvent, bucketedConfig)
+
+        return variable
     }
 
     allVariables(user: DVCUser): DVCVariableSet {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -6,7 +6,7 @@ import {
     DVCEvent
 } from './types'
 import { EnvironmentConfigManager } from './environmentConfigManager'
-import { bucketUserForConfig } from './utils/userBucketingHelper'
+import { bucketUserForConfig, variableForUser } from './utils/userBucketingHelper'
 import { DVCVariable, VariableParam } from './models/variable'
 import { checkParamDefined } from './utils/paramUtils'
 import { EventQueue, EventTypes } from './eventQueue'
@@ -132,38 +132,25 @@ export class DVCClient {
             })
         }
 
-        const bucketedConfig = bucketUserForConfig(populatedUser, this.sdkKey)
+        const configVariable = variableForUser(this.sdkKey, populatedUser, key)
 
         const options: VariableParam<T> = {
             key,
             type,
             defaultValue
         }
-        const configVariable = bucketedConfig?.variables?.[key]
-        let eventType = EventTypes.aggVariableEvaluated
         if (configVariable) {
             if (type === configVariable.type) {
                 options.value = configVariable.value as VariableTypeAlias<T>
                 options.evalReason = configVariable.evalReason
             } else {
-                eventType = EventTypes.aggVariableDefaulted
                 this.logger.error(
                     `Type mismatch for variable ${key}. Expected ${type}, got ${configVariable.type}`
                 )
             }
-        } else {
-            eventType = EventTypes.aggVariableDefaulted
         }
 
-        const variable = new DVCVariable(options)
-
-        const variableEvent = {
-            type: eventType,
-            target: variable.key
-        }
-        this.eventQueue.queueAggregateEvent(populatedUser, variableEvent, bucketedConfig)
-
-        return variable
+        return new DVCVariable(options)
     }
 
     allVariables(user: DVCUser): DVCVariableSet {

--- a/sdk/nodejs/src/utils/userBucketingHelper.ts
+++ b/sdk/nodejs/src/utils/userBucketingHelper.ts
@@ -1,4 +1,4 @@
-import { BucketedUserConfig, SDKVariable } from '@devcycle/types'
+import { BucketedUserConfig } from '@devcycle/types'
 import { DVCPopulatedUser } from '../models/populatedUser'
 import { getBucketingLib } from '../bucketing'
 
@@ -6,9 +6,4 @@ export function bucketUserForConfig(user: DVCPopulatedUser, token: string): Buck
     return JSON.parse(
         getBucketingLib().generateBucketedConfigForUser(token, JSON.stringify(user))
     ) as BucketedUserConfig
-}
-
-export function variableForUser(token: string, user: DVCPopulatedUser, variableKey: string): SDKVariable | null {
-    const variableJSON = getBucketingLib().variableForUser(token, JSON.stringify(user), variableKey)
-    return variableJSON ? JSON.parse(variableJSON) as SDKVariable : null
 }

--- a/sdk/nodejs/src/utils/userBucketingHelper.ts
+++ b/sdk/nodejs/src/utils/userBucketingHelper.ts
@@ -1,4 +1,4 @@
-import {BucketedUserConfig, SDKVariable} from '@devcycle/types'
+import { BucketedUserConfig, SDKVariable } from '@devcycle/types'
 import { DVCPopulatedUser } from '../models/populatedUser'
 import { getBucketingLib } from '../bucketing'
 

--- a/sdk/nodejs/src/utils/userBucketingHelper.ts
+++ b/sdk/nodejs/src/utils/userBucketingHelper.ts
@@ -1,4 +1,4 @@
-import { BucketedUserConfig } from '@devcycle/types'
+import {BucketedUserConfig, SDKVariable} from '@devcycle/types'
 import { DVCPopulatedUser } from '../models/populatedUser'
 import { getBucketingLib } from '../bucketing'
 
@@ -6,4 +6,9 @@ export function bucketUserForConfig(user: DVCPopulatedUser, token: string): Buck
     return JSON.parse(
         getBucketingLib().generateBucketedConfigForUser(token, JSON.stringify(user))
     ) as BucketedUserConfig
+}
+
+export function variableForUser(token: string, user: DVCPopulatedUser, variableKey: string): SDKVariable | null {
+    const variableJSON = getBucketingLib().variableForUser(token, JSON.stringify(user), variableKey)
+    return variableJSON ? JSON.parse(variableJSON) as SDKVariable : null
 }


### PR DESCRIPTION
Add `variableForUser()` method in the WASM code that will return a specific variable result for a user, rather than fetching the full `generateBucketedConfigForUser()` every time. Also generate `aggVariableEvaluated` and `aggVariableDefaulted` from within the WASM code.