### PR TITLE
DVC-6731 - Adding UTF8 functions for platform data and client custom data

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/platformData.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/platformData.test.ts
@@ -1,10 +1,15 @@
-import { testPlatformDataClass } from '../bucketingImportHelper'
+import { testPlatformDataClass, testPlatformDataClassFromUTF8 } from '../bucketingImportHelper'
 
-const testPlatformData = (data: unknown): unknown => {
-    return JSON.parse(testPlatformDataClass(JSON.stringify(data)))
+const testPlatformData = (str: string, utf8: boolean): any => {
+    if (utf8) {
+        const buff = Buffer.from(str, 'utf8')
+        return JSON.parse(testPlatformDataClassFromUTF8(buff))
+    } else {
+        return JSON.parse(testPlatformDataClass(str))
+    }
 }
 
-describe('PlatformData Model Tests', () => {
+describe.each([true, false])('PlatformData Model Tests', (utf8) => {
     it('should test PlatformData JSON parsing', () => {
         const platformData = {
             platform: 'platform',
@@ -13,7 +18,7 @@ describe('PlatformData Model Tests', () => {
             sdkVersion: '3.3.3',
             hostname: 'host.name'
         }
-        expect(testPlatformData(platformData)).toEqual(platformData)
+        expect(testPlatformData(JSON.stringify(platformData), utf8)).toEqual(platformData)
     })
 
     it('should test PlatformData non-optional JSON parsing', () => {
@@ -23,6 +28,6 @@ describe('PlatformData Model Tests', () => {
             sdkType: 'server',
             sdkVersion: '3.3.3'
         }
-        expect(testPlatformData(platformData)).toEqual(platformData)
+        expect(testPlatformData(JSON.stringify(platformData), utf8)).toEqual(platformData)
     })
 })

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -186,9 +186,20 @@ export function variableForUserPreallocated(
  * @param platformDataJSONStr
  */
 export function setPlatformData(platformDataJSONStr: string): void {
-    const platformData = new PlatformData(platformDataJSONStr)
+    const platformData = PlatformData.fromString(platformDataJSONStr)
     _setPlatformData(platformData)
 }
+
+/**
+ * Same interfaces as `setPlatformData()` but with a UTF8 buffer instead of a string.
+ * This is to avoid issues encoding / decoding between UTF8 and UTF16.
+ * @param platformDataJSONStr
+ */
+export function setPlatformDataUTF8(platformDataJSONStr: Uint8Array): void {
+    const platformData = PlatformData.fromUTF8(platformDataJSONStr)
+    _setPlatformData(platformData)
+}
+
 
 /**
  * Clear the platform data for the given SDK key.
@@ -259,6 +270,22 @@ export function hasConfigDataForEtag(sdkKey: string, etag: string): bool {
  */
 export function setClientCustomData(sdkKey: string, clientCustomDataJSONStr: string): void {
     const parsed = JSON.parse(clientCustomDataJSONStr)
+    if (!parsed.isObj) {
+        throw new Error('invalid global clientCustomDataJSONStr')
+    }
+
+    _setClientCustomData(sdkKey, parsed as JSON.Obj)
+}
+
+/**
+ * Set the client custom data for the given SDK key and JSON String custom data.
+ * Same interfaces as `setClientCustomData()` but with a UTF8 buffer instead of a string.
+ * This is to avoid issues encoding / decoding between UTF8 and UTF16.
+ * @param sdkKey
+ * @param clientCustomDataUTF8
+ */
+export function setClientCustomDataUTF8(sdkKey: string, clientCustomDataUTF8: Uint8Array): void {
+    const parsed = JSON.parse(clientCustomDataUTF8)
     if (!parsed.isObj) {
         throw new Error('invalid global clientCustomDataJSONStr')
     }

--- a/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
@@ -31,6 +31,7 @@ export {
     testDVCEventClass,
     testDVCRequestEventClass,
     testPlatformDataClass,
+    testPlatformDataClassFromUTF8,
 } from './types'
 
 export function testVariableForUserParams_PB(buffer: Uint8Array): Uint8Array {

--- a/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
@@ -11,17 +11,28 @@ export class PlatformData extends JSON.Obj {
     readonly sdkVersion: string
     readonly hostname: string | null
 
-    constructor(str: string) {
-        super()
-        const json = JSON.parse(str)
-        if (!json.isObj) throw new Error('Platform data not a JSON Object')
-        const jsonObj = json as JSON.Obj
+    static fromUTF8(platformDataUTF8: Uint8Array): PlatformData {
+        const platformJSON = JSON.parse(platformDataUTF8)
+        if (!platformJSON.isObj) throw new Error('platformData param not a JSON Object')
+        const platformJSONObj = platformJSON as JSON.Obj
+        return new PlatformData(platformJSONObj)
+    }
 
-        this.platform = getStringFromJSON(jsonObj, 'platform')
-        this.platformVersion = getStringFromJSON(jsonObj, 'platformVersion')
-        this.sdkType = getStringFromJSON(jsonObj, 'sdkType')
-        this.sdkVersion = getStringFromJSON(jsonObj, 'sdkVersion')
-        this.hostname = getStringFromJSONOptional(jsonObj, 'hostname')
+    static fromString(platformDataStr: string): PlatformData {
+        const platformJSON = JSON.parse(platformDataStr)
+        if (!platformJSON.isObj) throw new Error('platformData config param not a JSON Object')
+        const platformJSONObj = platformJSON as JSON.Obj
+        return new PlatformData(platformJSONObj)
+    }
+
+    constructor(platformJSONObj: JSON.Obj) {
+        super()
+
+        this.platform = getStringFromJSON(platformJSONObj, 'platform')
+        this.platformVersion = getStringFromJSON(platformJSONObj, 'platformVersion')
+        this.sdkType = getStringFromJSON(platformJSONObj, 'sdkType')
+        this.sdkVersion = getStringFromJSON(platformJSONObj, 'sdkVersion')
+        this.hostname = getStringFromJSONOptional(platformJSONObj, 'hostname')
     }
 
     stringify(): string {
@@ -36,7 +47,7 @@ export class PlatformData extends JSON.Obj {
 }
 
 export function testPlatformDataClass(dataStr: string): string {
-    const platformData = new PlatformData(dataStr)
+    const platformData = PlatformData.fromString(dataStr)
     return platformData.stringify()
 }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/platformData.ts
@@ -51,3 +51,7 @@ export function testPlatformDataClass(dataStr: string): string {
     return platformData.stringify()
 }
 
+export function testPlatformDataClassFromUTF8(dataStr: Uint8Array): string {
+    const platformData = PlatformData.fromUTF8(dataStr)
+    return platformData.stringify()
+}


### PR DESCRIPTION
Extends the pattern we used with setConfigDataUTF8() to cover setting platform data and client custom data

The idea it to provide methods that will ensure all the json string data is encoded properly inside of the WASM