### PR TITLE
Adding c# option to the protobuf so it is consistent with dotnet SDK

### DIFF
--- a/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
+++ b/lib/shared/bucketing-assembly-script/protobuf/variableForUserParams.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 option go_package = "./proto";
+option csharp_namespace = "DevCycle.SDK.Server.Local.Protobuf";
 
 enum VariableType_PB {
     Boolean = 0;


### PR DESCRIPTION
Added namespace option to the protobuf file that is necessary for the dotnet SDK changes
- want to ensure this version in `js-sdks` remains the source of truth for protobuf for all SDKs