### PR TITLE
Call variableUpdate subscriber with defaulted variable instead of undefined

### DIFF
--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -149,8 +149,9 @@ describe('EventEmitter tests', () => {
             eventEmitter.subscribe('variableUpdated:*', allUpdatesHandler)
             eventEmitter.subscribe(`variableUpdated:my-variable-key`, variableKeyHandler)
             eventEmitter.emitVariableUpdates(oldVariableSet, newVariableSet, {})
-            expect(allUpdatesHandler).toBeCalledWith('my-variable-key', undefined)
-            expect(variableKeyHandler).toBeCalledWith('my-variable-key', undefined)
+            const emptyDefaultVar = new DVCVariable({key: 'my-variable-key', defaultValue:{} }) 
+            expect(allUpdatesHandler).toBeCalledWith('my-variable-key', emptyDefaultVar)
+            expect(variableKeyHandler).toBeCalledWith('my-variable-key', emptyDefaultVar)
         })
 
         it('should emit variable updated event if variable added', () => {

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -84,17 +84,21 @@ export class EventEmitter {
             const newVariableValue = newVariable && newVariableSet[key].value
 
             if (JSON.stringify(oldVariableValue) !== JSON.stringify(newVariableValue)) {
-                const variables = variableDefaultMap[key] && Object.values(variableDefaultMap[key])
-                if (variables) {
+                const defaultVariables = variableDefaultMap[key] && Object.values(variableDefaultMap[key])
+                if (defaultVariables) {
                     newVariables = true
-                    variables.forEach((variable) => {
+                    defaultVariables.forEach((variable) => {
                         variable.value = newVariableValue ?? variable.defaultValue
                         variable.isDefaulted = newVariableValue === undefined || newVariableValue === null
                         variable.callback?.call(variable, variable.value)
                     })
                 }
-                this.emit(`${EventNames.VARIABLE_UPDATED}:*`, key, newVariable)
-                this.emit(`${EventNames.VARIABLE_UPDATED}:${key}`, key, newVariable)
+                const finalVariable = newVariable || new DVCVariable({
+                    key: key,
+                    defaultValue: defaultVariables?.[0].value || {}
+                })
+                this.emit(`${EventNames.VARIABLE_UPDATED}:*`, key, finalVariable)
+                this.emit(`${EventNames.VARIABLE_UPDATED}:${key}`, key, finalVariable)
             }
         })
         if (newVariables) {


### PR DESCRIPTION
currently, if we get a config update that removes a variable from the config (ex. a feature was turned off, variable was deleted, targeting changed etc), then we would call the variable update subscriber with undefined as the variable parameter rather than a defaulted variable. the solution is to construct a default variable and pass that to the subscriber instead.

however, there are 3 cases when a variable changes in the config: 
- the variable is in the new config -> we call update subscriber with that variable
- the variable was removed from the config but we use it in the code, so we know what default value to use -> we should call update subscriber with the defaulted DVCVariable object
- the variable was removed from the config, but it's never used in the code, so we don't have a default value for it -> in this case we still want to call the subscriber with a defaulted DVCVariable, but defaultValue is non-optional on a DVCVariable. 
- In this case, i'm using an empty object to represent that the variable has no default - is this okay?