### PR TITLE
fix: dependsOn hierarchy for legacy types

### DIFF
--- a/lib/shared/types/project.json
+++ b/lib/shared/types/project.json
@@ -16,7 +16,7 @@
         "cwd": "dist/lib/shared/types",
         "forwardAllArgs": true
       },
-      "dependsOn": [{ "projects": "self", "target": "build:emit-legacy-types" }]
+      "dependsOn": ["build:emit-legacy-types"]
     },
     "build": {
       "executor": "@nrwl/web:rollup",
@@ -44,7 +44,8 @@
         "command": "npx --yes downlevel-dts . ts3.5 --to=3.5",
         "cwd": "dist/lib/shared/types",
         "forwardAllArgs": true
-      }
+      },
+      "dependsOn": ["build"]
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/sdk/js/project.json
+++ b/sdk/js/project.json
@@ -10,7 +10,7 @@
         "cwd": "dist/sdk/js",
         "forwardAllArgs": true
       },
-      "dependsOn": [{ "projects": "self", "target": "build:emit-legacy-types" }]
+      "dependsOn": ["build:emit-legacy-types"]
     },
     "check-types": {
       "executor": "@nrwl/workspace:run-commands",
@@ -53,7 +53,8 @@
         "command": "npx --yes downlevel-dts . ts3.5 --to=3.5",
         "cwd": "dist/sdk/js",
         "forwardAllArgs": true
-      }
+      },
+      "dependsOn": ["build"]
     },
     "build:cdn": {
       "executor": "@nrwl/webpack:webpack",


### PR DESCRIPTION
I hadn't specified that emit-legacy-types depended on build, so build was happening after emit-legacy-types - effectively meaning that emit-legacy-types had nothing to work with since it's meant to run against the built files