### PR TITLE
DVC-6965 [fix]: export JS SDK types from React and React-Native SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "ts-jest": "~28.0.8",
     "ts-node": "~10.9.1",
     "tslib": "^2.0.0",
-    "typescript": "~4.7.4",
+    "typescript": "^5.0.4",
     "verdaccio": "^5.15.4"
   },
   "lint-staged": {

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -1,6 +1,7 @@
 import { useDVCClient, useVariable, useVariableValue, useIsDVCInitialized } from '@devcycle/devcycle-react-sdk'
 import { withDVCProvider } from './withDVCProvider'
 import { DVCProvider } from './DVCProvider'
+export type { DVCClient, DVCUser, DVCVariableValue } from '@devcycle/devcycle-react-sdk'
 
 export { 
     DVCProvider, 

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -6,6 +6,7 @@ import withDVCProvider from './withDVCProvider'
 import DVCProvider from './DVCProvider'
 import useDVCVariable  from './useDVCVariable'
 import useIsDVCInitialized from './useIsDVCInitialized'
+export type { DVCClient, DVCUser, DVCVariableValue } from '@devcycle/devcycle-js-sdk'
 
 export { 
     DVCProvider, 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11566,7 +11566,7 @@ __metadata:
     ts-jest: ~28.0.8
     ts-node: ~10.9.1
     tslib: ^2.0.0
-    typescript: ~4.7.4
+    typescript: ^5.0.4
     ua-parser-js: ^1.0.2
     uuid: ^8.3.2
     verdaccio: ^5.15.4
@@ -25467,13 +25467,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.7.4":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
@@ -25507,13 +25507,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=bda367"
+"typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=bda367"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 96d3030cb01143570567cb4f3a616b10df65f658f0e74e853e77a089a6a954e35c800be7db8b9bfe9a1ae05d9c2897e281359f65e4caa1caf266368e1c4febd3
+  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- React SDK  exports `DVClient, DVCUser, DVCVariableValue` from JS SDK
- React-Native SDK exports `DVClient, DVCUser, DVCVariableValue` from React SDK that is re-exporting the JS SDK types