### PR TITLE
chore: add generic arg for restricting possible types of variables in JS and React

### DIFF
--- a/lib/shared/types/src/types/config/models/variable.ts
+++ b/lib/shared/types/src/types/config/models/variable.ts
@@ -42,11 +42,15 @@ export enum VariableType {
 export type DVCJSON = { [key: string]: string | boolean | number }
 export type VariableValue = string | boolean | number | DVCJSON
 
+type UnionToIntersection<U> =
+    (U extends any ? (k: U)=>void : never) extends ((k: infer I)=>void) ? I : never
+type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
+
 // alias to resolve a generic type constrained by `VariableValue` back into its original type
-export type VariableTypeAlias<T> = T extends boolean ? boolean : (
+export type VariableTypeAlias<T> = IsUnion<T> extends true ? T : (T extends boolean ? boolean : (
         T extends number ? number : (
             T extends string ? string : (
                 T extends DVCJSON ? DVCJSON : never
                 )
             )
-        )
+        ))

--- a/sdk/js/src/Client.test.ts
+++ b/sdk/js/src/Client.test.ts
@@ -18,7 +18,15 @@ describe('Client', () => {
         client.variable('enum_var', 'value1')
         client.variable('enum_var', 'value2')
         // @ts-expect-error - should not allow invalid variable values for enums
-        client.variable('enum_var', 'something_else')
+        const enumVar = client.variable('enum_var', 'something_else')
+
+        // @ts-expect-error - should not allow comparison with impossible values
+        if (enumVar.value === 'something else') {
+            // no-op
+        }
+        if (enumVar.value === 'value1') {
+            // no-op
+        }
         client.variable('bool', true)
         client.variable('string', 'test')
         client.variable('number', 1)

--- a/sdk/js/src/Client.test.ts
+++ b/sdk/js/src/Client.test.ts
@@ -1,0 +1,26 @@
+import { DVCClient } from './Client'
+jest.mock('../src/Request')
+jest.mock('../src/StreamingConnection')
+
+type Variables = {
+    'enum_var': 'value1' | 'value2'
+    'bool': boolean,
+    'string': string,
+    'number': number,
+}
+
+describe('Client', () => {
+    it('should prevent invalid variables', () => {
+        const client = new DVCClient<Variables>('test', { user_id: 'test' })
+
+        // @ts-expect-error - should not allow invalid variables
+        client.variable('something', false)
+        client.variable('enum_var', 'value1')
+        client.variable('enum_var', 'value2')
+        // @ts-expect-error - should not allow invalid variable values for enums
+        client.variable('enum_var', 'something_else')
+        client.variable('bool', true)
+        client.variable('string', 'test')
+        client.variable('number', 1)
+    })
+})

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -7,7 +7,8 @@ import {
     DVCEvent as ClientEvent,
     DVCUser,
     ErrorCallback,
-    DVCFeature, VariableDefinitions,
+    DVCFeature,
+    VariableDefinitions,
 } from './types'
 import { DVCVariable, DVCVariableOptions } from './Variable'
 import { getConfigJson, saveEntity } from './Request'
@@ -41,12 +42,14 @@ type variableEvaluatedHandler = (
     variable: DVCVariable<DVCVariableValue>
 ) => void
 
-export class DVCClient<Variables extends VariableDefinitions = VariableDefinitions> implements Client<Variables> {
+export class DVCClient<
+  Variables extends VariableDefinitions = VariableDefinitions
+> implements Client<Variables> {
     private options: DVCOptions
-    private onInitialized: Promise<DVCClient>
+    private onInitialized: Promise<DVCClient<Variables>>
     private variableDefaultMap: {
-        [key: string]: { [key: string]: DVCVariable<any> }
-    }
+    [key: string]: { [key: string]: DVCVariable<any> };
+  }
     private sdkKey: string
     private userSaved = false
     private _closing = false
@@ -66,7 +69,7 @@ export class DVCClient<Variables extends VariableDefinitions = VariableDefinitio
 
     constructor(sdkKey: string, user: DVCUser, options: DVCOptions = {}) {
         this.logger =
-            options.logger || dvcDefaultLogger({ level: options.logLevel })
+      options.logger || dvcDefaultLogger({ level: options.logLevel })
         this.store = new CacheStore(
             options.storage || new DefaultStorage(),
             this.logger
@@ -134,9 +137,11 @@ export class DVCClient<Variables extends VariableDefinitions = VariableDefinitio
         }
     }
 
-    onClientInitialized(): Promise<DVCClient<Variables>>
-    onClientInitialized(onInitialized: ErrorCallback<DVCClient<Variables>>): void
-    onClientInitialized(onInitialized?: ErrorCallback<DVCClient<Variables>>): Promise<DVCClient<Variables>> | void {
+    onClientInitialized(): Promise<DVCClient<Variables>>;
+    onClientInitialized(onInitialized: ErrorCallback<DVCClient<Variables>>): void;
+    onClientInitialized(
+        onInitialized?: ErrorCallback<DVCClient<Variables>>
+    ): Promise<DVCClient<Variables>> | void {
         if (onInitialized && typeof onInitialized === 'function') {
             this.onInitialized
                 .then(() => onInitialized(null, this))
@@ -147,9 +152,9 @@ export class DVCClient<Variables extends VariableDefinitions = VariableDefinitio
     }
 
     variable<
-        K extends string & keyof Variables,
-        T extends DVCVariableValue & Variables[K]
-    >(key: K, defaultValue: T): DVCVariable<T> {
+    K extends string & keyof Variables,
+    T extends DVCVariableValue & Variables[K]
+  >(key: K, defaultValue: T): DVCVariable<T> {
         if (defaultValue === undefined || defaultValue === null) {
             throw new Error('Default value is a required param')
         }
@@ -163,14 +168,14 @@ export class DVCClient<Variables extends VariableDefinitions = VariableDefinitio
         )
 
         const defaultValueKey =
-            typeof defaultValue === 'string'
-                ? defaultValue
-                : JSON.stringify(defaultValue)
+      typeof defaultValue === 'string'
+          ? defaultValue
+          : JSON.stringify(defaultValue)
 
         let variable
         if (
             this.variableDefaultMap[key] &&
-            this.variableDefaultMap[key][defaultValueKey]
+      this.variableDefaultMap[key][defaultValueKey]
         ) {
             variable = this.variableDefaultMap[key][
                 defaultValueKey

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -7,7 +7,7 @@ import {
     DVCEvent as ClientEvent,
     DVCUser,
     ErrorCallback,
-    DVCFeature,
+    DVCFeature, VariableDefinitions,
 } from './types'
 import { DVCVariable, DVCVariableOptions } from './Variable'
 import { getConfigJson, saveEntity } from './Request'
@@ -41,7 +41,7 @@ type variableEvaluatedHandler = (
     variable: DVCVariable<DVCVariableValue>
 ) => void
 
-export class DVCClient implements Client {
+export class DVCClient<Variables extends VariableDefinitions = VariableDefinitions> implements Client<Variables> {
     private options: DVCOptions
     private onInitialized: Promise<DVCClient>
     private variableDefaultMap: {
@@ -134,11 +134,9 @@ export class DVCClient implements Client {
         }
     }
 
-    onClientInitialized(): Promise<DVCClient>
-    onClientInitialized(onInitialized: ErrorCallback<DVCClient>): void
-    onClientInitialized(
-        onInitialized?: ErrorCallback<DVCClient>
-    ): Promise<DVCClient> | void {
+    onClientInitialized(): Promise<DVCClient<Variables>>
+    onClientInitialized(onInitialized: ErrorCallback<DVCClient<Variables>>): void
+    onClientInitialized(onInitialized?: ErrorCallback<DVCClient<Variables>>): Promise<DVCClient<Variables>> | void {
         if (onInitialized && typeof onInitialized === 'function') {
             this.onInitialized
                 .then(() => onInitialized(null, this))
@@ -148,10 +146,10 @@ export class DVCClient implements Client {
         return this.onInitialized
     }
 
-    variable<T extends DVCVariableValue>(
-        key: string,
-        defaultValue: T
-    ): DVCVariable<T> {
+    variable<
+        K extends string & keyof Variables,
+        T extends DVCVariableValue & Variables[K]
+    >(key: K, defaultValue: T): DVCVariable<T> {
         if (defaultValue === undefined || defaultValue === null) {
             throw new Error('Default value is a required param')
         }

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -45,11 +45,11 @@ export type DVCFeatureSet = {
  * @param user
  * @param options
  */
-export type initialize = (
+export type initialize = <Variables extends VariableDefinitions = VariableDefinitions>(
     sdkKey: string,
     user: DVCUser,
     options?: DVCOptions
-) => DVCClient
+) => DVCClient<Variables>
 
 export interface DVCOptions {
     eventFlushIntervalMS?: number
@@ -123,7 +123,11 @@ export interface DVCUser {
     privateCustomData?: DVCCustomDataJSON
 }
 
-export interface DVCClient {
+export interface VariableDefinitions {
+    [key: string]: VariableValue,
+}
+
+export interface DVCClient<Variables extends VariableDefinitions = VariableDefinitions> {
     /**
      * User document describing
      */
@@ -136,8 +140,8 @@ export interface DVCClient {
      *
      * @param onInitialized
      */
-    onClientInitialized(): Promise<DVCClient>
-    onClientInitialized(onInitialized: ErrorCallback<DVCClient>): void
+    onClientInitialized(): Promise<DVCClient<Variables>>
+    onClientInitialized(onInitialized: ErrorCallback<DVCClient<Variables>>): void
 
     /**
      * Grab variable values associated with Features. Use the key created in the dashboard to fetch
@@ -148,8 +152,8 @@ export interface DVCClient {
      * @param key
      * @param defaultValue
      */
-    variable<T extends DVCVariableValue>(
-        key: string,
+    variable<K extends string & keyof Variables, T extends DVCVariableValue & Variables[K]>(
+        key: K,
         defaultValue: T
     ): DVCVariable<T>
 

--- a/sdk/react/src/useDVCClient.ts
+++ b/sdk/react/src/useDVCClient.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react'
 import context from './context'
-import { DVCClient } from '@devcycle/devcycle-js-sdk'
+import { DVCClient, VariableDefinitions } from '@devcycle/devcycle-js-sdk'
 
-export const useDVCClient = (): DVCClient => {
+export const useDVCClient = <Variables extends VariableDefinitions = VariableDefinitions>(): DVCClient<Variables> => {
     const dvcContext = useContext(context)
 
     if (dvcContext === undefined) throw new Error('useDVCClient must be used within DVCProvider')

--- a/sdk/react/src/useVariable.ts
+++ b/sdk/react/src/useVariable.ts
@@ -1,8 +1,12 @@
 import { useContext, useRef, useState } from 'react'
 import context from './context'
 import type { DVCVariable, DVCVariableValue } from '@devcycle/devcycle-js-sdk'
+import { VariableDefinitions } from '@devcycle/devcycle-js-sdk'
 
-export const useVariable = <T extends DVCVariableValue>(key: string, defaultValue: T): DVCVariable<T> => {
+export const useVariable = <Variables extends VariableDefinitions = VariableDefinitions,
+    K extends string & keyof Variables = string & keyof Variables,
+    T extends DVCVariableValue & Variables[K] = DVCVariableValue & Variables[K]
+>(key: K, defaultValue: T): DVCVariable<T> => {
     const dvcContext = useContext(context)
     const [_, forceRerender] = useState({})
     const ref = useRef<DVCVariable<T>>()

--- a/sdk/react/src/useVariableValue.ts
+++ b/sdk/react/src/useVariableValue.ts
@@ -1,9 +1,11 @@
 import { useVariable } from './'
-import type { DVCVariableValue } from '@devcycle/devcycle-js-sdk'
-import { VariableTypeAlias } from '@devcycle/types'
+import type { DVCVariable, DVCVariableValue, VariableDefinitions } from '@devcycle/devcycle-js-sdk'
 
-export const useVariableValue = <T extends DVCVariableValue>(key: string, defaultValue: T): VariableTypeAlias<T> => {
-    return useVariable(key, defaultValue).value
+export const useVariableValue = <Variables extends VariableDefinitions = VariableDefinitions,
+    K extends string & keyof Variables = string & keyof Variables,
+    T extends DVCVariableValue & Variables[K] = DVCVariableValue & Variables[K]
+>(key: K, defaultValue: T): DVCVariable<T>['value'] => {
+    return useVariable<Variables, K, T>(key, defaultValue).value
 }
 
 export default useVariableValue


### PR DESCRIPTION
Now you can define a generic arg to specify the set of variable keys and default values that are allowed in the JS client:
![image](https://user-images.githubusercontent.com/1740731/234121906-9cd9ad69-7b74-40e8-a23a-2b90b432a44f.png)
