### PR TITLE
DVC-6484 add hasConfigData() WASM method

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
@@ -1,5 +1,9 @@
 import testData from '../../../bucketing-test-data/json-data/testData.json'
-import { testConfigBodyClass } from '../bucketingImportHelper'
+import {
+    testConfigBodyClass,
+    setConfigData,
+    hasConfigDataForEtag
+} from '../bucketingImportHelper'
 import cloneDeep from 'lodash/cloneDeep'
 
 describe('Config Body', () => {
@@ -114,5 +118,16 @@ describe('Config Body', () => {
         for (let i = 0; i < 1000; i++) {
             testConfigBodyClass(JSON.stringify(testData.config))
         }
+    })
+})
+
+describe('hasConfigDataForEtag', () => {
+    it('should return true if config has data', () => {
+        const sdkKey = 'sdkKey'
+        const etag = 'etag'
+        setConfigData(sdkKey, JSON.stringify(testData.config), etag)
+        expect(hasConfigDataForEtag(sdkKey, etag)).toBe(true)
+        expect(hasConfigDataForEtag(sdkKey, 'not-etag')).toBe(false)
+        expect(hasConfigDataForEtag('not-sdk-key', etag)).toBe(false)
     })
 })

--- a/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
@@ -2,6 +2,7 @@ import testData from '../../../bucketing-test-data/json-data/testData.json'
 import {
     testConfigBodyClass,
     setConfigData,
+    setConfigDataWithEtag,
     hasConfigDataForEtag
 } from '../bucketingImportHelper'
 import cloneDeep from 'lodash/cloneDeep'
@@ -125,7 +126,7 @@ describe('hasConfigDataForEtag', () => {
     it('should return true if config has data', () => {
         const sdkKey = 'sdkKey'
         const etag = 'etag'
-        setConfigData(sdkKey, JSON.stringify(testData.config), etag)
+        setConfigDataWithEtag(sdkKey, JSON.stringify(testData.config), etag)
         expect(hasConfigDataForEtag(sdkKey, etag)).toBe(true)
         expect(hasConfigDataForEtag(sdkKey, 'not-etag')).toBe(false)
         expect(hasConfigDataForEtag('not-sdk-key', etag)).toBe(false)

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -1,9 +1,10 @@
-import {
-    _generateBoundedHashes, _generateBucketedConfig, _generateBucketedVariableForUser,
-} from './bucketing'
-
 import { JSON } from 'assemblyscript-json/assembly'
 import { ConfigBody, DVCPopulatedUser, FeatureVariation, PlatformData } from './types'
+import {
+    _generateBoundedHashes,
+    _generateBucketedConfig,
+    _generateBucketedVariableForUser
+} from './bucketing'
 import { _clearPlatformData, _setPlatformData } from './managers/platformDataManager'
 import { _getConfigData, _setConfigData } from './managers/configDataManager'
 import { _getClientCustomData, _setClientCustomData } from './managers/clientCustomDataManager'
@@ -62,9 +63,14 @@ export function clearPlatformData(empty: string | null = null): void {
     _clearPlatformData()
 }
 
-export function setConfigData(sdkKey: string, configDataStr: string): void {
-    const configData = new ConfigBody(configDataStr)
+export function setConfigData(sdkKey: string, configDataStr: string, etag: string): void {
+    const configData = new ConfigBody(configDataStr, etag)
     _setConfigData(sdkKey, configData)
+}
+
+export function hasConfigDataForEtag(sdkKey: string, etag: string): bool {
+    const configData = _getConfigData(sdkKey)
+    return configData && configData.etag === etag
 }
 
 export function setClientCustomData(sdkKey: string, data: string): void {

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -63,14 +63,19 @@ export function clearPlatformData(empty: string | null = null): void {
     _clearPlatformData()
 }
 
-export function setConfigData(sdkKey: string, configDataStr: string, etag: string): void {
+export function setConfigData(sdkKey: string, configDataStr: string): void {
+    const configData = new ConfigBody(configDataStr)
+    _setConfigData(sdkKey, configData)
+}
+
+export function setConfigDataWithEtag(sdkKey: string, configDataStr: string, etag: string): void {
     const configData = new ConfigBody(configDataStr, etag)
     _setConfigData(sdkKey, configData)
 }
 
 export function hasConfigDataForEtag(sdkKey: string, etag: string): bool {
     const configData = _getConfigData(sdkKey)
-    return configData && configData.etag === etag
+    return configData && configData.etag !== null && configData.etag === etag
 }
 
 export function setClientCustomData(sdkKey: string, data: string): void {

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -6,7 +6,7 @@ import {
     _generateBucketedVariableForUser
 } from './bucketing'
 import { _clearPlatformData, _setPlatformData } from './managers/platformDataManager'
-import { _getConfigData, _setConfigData } from './managers/configDataManager'
+import { _getConfigData, _hasConfigData, _setConfigData } from './managers/configDataManager'
 import { _getClientCustomData, _setClientCustomData } from './managers/clientCustomDataManager'
 import { queueVariableEvaluatedEvent } from './managers/eventQueueManager'
 
@@ -74,6 +74,7 @@ export function setConfigDataWithEtag(sdkKey: string, configDataStr: string, eta
 }
 
 export function hasConfigDataForEtag(sdkKey: string, etag: string): bool {
+    if (!_hasConfigData(sdkKey)) return false
     const configData = _getConfigData(sdkKey)
     return configData && configData.etag !== null && configData.etag === etag
 }

--- a/lib/shared/bucketing-assembly-script/assembly/managers/configDataManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/configDataManager.ts
@@ -13,3 +13,7 @@ export function _getConfigData(sdkKey: string): ConfigBody {
         return _configData.get(sdkKey)
     }
 }
+
+export function _hasConfigData(sdkKey: string): bool {
+    return _configData.has(sdkKey)
+}

--- a/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
@@ -97,7 +97,7 @@ export function doesUserPassRolloutFromJSON(rolloutStr: string | null, boundedHa
     return _doesUserPassRollout(rollout, boundedHash)
 }
 
-export function testConfigBodyClass(configStr: string, etag: string = 'etag'): string {
+export function testConfigBodyClass(configStr: string, etag: string | null = null): string {
     const config = new ConfigBody(configStr, etag)
     return config.stringify()
 }

--- a/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
@@ -97,8 +97,8 @@ export function doesUserPassRolloutFromJSON(rolloutStr: string | null, boundedHa
     return _doesUserPassRollout(rollout, boundedHash)
 }
 
-export function testConfigBodyClass(configStr: string): string {
-    const config = new ConfigBody(configStr)
+export function testConfigBodyClass(configStr: string, etag: string = 'etag'): string {
+    const config = new ConfigBody(configStr, etag)
     return config.stringify()
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -85,15 +85,18 @@ export class ConfigBody {
     readonly features: Feature[]
     readonly variables: Variable[]
     readonly variableHashes: Map<string, i64>
+    readonly etag: string
 
     private readonly _variableKeyMap: Map<string, Variable>
     private readonly _variableIdMap: Map<string, Variable>
     private readonly _variableIdToFeatureMap: Map<string, Feature>
 
-    constructor(configStr: string) {
+    constructor(configStr: string, etag: string) {
         const configJSON = JSON.parse(configStr)
         if (!configJSON.isObj) throw new Error('generateBucketedConfig config param not a JSON Object')
         const configJSONObj = configJSON as JSON.Obj
+
+        this.etag = etag
 
         this.project = new PublicProject(getJSONObjFromJSON(configJSONObj, 'project'))
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -85,13 +85,13 @@ export class ConfigBody {
     readonly features: Feature[]
     readonly variables: Variable[]
     readonly variableHashes: Map<string, i64>
-    readonly etag: string
+    readonly etag: string | null
 
     private readonly _variableKeyMap: Map<string, Variable>
     private readonly _variableIdMap: Map<string, Variable>
     private readonly _variableIdToFeatureMap: Map<string, Feature>
 
-    constructor(configStr: string, etag: string) {
+    constructor(configStr: string, etag: string | null = null) {
         const configJSON = JSON.parse(configStr)
         if (!configJSON.isObj) throw new Error('generateBucketedConfig config param not a JSON Object')
         const configJSONObj = configJSON as JSON.Obj

--- a/sdk/nodejs/src/environmentConfigManager.ts
+++ b/sdk/nodejs/src/environmentConfigManager.ts
@@ -103,9 +103,10 @@ export class EnvironmentConfigManager {
             return
         } else if (res?.status === 200 && projectConfig) {
             try {
-                getBucketingLib().setConfigData(this.sdkKey, projectConfig)
+                const etag = res?.headers.get('etag') || ''
+                getBucketingLib().setConfigData(this.sdkKey, projectConfig, etag)
                 this.hasConfig = true
-                this.configEtag = res?.headers.get('etag') || ''
+                this.configEtag = etag
                 return
             } catch (e) {
                 logError(new Error('Invalid config JSON.'))

--- a/sdk/nodejs/src/environmentConfigManager.ts
+++ b/sdk/nodejs/src/environmentConfigManager.ts
@@ -104,7 +104,7 @@ export class EnvironmentConfigManager {
         } else if (res?.status === 200 && projectConfig) {
             try {
                 const etag = res?.headers.get('etag') || ''
-                getBucketingLib().setConfigData(this.sdkKey, projectConfig, etag)
+                getBucketingLib().setConfigData(this.sdkKey, projectConfig)
                 this.hasConfig = true
                 this.configEtag = etag
                 return


### PR DESCRIPTION
- `setConfigDataWithEtag()` and `hasConfigDataForEtag()` methods will be used to check if we already have a config set for a specific etag value. This will mainly be used in our CF workers to optimize how often we set the config.