### PR TITLE
Add setConfigDataUTF8() method to Bucketing AS

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
@@ -35,7 +35,17 @@ describe.each([true, false])('Config Body', (utf8) => {
             .toThrow('Missing string value for key: "type"')
     })
 
-    it('should handle ')
+    it('should handle extended UTF8 characters, from UTF8: ' + utf8, () => {
+        const config = {
+            ...testData.config,
+            project: { ...testData.config.project, key: '👍 ö' }
+        }
+        expect(testConfigBody(JSON.stringify(config), utf8))
+            .toEqual(JSON.parse(JSON.stringify({
+                ...config,
+                variableHashes: undefined
+            })))
+    })
 
     it('should throw if feature.type is missing not a valid type', () => {
         const config = cloneDeep(testData.config)

--- a/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
@@ -35,6 +35,8 @@ describe.each([true, false])('Config Body', (utf8) => {
             .toThrow('Missing string value for key: "type"')
     })
 
+    it('should handle ')
+
     it('should throw if feature.type is missing not a valid type', () => {
         const config = cloneDeep(testData.config)
         const feature: any = config.features[0]

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -18,7 +18,6 @@ import { _clearPlatformData, _setPlatformData } from './managers/platformDataMan
 import { _getConfigData, _hasConfigData, _setConfigData } from './managers/configDataManager'
 import { _getClientCustomData, _setClientCustomData } from './managers/clientCustomDataManager'
 import { queueVariableEvaluatedEvent } from './managers/eventQueueManager'
-import Config from "react-native-config";
 
 export function generateBoundedHashesFromJSON(user_id: string, target_id: string): string {
     const boundedHash = _generateBoundedHashes(user_id, target_id)

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -155,6 +155,10 @@ export function clearPlatformData(empty: string | null = null): void {
     _clearPlatformData()
 }
 
+export function setConfigDataUTF8Preallocated(sdkKey: string, configDataStr: Uint8Array, length: i32): void {
+    setConfigDataUTF8(sdkKey, configDataStr.slice(0, length))
+}
+
 export function setConfigDataUTF8(sdkKey: string, configDataStr: Uint8Array): void {
     const configData = ConfigBody.fromUTF8(configDataStr)
     _setConfigData(sdkKey, configData)

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -18,6 +18,7 @@ import { _clearPlatformData, _setPlatformData } from './managers/platformDataMan
 import { _getConfigData, _hasConfigData, _setConfigData } from './managers/configDataManager'
 import { _getClientCustomData, _setClientCustomData } from './managers/clientCustomDataManager'
 import { queueVariableEvaluatedEvent } from './managers/eventQueueManager'
+import Config from "react-native-config";
 
 export function generateBoundedHashesFromJSON(user_id: string, target_id: string): string {
     const boundedHash = _generateBoundedHashes(user_id, target_id)
@@ -155,13 +156,18 @@ export function clearPlatformData(empty: string | null = null): void {
     _clearPlatformData()
 }
 
+export function setConfigDataUTF8(sdkKey: string, configDataStr: Uint8Array): void {
+    const configData = ConfigBody.fromUTF8(configDataStr)
+    _setConfigData(sdkKey, configData)
+}
+
 export function setConfigData(sdkKey: string, configDataStr: string): void {
-    const configData = new ConfigBody(configDataStr)
+    const configData = ConfigBody.fromString(configDataStr)
     _setConfigData(sdkKey, configData)
 }
 
 export function setConfigDataWithEtag(sdkKey: string, configDataStr: string, etag: string): void {
-    const configData = new ConfigBody(configDataStr, etag)
+    const configData = ConfigBody.fromString(configDataStr, etag)
     _setConfigData(sdkKey, configData)
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
@@ -121,7 +121,12 @@ export function doesUserPassRolloutFromJSON(rolloutStr: string | null, boundedHa
 }
 
 export function testConfigBodyClass(configStr: string, etag: string | null = null): string {
-    const config = new ConfigBody(configStr, etag)
+    const config = ConfigBody.fromString(configStr, etag)
+    return config.stringify()
+}
+
+export function testConfigBodyClassFromUTF8(configStr: Uint8Array, etag: string | null = null): string {
+    const config = ConfigBody.fromUTF8(configStr, etag)
     return config.stringify()
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -90,11 +90,21 @@ export class ConfigBody {
     private readonly _variableIdMap: Map<string, Variable>
     private readonly _variableIdToFeatureMap: Map<string, Feature>
 
-    constructor(configStr: string, etag: string | null = null) {
+    static fromUTF8(configUTF8: Uint8Array, etag: string | null = null): ConfigBody {
+        const configJSON = JSON.parse(configUTF8)
+        if (!configJSON.isObj) throw new Error('generateBucketedConfig config param not a JSON Object')
+        const configJSONObj = configJSON as JSON.Obj
+        return new ConfigBody(configJSONObj, etag)
+    }
+
+    static fromString(configStr: string, etag: string | null = null): ConfigBody {
         const configJSON = JSON.parse(configStr)
         if (!configJSON.isObj) throw new Error('generateBucketedConfig config param not a JSON Object')
         const configJSONObj = configJSON as JSON.Obj
+        return new ConfigBody(configJSONObj, etag)
+    }
 
+    constructor(configJSONObj: JSON.Obj, etag: string | null = null) {
         this.etag = etag
 
         this.project = new PublicProject(getJSONObjFromJSON(configJSONObj, 'project'))

--- a/sdk/nodejs/__tests__/environmentConfigManager.spec.ts
+++ b/sdk/nodejs/__tests__/environmentConfigManager.spec.ts
@@ -49,7 +49,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
         expect(setInterval_mock).toHaveBeenCalledTimes(1)
 
         await envConfig._fetchConfig()
-        expect(getBucketingLib().setConfigData).toHaveBeenCalledWith('sdkKey', '{}')
+        expect(getBucketingLib().setConfigDataUTF8).toHaveBeenCalledWith('sdkKey', Buffer.from('{}', 'utf8'))
 
         expect(envConfig).toEqual(expect.objectContaining({
             sdkKey: 'sdkKey',

--- a/sdk/nodejs/src/__mocks__/bucketing.ts
+++ b/sdk/nodejs/src/__mocks__/bucketing.ts
@@ -28,6 +28,7 @@ enum VariableType {
 export const importBucketingLib = async (): Promise<void> => {
     Bucketing = await new Promise((resolve) => resolve({
         setConfigData: jest.fn(),
+        setConfigDataUTF8: jest.fn(),
         setPlatformData: jest.fn(),
         generateBucketedConfigForUser: jest.fn().mockReturnValue(JSON.stringify({
             variables: { 'test-key': testVariable }

--- a/sdk/nodejs/src/environmentConfigManager.ts
+++ b/sdk/nodejs/src/environmentConfigManager.ts
@@ -104,7 +104,8 @@ export class EnvironmentConfigManager {
         } else if (res?.status === 200 && projectConfig) {
             try {
                 const etag = res?.headers.get('etag') || ''
-                getBucketingLib().setConfigData(this.sdkKey, projectConfig)
+                const configBuffer = Buffer.from(projectConfig, 'utf8')
+                getBucketingLib().setConfigDataUTF8(this.sdkKey, configBuffer)
                 this.hasConfig = true
                 this.configEtag = etag
                 return


### PR DESCRIPTION
- Add `setConfigDataUTF8()` and `setConfigDataUTF8Preallocated` methods to the bucketing AS lib for use with GO SDK to avoid casing of UTF8 JSON data -> UTF16 String in AS -> UTF8 String for JSON decoding in AS.