### PR TITLE
Dispatch real events in eventEmitter

### DIFF
--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -48,7 +48,7 @@ describe('EventEmitter tests', () => {
         it('should subscribe to event', () => {
             const handler = jest.fn()
             eventEmitter.subscribe('initialized', handler)
-            expect(eventEmitter.events['initialized'][0]).toEqual(handler)
+            expect(eventEmitter.events['initialized'][0].handler).toEqual(handler)
         })
 
         it('should subscribe with more than one event', () => {
@@ -56,8 +56,8 @@ describe('EventEmitter tests', () => {
             const handler2 = jest.fn()
             eventEmitter.subscribe('initialized', handler1)
             eventEmitter.subscribe('initialized', handler2)
-            expect(eventEmitter.events['initialized'][0]).toEqual(handler1)
-            expect(eventEmitter.events['initialized'][1]).toEqual(handler2)
+            expect(eventEmitter.events['initialized'][0].handler).toEqual(handler1)
+            expect(eventEmitter.events['initialized'][1].handler).toEqual(handler2)
         })
     })
 

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -32,6 +32,7 @@ type featureUpdatedHandler = (key: string, feature: DVCFeature | null) => void
 type newVariablesHandler = () => void
 type errorHandler = (error: unknown) => void
 type initializedHandler = (success: boolean) => void
+type configUpdatedHandler = (newVars: DVCVariableSet) => void
 
 export class DVCClient implements Client {
     private options: DVCOptions
@@ -269,6 +270,7 @@ export class DVCClient implements Client {
     subscribe(key: `featureUpdated:${string}` , handler: featureUpdatedHandler): void;
     subscribe(key: 'error' , handler: errorHandler): void;
     subscribe(key: 'initialized' , handler: initializedHandler): void;
+    subscribe(key: 'configUpdated' , handler: configUpdatedHandler): void;
     subscribe(key: string, handler: (...args: any[]) => void): void {
         this.eventEmitter.subscribe(key, handler)
     }


### PR DESCRIPTION
this means the handler is called in a different thread than our regular config fetching code, so we don't catch exceptions thrown in the callback. 

every time subscribe/ unsubscribe are called, i had to remove the whole event listener, update our event handler store, and then add the listener again - not sure if there's a better way to do this? but since i'm using a wrapper to call multiple handlers, there doesn't seem to be a better way to edit the list of handlers in place 