### PR TITLE
DVC-6674 - removed workaround for as-proto bug

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/protobuf.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/protobuf.test.ts
@@ -131,7 +131,7 @@ describe('protobuf variable tests', () => {
                         name: { value: 'name', isNull: false },
                         language: { value: 'en', isNull: false },
                         country: { value: 'CA', isNull: false },
-                        appBuild: { value: 610.0, isNull: false, dummy: '' },
+                        appBuild: { value: 610.0, isNull: false },
                         appVersion: { value: '1.0.0', isNull: false },
                         deviceModel: { value: 'NodeJS', isNull: false },
                         customData: {
@@ -192,7 +192,7 @@ describe('protobuf variable tests', () => {
                     name: { value: 'name', isNull: false },
                     language: { value: 'en', isNull: false },
                     country: { value: 'CA', isNull: false },
-                    appBuild: { value: 610.0, isNull: false, dummy: '' },
+                    appBuild: { value: 610.0, isNull: false},
                     appVersion: { value: '1.0.0', isNull: false },
                     deviceModel: { value: 'NodeJS', isNull: false },
                     customData: {
@@ -235,7 +235,7 @@ describe('protobuf variable tests', () => {
                     name: { value: '', isNull: true },
                     language: { value: '', isNull: true },
                     country: { value: '', isNull: true },
-                    appBuild: { value: 0, isNull: true, dummy: '' },
+                    appBuild: { value: 0, isNull: true, },
                     appVersion: { value: '', isNull: true },
                     deviceModel: { value: '', isNull: true },
                     customData: { value: {}, isNull: true },

--- a/lib/shared/bucketing-assembly-script/assembly/types/protobuf-generated/NullableDouble.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/protobuf-generated/NullableDouble.ts
@@ -12,9 +12,6 @@ export class NullableDouble {
 
     writer.uint32(16);
     writer.bool(message.isNull);
-
-    writer.uint32(26);
-    writer.string(message.dummy);
   }
 
   static decode(reader: Reader, length: i32): NullableDouble {
@@ -32,10 +29,6 @@ export class NullableDouble {
           message.isNull = reader.bool();
           break;
 
-        case 3:
-          message.dummy = reader.string();
-          break;
-
         default:
           reader.skipType(tag & 7);
           break;
@@ -47,12 +40,10 @@ export class NullableDouble {
 
   value: f64;
   isNull: bool;
-  dummy: string;
 
-  constructor(value: f64 = 0.0, isNull: bool = false, dummy: string = "") {
+  constructor(value: f64 = 0.0, isNull: bool = false) {
     this.value = value;
     this.isNull = isNull;
-    this.dummy = dummy;
   }
 }
 

--- a/lib/shared/bucketing-assembly-script/protobuf/compiled.d.ts
+++ b/lib/shared/bucketing-assembly-script/protobuf/compiled.d.ts
@@ -116,9 +116,6 @@ export class NullableDouble implements INullableDouble {
     /** NullableDouble isNull. */
     public isNull: boolean;
 
-    /** NullableDouble dummy. */
-    public dummy: string;
-
     /**
      * Creates a new NullableDouble instance using the specified properties.
      * @param [properties] Properties to set

--- a/lib/shared/bucketing-assembly-script/protobuf/compiled.js
+++ b/lib/shared/bucketing-assembly-script/protobuf/compiled.js
@@ -262,7 +262,6 @@ $root.NullableDouble = (function() {
      * @interface INullableDouble
      * @property {number|null} [value] NullableDouble value
      * @property {boolean|null} [isNull] NullableDouble isNull
-     * @property {string|null} [dummy] NullableDouble dummy
      */
 
     /**
@@ -297,14 +296,6 @@ $root.NullableDouble = (function() {
     NullableDouble.prototype.isNull = false;
 
     /**
-     * NullableDouble dummy.
-     * @member {string} dummy
-     * @memberof NullableDouble
-     * @instance
-     */
-    NullableDouble.prototype.dummy = "";
-
-    /**
      * Creates a new NullableDouble instance using the specified properties.
      * @function create
      * @memberof NullableDouble
@@ -332,8 +323,6 @@ $root.NullableDouble = (function() {
             writer.uint32(/* id 1, wireType 1 =*/9).double(message.value);
         if (message.isNull != null && Object.hasOwnProperty.call(message, "isNull"))
             writer.uint32(/* id 2, wireType 0 =*/16).bool(message.isNull);
-        if (message.dummy != null && Object.hasOwnProperty.call(message, "dummy"))
-            writer.uint32(/* id 3, wireType 2 =*/26).string(message.dummy);
         return writer;
     };
 
@@ -374,10 +363,6 @@ $root.NullableDouble = (function() {
                 }
             case 2: {
                     message.isNull = reader.bool();
-                    break;
-                }
-            case 3: {
-                    message.dummy = reader.string();
                     break;
                 }
             default:
@@ -421,9 +406,6 @@ $root.NullableDouble = (function() {
         if (message.isNull != null && message.hasOwnProperty("isNull"))
             if (typeof message.isNull !== "boolean")
                 return "isNull: boolean expected";
-        if (message.dummy != null && message.hasOwnProperty("dummy"))
-            if (!$util.isString(message.dummy))
-                return "dummy: string expected";
         return null;
     };
 
@@ -443,8 +425,6 @@ $root.NullableDouble = (function() {
             message.value = Number(object.value);
         if (object.isNull != null)
             message.isNull = Boolean(object.isNull);
-        if (object.dummy != null)
-            message.dummy = String(object.dummy);
         return message;
     };
 
@@ -464,14 +444,11 @@ $root.NullableDouble = (function() {
         if (options.defaults) {
             object.value = 0;
             object.isNull = false;
-            object.dummy = "";
         }
         if (message.value != null && message.hasOwnProperty("value"))
             object.value = options.json && !isFinite(message.value) ? String(message.value) : message.value;
         if (message.isNull != null && message.hasOwnProperty("isNull"))
             object.isNull = message.isNull;
-        if (message.dummy != null && message.hasOwnProperty("dummy"))
-            object.dummy = message.dummy;
         return object;
     };
 

--- a/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
+++ b/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
@@ -17,7 +17,6 @@ message NullableString {
 message NullableDouble {
   double value = 1;
   bool isNull = 2;
-  string dummy = 3;
 }
 
 enum CustomDataType {


### PR DESCRIPTION
Removed the dummy string for NullableDouble now that the `@unmanaged` bug in as-proto is fixed