### PR TITLE
chore(typescript): emit 3.5 types

### DIFF
--- a/lib/shared/types/package.json
+++ b/lib/shared/types/package.json
@@ -4,5 +4,12 @@
   "license": "MIT",
   "dependencies": {
     "@types/validator": "13.7.6"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "./ts3.5/*"
+      ]
+    }
   }
 }

--- a/lib/shared/types/project.json
+++ b/lib/shared/types/project.json
@@ -15,13 +15,12 @@
         "command": "../../../../scripts/npm-safe-publish.sh \"@devcycle/types\"",
         "cwd": "dist/lib/shared/types",
         "forwardAllArgs": true
-      }
+      },
+      "dependsOn": [{ "projects": "self", "target": "build:emit-legacy-types" }]
     },
     "build": {
       "executor": "@nrwl/web:rollup",
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "options": {
         "format": ["esm", "cjs"],
         "project": "lib/shared/types/package.json",
@@ -39,22 +38,24 @@
         "skipTypeField": true
       }
     },
+    "build:emit-legacy-types": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "npx --yes downlevel-dts . ts3.5 --to=3.5",
+        "cwd": "dist/lib/shared/types",
+        "forwardAllArgs": true
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
+      "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "lib/shared/types/**/*.ts"
-        ]
+        "lintFilePatterns": ["lib/shared/types/**/*.ts"]
       }
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": [
-        "coverage/lib/shared/types"
-      ],
+      "outputs": ["coverage/lib/shared/types"],
       "options": {
         "jestConfig": "lib/shared/types/jest.config.ts",
         "passWithNoTests": true,

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -3,5 +3,12 @@
   "version": "1.9.1",
   "description": "The DevCycle JS SDK used for feature management.",
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "./ts3.5/*"
+      ]
+    }
+  }
 }

--- a/sdk/js/project.json
+++ b/sdk/js/project.json
@@ -9,7 +9,8 @@
         "command": "../../../scripts/npm-safe-publish.sh \"@devcycle/devcycle-js-sdk\"",
         "cwd": "dist/sdk/js",
         "forwardAllArgs": true
-      }
+      },
+      "dependsOn": [{ "projects": "self", "target": "build:emit-legacy-types" }]
     },
     "check-types": {
       "executor": "@nrwl/workspace:run-commands",
@@ -20,20 +21,14 @@
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
+      "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "sdk/js/**/*.ts"
-        ]
+        "lintFilePatterns": ["sdk/js/**/*.ts"]
       }
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": [
-        "coverage/sdk/js"
-      ],
+      "outputs": ["coverage/sdk/js"],
       "options": {
         "jestConfig": "sdk/js/jest.config.ts",
         "passWithNoTests": false,
@@ -42,25 +37,27 @@
     },
     "build": {
       "executor": "@nrwl/js:tsc",
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/sdk/js",
         "tsConfig": "sdk/js/tsconfig.lib.json",
         "packageJson": "sdk/js/package.json",
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "main": "sdk/js/src/index.ts",
-        "assets": [
-          "sdk/js/*.md"
-        ]
+        "assets": ["sdk/js/*.md"]
+      }
+    },
+    "build:emit-legacy-types": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "npx --yes downlevel-dts . ts3.5 --to=3.5",
+        "cwd": "dist/sdk/js",
+        "forwardAllArgs": true
       }
     },
     "build:cdn": {
       "executor": "@nrwl/webpack:webpack",
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "options": {
         "libraryName": "DevCycle",
         "libraryTarget": "umd",


### PR DESCRIPTION
A user is trying to get the devcycle-js-sdk working with Angular 8, whose compiler depends on a max typescript version of 3.5.9. Our sdk and shared types packages are transpiled with a version of typescript beyond that range, so the types it emits are incompatible with the older typescript compiler.

Using `downlevel-dts` we're able to emit 3.5 compatible types, and using `typesVersions` in `package.json`, we're able to tell versions of typescript lower than 4 where to find them.