### PR TITLE
Adding UTF8 version of getBucketedConfigForUser

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/dvcUser.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/dvcUser.test.ts
@@ -1,13 +1,19 @@
-import { testDVCUserClass } from '../bucketingImportHelper'
+import { testDVCUserClass, testDVCUserClassFromUTF8 } from '../bucketingImportHelper'
 import { setPlatformDataJSON } from '../setPlatformData'
 
 setPlatformDataJSON()
 
-function testDVCUser(userObj: unknown): unknown {
-    return JSON.parse(testDVCUserClass(JSON.stringify(userObj)))
+function testDVCUser(obj: any, utf8: boolean): any {
+    const str = JSON.stringify(obj)
+    if (utf8) {
+        const buff = Buffer.from(str, 'utf8')
+        return JSON.parse(testDVCUserClassFromUTF8(buff))
+    } else {
+        return JSON.parse(testDVCUserClass(str))
+    }
 }
 
-describe('dvcUser Tests', () => {
+describe.each([true, false])('dvcUser Tests', (utf8) => {
     it('should test DVCUser class JSON parsing', () => {
         const userObj = {
             user_id: '24601',
@@ -28,7 +34,7 @@ describe('dvcUser Tests', () => {
             }
         }
 
-        expect(testDVCUser(userObj)).toEqual(expect.objectContaining({
+        expect(testDVCUser(userObj, utf8)).toEqual(expect.objectContaining({
             ...userObj,
             deviceModel: 'iPhone',
             platform: 'NodeJS',
@@ -49,7 +55,7 @@ describe('dvcUser Tests', () => {
             }
         }
 
-        expect(() => testDVCUser(userObj))
+        expect(() => testDVCUser(userObj, utf8))
             .toThrow('DVCUser customData can\'t contain nested objects or arrays')
     })
 
@@ -62,7 +68,7 @@ describe('dvcUser Tests', () => {
             }
         }
 
-        expect(() => testDVCUser(userObj))
+        expect(() => testDVCUser(userObj, utf8))
             .toThrow('DVCUser privateCustomData can\'t contain nested objects or arrays')
     })
 
@@ -71,7 +77,7 @@ describe('dvcUser Tests', () => {
             user_id: 'test@devcycle.com'
         }
 
-        expect(testDVCUser(userObj)).toEqual(expect.objectContaining({
+        expect(testDVCUser(userObj, utf8)).toEqual(expect.objectContaining({
             ...userObj,
             platform: 'NodeJS',
             platformVersion: '',
@@ -88,14 +94,14 @@ describe('dvcUser Tests', () => {
             appBuild: 'not a number'
         }
 
-        expect(() => testDVCUser(userObj))
+        expect(() => testDVCUser(userObj, utf8))
             .toThrow('Invalid number value: not a number, for key: "appBuild"')
     })
 
     it('should throw is string key is not a string', () => {
         const userObj = { user_id: true }
 
-        expect(() => testDVCUser(userObj))
+        expect(() => testDVCUser(userObj, utf8))
             .toThrow('Missing string value for key: "user_id",')
     })
 })

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -41,6 +41,13 @@ export function generateBucketedConfigForUser(sdkKey: string, userJSONStr: strin
     return bucketedConfig.stringify()
 }
 
+export function generateBucketedConfigForUserUTF8(sdkKey: string, userJSONStr: Uint8Array): Uint8Array  {
+    const config = _getConfigData(sdkKey)
+    const user = DVCPopulatedUser.fromUTF8(userJSONStr)
+    const bucketedConfig = _generateBucketedConfig(config, user, _getClientCustomData(sdkKey))
+    return Uint8Array.wrap(String.UTF8.encode(bucketedConfig.stringify()))
+}
+
 export enum VariableType {
     Boolean,
     Number,

--- a/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
@@ -137,6 +137,12 @@ export function testDVCUserClass(userStr: string): string {
     return populatedUser.stringify()
 }
 
+export function testDVCUserClassFromUTF8(userStr: Uint8Array): string {
+    const user = DVCUser.fromUTF8(userStr)
+    const populatedUser = new DVCPopulatedUser(user)
+    return populatedUser.stringify()
+}
+
 export function testBucketedUserConfigClass(userConfigStr: string): string {
     const userConfig = BucketedUserConfig.fromJSONString(userConfigStr)
     return userConfig.stringify()

--- a/lib/shared/bucketing-assembly-script/assembly/types/dvcUser.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/dvcUser.ts
@@ -134,8 +134,16 @@ export class DVCUser extends JSON.Obj implements DVCUserInterface {
     static fromJSONString(userStr: string): DVCUser {
         const userJSON = JSON.parse(userStr)
         if (!userJSON.isObj) throw new Error('dvcUserFromJSONString not a JSON Object')
-        const user = userJSON as JSON.Obj
+        return this.fromJSONObj(userJSON as JSON.Obj)
+    }
 
+    static fromUTF8(userStr: Uint8Array): DVCUser {
+        const userJSON = JSON.parse(userStr)
+        if (!userJSON.isObj) throw new Error('dvcUserFromUTF8 not a JSON Object')
+        return this.fromJSONObj(userJSON as JSON.Obj)
+    }
+
+    static fromJSONObj(user: JSON.Obj): DVCUser {
         const customData = user.getObj('customData')
         if (!isFlatJSONObj(customData)) {
             throw new Error('DVCUser customData can\'t contain nested objects or arrays')
@@ -243,6 +251,10 @@ export class DVCPopulatedUser extends JSON.Value implements DVCUserInterface {
 
     static fromJSONString(userStr: string): DVCPopulatedUser {
         return new DVCPopulatedUser(DVCUser.fromJSONString(userStr))
+    }
+
+    static fromUTF8(userBytes: Uint8Array): DVCPopulatedUser {
+        return new DVCPopulatedUser(DVCUser.fromUTF8(userBytes))
     }
 
     getCombinedCustomData(): JSON.Obj {


### PR DESCRIPTION
When working in protobuf we need to export the getBucketedConfigForUser() data as a UTF8 encoded Uint8Array instead of the fake utf-16 strings we were using before, otherwise special characters get corrupted