### PR TITLE
DVC-6502 remove variableHashes from bucketed config output

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
@@ -153,12 +153,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                1879689550,
-                2621975932,
-                4138596111
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -251,9 +245,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                1879689550
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -412,12 +403,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                2547774734,
-                2621975932,
-                4138596111
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -478,11 +463,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                2621975932,
-                4138596111
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',

--- a/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
@@ -10,7 +10,10 @@ import cloneDeep from 'lodash/cloneDeep'
 describe('Config Body', () => {
     it('should parse valid JSON into ConfigBody class', () => {
         const result = JSON.parse(testConfigBodyClass(JSON.stringify(testData.config)))
-        expect(result).toEqual(JSON.parse(JSON.stringify(testData.config)))
+        expect(result).toEqual(JSON.parse(JSON.stringify({
+            ...testData.config,
+            variableHashes: undefined
+        })))
     })
 
     it('should throw if target.rollout is missing type', () => {

--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/bucketing.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/bucketing.ts
@@ -181,23 +181,6 @@ function doesUserQualifyForFeature(
     }
 }
 
-// TODO: can we safely remove this?
-export function generateKnownVariableKeys(
-    variableHashes: Map<string, i64>,
-    variableMap: Map<string, SDKVariable>
-): i64[] {
-    const knownVariableKeys: i64[] = []
-    const hashKeys = variableHashes.keys()
-    for (let i = 0; i < hashKeys.length; i++) {
-        const key = hashKeys[i]
-        const hash = variableHashes.get(key)
-        if (!variableMap.has(key)) {
-            knownVariableKeys.push(hash)
-        }
-    }
-    return knownVariableKeys
-}
-
 export function bucketUserForVariation(
     feature: Feature,
     targetAndHashes: TargetAndHashes,
@@ -278,8 +261,7 @@ export function _generateBucketedConfig(
         featureKeyMap,
         featureVariationMap,
         variableVariationMap,
-        variableMap,
-        generateKnownVariableKeys(config.variableHashes, variableMap)
+        variableMap
     )
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/bucketedUserConfig.ts
@@ -1,6 +1,5 @@
 import { JSON } from 'assemblyscript-json/assembly'
 import {
-    getJSONArrayFromJSON,
     getJSONObjFromJSON,
     getJSONValueFromJSON,
     getStringFromJSON,
@@ -56,7 +55,6 @@ export class BucketedUserConfig extends JSON.Obj {
         public readonly featureVariationMap: Map<string, string>,
         public readonly variableVariationMap: Map<string, FeatureVariation>,
         public readonly variables: Map<string, SDKVariable>,
-        public readonly knownVariableKeys: i64[]
     ) {
         super()
     }
@@ -100,17 +98,6 @@ export class BucketedUserConfig extends JSON.Obj {
             variablesMap.set(key, SDKVariable.fromJSONObj(variables.get(key) as JSON.Obj))
         }
 
-        const knownVariableKeys = getJSONArrayFromJSON(userConfigJSONObj, 'knownVariableKeys')
-        const knownVariableKeysArray = new Array<i64>()
-        for (let i = 0; i < knownVariableKeys.valueOf().length; i++) {
-            const num = knownVariableKeys.valueOf()[i]
-            if (num && num.isFloat) {
-                knownVariableKeysArray.push(i64((num as JSON.Float).valueOf()))
-            } else if (num && num.isInteger) {
-                knownVariableKeysArray.push((num as JSON.Integer).valueOf())
-            }
-        }
-
         return new BucketedUserConfig(
             project,
             environment,
@@ -118,7 +105,6 @@ export class BucketedUserConfig extends JSON.Obj {
             featureVarMap,
             variableVariationMap,
             variablesMap,
-            knownVariableKeysArray
         )
     }
 
@@ -130,7 +116,6 @@ export class BucketedUserConfig extends JSON.Obj {
         json.set('featureVariationMap', jsonObjFromMap(this.featureVariationMap))
         json.set('variableVariationMap', jsonObjFromMap(this.variableVariationMap))
         json.set('variables', jsonObjFromMap(this.variables))
-        json.set('knownVariableKeys', this.knownVariableKeys)
         return json.stringify()
     }
 }

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -84,7 +84,6 @@ export class ConfigBody {
     readonly environment: PublicEnvironment
     readonly features: Feature[]
     readonly variables: Variable[]
-    readonly variableHashes: Map<string, i64>
     readonly etag: string | null
 
     private readonly _variableKeyMap: Map<string, Variable>
@@ -146,17 +145,6 @@ export class ConfigBody {
         this.variables = variables
         this._variableKeyMap = _variableKeyMap
         this._variableIdMap = _variableIdMap
-
-        const variableHashes = getJSONObjFromJSON(configJSONObj, 'variableHashes')
-        const variableHashesMap = new Map<string, i64>()
-        const keys = variableHashes.keys
-        for (let i=0; i < keys.length; i++) {
-            const key = keys[i]
-            const value = variableHashes.getInteger(key)
-            if (!value) throw new Error(`Unable to get variableHashes value for key: ${key}`)
-            variableHashesMap.set(key, value.valueOf())
-        }
-        this.variableHashes = variableHashesMap
     }
 
     stringify(): string {
@@ -166,7 +154,6 @@ export class ConfigBody {
         json.set('audiences', jsonObjFromMap(this.audiences))
         json.set('features', jsonArrFromValueArray(this.features))
         json.set('variables', jsonArrFromValueArray(this.variables))
-        json.set('variableHashes', jsonObjFromMap(this.variableHashes))
         return json.stringify()
     }
 

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -435,7 +435,6 @@ export const config: ConfigBody = {
             },
             variations: [variations[5]]
         }],
-
     variables,
     variableHashes
 }

--- a/lib/shared/bucketing/__test__/bucketing.test.ts
+++ b/lib/shared/bucketing/__test__/bucketing.test.ts
@@ -88,12 +88,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                1879689550,
-                2621975932,
-                4138596111
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -165,9 +159,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                1879689550
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -272,12 +263,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                1879689550,
-                2621975932,
-                4138596111,
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -341,13 +326,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                2547774734,
-                1879689550,
-                2621975932,
-                4138596111,
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -383,12 +361,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                2547774734,
-                2621975932,
-                4138596111
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',
@@ -440,11 +412,6 @@ describe('Config Parsing and Generating', () => {
                 '_id': '6153553b8cf4e45e0464268d',
                 'key': 'test-environment'
             },
-            'knownVariableKeys': [
-                3126796075,
-                2621975932,
-                4138596111
-            ],
             'project': expect.objectContaining({
                 '_id': '61535533396f00bab586cb17',
                 'a0_organization': 'org_12345612345',

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -151,19 +151,6 @@ export const getSegmentedFeatureDataFromConfig = (
     }, initialValue)
 }
 
-export const generateKnownVariableKeys = (
-    { variableHashes, variableMap }:
-    { variableHashes: ConfigBody['variableHashes'], variableMap: BucketedUserConfig['variables']}
-): BucketedUserConfig['knownVariableKeys'] => {
-    const knownVariableKeys: number[] = []
-    for (const [key, hash] of Object.entries(variableHashes)) {
-        if (!variableMap?.[key]) {
-            knownVariableKeys.push(hash)
-        }
-    }
-    return knownVariableKeys
-}
-
 export const generateBucketedConfig = (
     { config, user }:
     { config: ConfigBody, user: DVCBucketingUser }
@@ -215,10 +202,6 @@ export const generateBucketedConfig = (
         featureVariationMap,
         // Return empty object for now, until we switch to WASM bucketing logic
         variableVariationMap: {},
-        knownVariableKeys: generateKnownVariableKeys({
-            variableHashes: config.variableHashes,
-            variableMap
-        }),
         variables: variableMap
     }
 }

--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -381,13 +381,6 @@ export interface BucketedUserConfig {
     }
 
     /**
-     * Hashes `murmurhash.v3(variable.key + environment.apiKey)` of all known variable keys
-     * not contained in the `variables` object. This is so the SDK doesn't make
-     * requests for new Variables for known variables.
-     */
-    knownVariableKeys: number[]
-
-    /**
      * Information about how to establish a streaming connection to receive config updates
      */
     sse?: {

--- a/lib/shared/types/src/types/config/configBody.ts
+++ b/lib/shared/types/src/types/config/configBody.ts
@@ -54,7 +54,7 @@ export class ConfigBody<IdType = string> {
      */
      variableHashes: {
         [key: string]: number
-    }
+     }
 
      /**
      * **Implement Later**

--- a/sdk/nodejs/__tests__/eventQueue.test.ts
+++ b/sdk/nodejs/__tests__/eventQueue.test.ts
@@ -25,7 +25,6 @@ describe('EventQueue Unit Tests', () => {
     const bucketedUserConfig: BucketedUserConfig = {
         environment: { _id: '', key: '' },
         features: {},
-        knownVariableKeys: [],
         project: {
             _id: '',
             key: '',


### PR DESCRIPTION
- we never ended up using `variableHashes` for what it was intended for, let's clean it up.