### PR TITLE
fix: use dummy string field to stop unmanaged class decorator

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/protobuf.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/protobuf.test.ts
@@ -131,7 +131,7 @@ describe('protobuf variable tests', () => {
                         name: { value: 'name', isNull: false },
                         language: { value: 'en', isNull: false },
                         country: { value: 'CA', isNull: false },
-                        appBuild: { value: 610.0, isNull: false },
+                        appBuild: { value: 610.0, isNull: false, dummy: '' },
                         appVersion: { value: '1.0.0', isNull: false },
                         deviceModel: { value: 'NodeJS', isNull: false },
                         customData: {
@@ -192,7 +192,7 @@ describe('protobuf variable tests', () => {
                     name: { value: 'name', isNull: false },
                     language: { value: 'en', isNull: false },
                     country: { value: 'CA', isNull: false },
-                    appBuild: { value: 610.0, isNull: false },
+                    appBuild: { value: 610.0, isNull: false, dummy: '' },
                     appVersion: { value: '1.0.0', isNull: false },
                     deviceModel: { value: 'NodeJS', isNull: false },
                     customData: {
@@ -235,7 +235,7 @@ describe('protobuf variable tests', () => {
                     name: { value: '', isNull: true },
                     language: { value: '', isNull: true },
                     country: { value: '', isNull: true },
-                    appBuild: { value: 0, isNull: true },
+                    appBuild: { value: 0, isNull: true, dummy: '' },
                     appVersion: { value: '', isNull: true },
                     deviceModel: { value: '', isNull: true },
                     customData: { value: {}, isNull: true },

--- a/lib/shared/bucketing-assembly-script/assembly/types/protobuf-generated/NullableDouble.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/protobuf-generated/NullableDouble.ts
@@ -5,7 +5,6 @@
 
 import { Writer, Reader, Protobuf } from "as-proto/assembly";
 
-@unmanaged
 export class NullableDouble {
   static encode(message: NullableDouble, writer: Writer): void {
     writer.uint32(9);
@@ -13,6 +12,9 @@ export class NullableDouble {
 
     writer.uint32(16);
     writer.bool(message.isNull);
+
+    writer.uint32(26);
+    writer.string(message.dummy);
   }
 
   static decode(reader: Reader, length: i32): NullableDouble {
@@ -30,6 +32,10 @@ export class NullableDouble {
           message.isNull = reader.bool();
           break;
 
+        case 3:
+          message.dummy = reader.string();
+          break;
+
         default:
           reader.skipType(tag & 7);
           break;
@@ -41,10 +47,12 @@ export class NullableDouble {
 
   value: f64;
   isNull: bool;
+  dummy: string;
 
-  constructor(value: f64 = 0.0, isNull: bool = false) {
+  constructor(value: f64 = 0.0, isNull: bool = false, dummy: string = "") {
     this.value = value;
     this.isNull = isNull;
+    this.dummy = dummy;
   }
 }
 

--- a/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
+++ b/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
@@ -15,6 +15,7 @@ message NullableString {
 message NullableDouble {
   double value = 1;
   bool isNull = 2;
+  string dummy = 3;
 }
 
 enum CustomDataType {


### PR DESCRIPTION
- add a string field to the NullableDouble proto object to prevent the output from including an `unmanaged` decorator
- this decorator is added by the as-proto library to "optimize performance" but actually causes a memory leak by creating unmanaged (and ungarbage-collected) objects each time a decode operation occurs