### PR TITLE
Added proto file header for Go generation

### DIFF
--- a/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
+++ b/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+option go_package = "./proto";
+
 enum VariableType_PB {
     Boolean = 0;
     Number = 1;


### PR DESCRIPTION
Added in the go_package option to support protobuf file generation in Golang. The option should be ignored by other protobuf generators. 

Ultimately the .proto file in this project should be the record of authority and used by all other SDKs when generated protobuf classes

