### PR TITLE
feat: emit variable evaluated event

### DIFF
--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -91,6 +91,33 @@ describe('EventEmitter tests', () => {
         })
     })
 
+    describe('emitVariableEvaluated', () => {
+        it('should emit variable evaluated event if subscribed to variable evaluations', () => {
+            const allUpdatesHandler = jest.fn()
+            const variableKeyHandler = jest.fn()
+            const evaluatedVariable = {
+                _id: 'variable_id',
+                key: 'my-variable-key',
+                value: 'my-new-value',
+                type: 'my-type',
+            }
+            eventEmitter.subscribe('variableEvaluated', allUpdatesHandler)
+            eventEmitter.emitVariableEvaluated(evaluatedVariable)
+            expect(allUpdatesHandler).toBeCalledWith(evaluatedVariable)
+        })
+        it('should not emit variable evaluated events if not subscribed to variable evaluations', () => {
+            const allUpdatesHandler = jest.fn()
+            const evaluatedVariable = {
+                _id: 'variable_id',
+                key: 'my-variable-key',
+                value: 'my-new-value',
+                type: 'my-type',
+            }
+            eventEmitter.emitVariableEvaluated(evaluatedVariable)
+            expect(allUpdatesHandler).not.toBeCalledWith(evaluatedVariable)
+        })
+    })
+
     describe('emitVariableUpdates', () => {
         it('should emit variable updated event if subscribed to all variable updates, and specific key', () => {
             const allUpdatesHandler = jest.fn()
@@ -265,7 +292,7 @@ describe('EventEmitter tests', () => {
             )
         })
 
-        it('should not mit feature updated event if no updates', () => {
+        it('should not emit feature updated event if no updates', () => {
             const allUpdatesHandler = jest.fn()
             const featureKeyHandler = jest.fn()
             const oldFeatureSet = {

--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -6,9 +6,9 @@ const testConfig = {
     project: {
         settings: {
             edgeDB: {
-                enabled: true
-            }
-        }
+                enabled: true,
+            },
+        },
     },
     environment: {},
     features: {},
@@ -18,10 +18,10 @@ const testConfig = {
             _id: 'id',
             value: 'value1',
             type: 'String',
-            default_value: 'default_value'
-        }
+            default_value: 'default_value',
+        },
     },
-    etag: '123'
+    etag: '123',
 }
 describe('EventEmitter tests', () => {
     const eventEmitter = new EventEmitter()
@@ -42,7 +42,9 @@ describe('EventEmitter tests', () => {
     describe('subscribe', () => {
         it('should throw error if event is not a predefined event', () => {
             const handler = jest.fn()
-            expect(() => eventEmitter.subscribe('not_an_event', handler)).toThrow(expect.any(Error))
+            expect(() =>
+                eventEmitter.subscribe('not_an_event', handler)
+            ).toThrow(expect.any(Error))
         })
 
         it('should subscribe to event', () => {
@@ -98,22 +100,31 @@ describe('EventEmitter tests', () => {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             const variableSet = {
                 'my-variable-key': {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-new-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             eventEmitter.subscribe('variableUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`variableUpdated:my-variable-key`, variableKeyHandler)
+            eventEmitter.subscribe(
+                `variableUpdated:my-variable-key`,
+                variableKeyHandler
+            )
             eventEmitter.emitVariableUpdates(oldVariableSet, variableSet, {})
-            expect(allUpdatesHandler).toBeCalledWith('my-variable-key', variableSet['my-variable-key'])
-            expect(variableKeyHandler).toBeCalledWith('my-variable-key', variableSet['my-variable-key'])
+            expect(allUpdatesHandler).toBeCalledWith(
+                'my-variable-key',
+                variableSet['my-variable-key']
+            )
+            expect(variableKeyHandler).toBeCalledWith(
+                'my-variable-key',
+                variableSet['my-variable-key']
+            )
         })
 
         it('should not emit variable updated event if no updates', () => {
@@ -124,19 +135,22 @@ describe('EventEmitter tests', () => {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             const variableSet = {
                 'my-variable-key': {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             eventEmitter.subscribe('variableUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`variableUpdated:my-variable-key`, variableKeyHandler)
+            eventEmitter.subscribe(
+                `variableUpdated:my-variable-key`,
+                variableKeyHandler
+            )
             eventEmitter.emitVariableUpdates(oldVariableSet, variableSet, {})
             expect(allUpdatesHandler).not.toBeCalled()
             expect(variableKeyHandler).not.toBeCalled()
@@ -156,20 +170,23 @@ describe('EventEmitter tests', () => {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             const newVariableSet = {
                 'different-variable-key': {
                     _id: 'variable_id_2',
                     key: 'different-variable-key',
                     value: 'different-value',
-                    type: 'string'
-                }
+                    type: 'string',
+                },
             }
 
             eventEmitter.subscribe('variableUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`variableUpdated:my-variable-key`, variableKeyHandler)
+            eventEmitter.subscribe(
+                `variableUpdated:my-variable-key`,
+                variableKeyHandler
+            )
             eventEmitter.emitVariableUpdates(oldVariableSet, newVariableSet, {})
             expect(allUpdatesHandler).toBeCalledWith('my-variable-key', null)
             expect(variableKeyHandler).toBeCalledWith('my-variable-key', null)
@@ -183,23 +200,32 @@ describe('EventEmitter tests', () => {
                     _id: 'variable_id_2',
                     key: 'different-variable-key',
                     value: 'different-value',
-                    type: 'string'
-                }
+                    type: 'string',
+                },
             }
             const newVariableSet = {
                 'my-variable-key': {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
 
             eventEmitter.subscribe('variableUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`variableUpdated:my-variable-key`, variableKeyHandler)
+            eventEmitter.subscribe(
+                `variableUpdated:my-variable-key`,
+                variableKeyHandler
+            )
             eventEmitter.emitVariableUpdates(oldVariableSet, newVariableSet, {})
-            expect(allUpdatesHandler).toBeCalledWith('my-variable-key', newVariableSet['my-variable-key'])
-            expect(variableKeyHandler).toBeCalledWith('my-variable-key', newVariableSet['my-variable-key'])
+            expect(allUpdatesHandler).toBeCalledWith(
+                'my-variable-key',
+                newVariableSet['my-variable-key']
+            )
+            expect(variableKeyHandler).toBeCalledWith(
+                'my-variable-key',
+                newVariableSet['my-variable-key']
+            )
         })
     })
 
@@ -212,22 +238,31 @@ describe('EventEmitter tests', () => {
                     _id: 'feature_id',
                     _variation: 'variation1',
                     key: 'my-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             const featureSet = {
                 'my-feature-key': {
                     _id: 'feature_id',
                     _variation: 'variation2',
                     key: 'my-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             eventEmitter.subscribe('featureUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`featureUpdated:my-feature-key`, featureKeyHandler)
+            eventEmitter.subscribe(
+                `featureUpdated:my-feature-key`,
+                featureKeyHandler
+            )
             eventEmitter.emitFeatureUpdates(oldFeatureSet, featureSet)
-            expect(allUpdatesHandler).toBeCalledWith('my-feature-key', featureSet['my-feature-key'])
-            expect(featureKeyHandler).toBeCalledWith('my-feature-key', featureSet['my-feature-key'])
+            expect(allUpdatesHandler).toBeCalledWith(
+                'my-feature-key',
+                featureSet['my-feature-key']
+            )
+            expect(featureKeyHandler).toBeCalledWith(
+                'my-feature-key',
+                featureSet['my-feature-key']
+            )
         })
 
         it('should not mit feature updated event if no updates', () => {
@@ -238,19 +273,22 @@ describe('EventEmitter tests', () => {
                     _id: 'feature_id',
                     _variation: 'variation1',
                     key: 'my-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             const featureSet = {
                 'my-feature-key': {
                     _id: 'feature_id',
                     _variation: 'variation1',
                     key: 'my-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             eventEmitter.subscribe('featureUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`featureUpdated:my-feature-key`, featureKeyHandler)
+            eventEmitter.subscribe(
+                `featureUpdated:my-feature-key`,
+                featureKeyHandler
+            )
             eventEmitter.emitFeatureUpdates(oldFeatureSet, featureSet)
             expect(allUpdatesHandler).not.toBeCalled()
             expect(featureKeyHandler).not.toBeCalled()
@@ -270,19 +308,22 @@ describe('EventEmitter tests', () => {
                     _id: 'feature_id',
                     _variation: 'variation1',
                     key: 'my-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             const newFeatureSet = {
                 'different-feature-key': {
                     _id: 'different_feature_id',
                     _variation: 'different-variation1',
                     key: 'different-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             eventEmitter.subscribe('featureUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`featureUpdated:my-feature-key`, featureKeyHandler)
+            eventEmitter.subscribe(
+                `featureUpdated:my-feature-key`,
+                featureKeyHandler
+            )
             eventEmitter.emitFeatureUpdates(oldFeatureSet, newFeatureSet)
             expect(allUpdatesHandler).toBeCalledWith('my-feature-key', null)
             expect(featureKeyHandler).toBeCalledWith('my-feature-key', null)
@@ -296,22 +337,31 @@ describe('EventEmitter tests', () => {
                     _id: 'different_feature_id',
                     _variation: 'different-variation1',
                     key: 'different-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             const newFeatureSet = {
                 'my-feature-key': {
                     _id: 'feature_id',
                     _variation: 'variation1',
                     key: 'my-feature-key',
-                    type: 'experiment'
-                }
+                    type: 'experiment',
+                },
             }
             eventEmitter.subscribe('featureUpdated:*', allUpdatesHandler)
-            eventEmitter.subscribe(`featureUpdated:my-feature-key`, featureKeyHandler)
+            eventEmitter.subscribe(
+                `featureUpdated:my-feature-key`,
+                featureKeyHandler
+            )
             eventEmitter.emitFeatureUpdates(oldFeatureSet, newFeatureSet)
-            expect(allUpdatesHandler).toBeCalledWith('my-feature-key', newFeatureSet['my-feature-key'])
-            expect(featureKeyHandler).toBeCalledWith('my-feature-key', newFeatureSet['my-feature-key'])
+            expect(allUpdatesHandler).toBeCalledWith(
+                'my-feature-key',
+                newFeatureSet['my-feature-key']
+            )
+            expect(featureKeyHandler).toBeCalledWith(
+                'my-feature-key',
+                newFeatureSet['my-feature-key']
+            )
         })
     })
 
@@ -323,8 +373,8 @@ describe('EventEmitter tests', () => {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-new-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             eventEmitter.subscribe('configUpdated', configHandler)
             eventEmitter.emitConfigUpdate(variableSet)
@@ -338,8 +388,8 @@ describe('EventEmitter tests', () => {
                     _id: 'variable_id',
                     key: 'my-variable-key',
                     value: 'my-new-value',
-                    type: 'my-type'
-                }
+                    type: 'my-type',
+                },
             }
             eventEmitter.subscribe('configUpdated', configHandler)
             eventEmitter.unsubscribe('configUpdated')
@@ -353,8 +403,8 @@ describe('EventEmitter tests', () => {
             client.eventEmitter = eventEmitter
             eventEmitter.subscribe('configUpdated', configHandler)
             client.handleConfigReceived(
-                testConfig, 
-                new DVCPopulatedUser({ user_id: 'user1' }, null), 
+                testConfig,
+                new DVCPopulatedUser({ user_id: 'user1' }, null),
                 123
             )
             expect(configHandler).toHaveBeenCalledWith(testConfig.variables)
@@ -367,8 +417,8 @@ describe('EventEmitter tests', () => {
             client.config = testConfig
             eventEmitter.subscribe('configUpdated', configHandler)
             client.handleConfigReceived(
-                testConfig, 
-                new DVCPopulatedUser({ user_id: 'user1' }, null), 
+                testConfig,
+                new DVCPopulatedUser({ user_id: 'user1' }, null),
                 123
             )
             expect(configHandler).not.toHaveBeenCalled()
@@ -378,11 +428,11 @@ describe('EventEmitter tests', () => {
             const configHandler = jest.fn()
             const client = new DVCClient('test_sdk_key', { user_id: 'user1' })
             client.eventEmitter = eventEmitter
-            client.config = {...testConfig, etag: '567'}
+            client.config = { ...testConfig, etag: '567' }
             eventEmitter.subscribe('configUpdated', configHandler)
             client.handleConfigReceived(
-                testConfig, 
-                new DVCPopulatedUser({ user_id: 'user1' }, null), 
+                testConfig,
+                new DVCPopulatedUser({ user_id: 'user1' }, null),
                 123
             )
             expect(configHandler).toHaveBeenCalledWith(testConfig.variables)

--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -92,18 +92,47 @@ describe('EventEmitter tests', () => {
     })
 
     describe('emitVariableEvaluated', () => {
-        it('should emit variable evaluated event if subscribed to variable evaluations', () => {
+        it('should emit variable evaluated event if subscribed to all variable evaluations', () => {
             const allUpdatesHandler = jest.fn()
-            const variableKeyHandler = jest.fn()
             const evaluatedVariable = {
                 _id: 'variable_id',
                 key: 'my-variable-key',
                 value: 'my-new-value',
                 type: 'my-type',
             }
-            eventEmitter.subscribe('variableEvaluated', allUpdatesHandler)
+            eventEmitter.subscribe('variableEvaluated:*', allUpdatesHandler)
             eventEmitter.emitVariableEvaluated(evaluatedVariable)
             expect(allUpdatesHandler).toBeCalledWith(evaluatedVariable)
+        })
+        it('should emit variable evaluated event if subscribed to specific variable evaluations', () => {
+            const allUpdatesHandler = jest.fn()
+            const evaluatedVariable = {
+                _id: 'variable_id',
+                key: 'my-variable-key',
+                value: 'my-new-value',
+                type: 'my-type',
+            }
+            eventEmitter.subscribe(
+                'variableEvaluated:my-variable-key',
+                allUpdatesHandler
+            )
+            eventEmitter.emitVariableEvaluated(evaluatedVariable)
+            expect(allUpdatesHandler).toBeCalledWith(evaluatedVariable)
+        })
+        it('should not emit variable evaluated event if not subscribed to specific variable key', () => {
+            const allUpdatesHandler = jest.fn()
+            const evaluatedVariable = {
+                _id: 'variable_id',
+                key: 'my-variable-key',
+                value: 'my-new-value',
+                type: 'my-type',
+            }
+            eventEmitter.subscribe(
+                'variableEvaluated:not-my-variable-key',
+                allUpdatesHandler
+            )
+            eventEmitter.emitVariableEvaluated(evaluatedVariable)
+            expect(allUpdatesHandler).not.toBeCalledWith(evaluatedVariable)
         })
         it('should not emit variable evaluated events if not subscribed to variable evaluations', () => {
             const allUpdatesHandler = jest.fn()

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -223,6 +223,7 @@ export class DVCClient implements Client {
             this.logger.warn(`Error with queueing aggregate events ${e}`)
         }
 
+        this.eventEmitter.emitVariableEvaluated(variable)
         return variable
     }
 

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -88,7 +88,8 @@ export class EventEmitter {
     }
 
     emitVariableEvaluated(variable: DVCVariable<any>): void {
-        this.emit(EventNames.VARIABLE_EVALUATED, variable)
+        this.emit(`${EventNames.VARIABLE_EVALUATED}:*`, variable)
+        this.emit(`${EventNames.VARIABLE_EVALUATED}:${variable.key}`, variable)
     }
 
     emitVariableUpdates(

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -14,10 +14,12 @@ const EventNames = {
 type EventHandler = (...args: any[]) => void
 
 const isInvalidEventKey = (key: string): boolean => {
-    return !Object.values(EventNames).includes(key) &&
-    !key.startsWith(EventNames.VARIABLE_UPDATED) &&
-    !key.startsWith(EventNames.FEATURE_UPDATED) &&
-    !key.startsWith(EventNames.NEW_VARIABLES)
+    return (
+        !Object.values(EventNames).includes(key) &&
+        !key.startsWith(EventNames.VARIABLE_UPDATED) &&
+        !key.startsWith(EventNames.FEATURE_UPDATED) &&
+        !key.startsWith(EventNames.NEW_VARIABLES)
+    )
 }
 
 export class EventEmitter {
@@ -33,10 +35,10 @@ export class EventEmitter {
 
         if (isInvalidEventKey(key)) {
             throw new Error('Not a valid event to subscribe to')
-        }  
-        
+        }
+
         if (!this.handlers[key]) {
-            this.handlers[key] = [ handler ]
+            this.handlers[key] = [handler]
         } else {
             this.handlers[key].push(handler)
         }
@@ -50,8 +52,9 @@ export class EventEmitter {
         }
 
         if (handler) {
-            const handlerIndex = this.handlers[key]
-                .findIndex((h) => h === handler)
+            const handlerIndex = this.handlers[key].findIndex(
+                (h) => h === handler
+            )
 
             this.handlers[key].splice(handlerIndex, 1)
         } else {
@@ -85,28 +88,49 @@ export class EventEmitter {
     emitVariableUpdates(
         oldVariableSet: DVCVariableSet,
         newVariableSet: DVCVariableSet,
-        variableDefaultMap: { [key: string]: { [defaultValue: string]: DVCVariable<any> } }
+        variableDefaultMap: {
+            [key: string]: { [defaultValue: string]: DVCVariable<any> }
+        }
     ): void {
-        const keys = new Set(Object.keys(oldVariableSet).concat(Object.keys(newVariableSet)))
+        const keys = new Set(
+            Object.keys(oldVariableSet).concat(Object.keys(newVariableSet))
+        )
         let newVariables = false
         keys.forEach((key) => {
-            const oldVariableValue = oldVariableSet[key] && oldVariableSet[key].value
+            const oldVariableValue =
+                oldVariableSet[key] && oldVariableSet[key].value
             const newVariable = newVariableSet[key]
             const newVariableValue = newVariable && newVariableSet[key].value
 
-            if (JSON.stringify(oldVariableValue) !== JSON.stringify(newVariableValue)) {
-                const variables = variableDefaultMap[key] && Object.values(variableDefaultMap[key])
+            if (
+                JSON.stringify(oldVariableValue) !==
+                JSON.stringify(newVariableValue)
+            ) {
+                const variables =
+                    variableDefaultMap[key] &&
+                    Object.values(variableDefaultMap[key])
                 if (variables) {
                     newVariables = true
                     variables.forEach((variable) => {
-                        variable.value = newVariableValue ?? variable.defaultValue
-                        variable.isDefaulted = newVariableValue === undefined || newVariableValue === null
+                        variable.value =
+                            newVariableValue ?? variable.defaultValue
+                        variable.isDefaulted =
+                            newVariableValue === undefined ||
+                            newVariableValue === null
                         variable.callback?.call(variable, variable.value)
                     })
                 }
-                const finalVariable = newVariable || null 
-                this.emit(`${EventNames.VARIABLE_UPDATED}:*`, key, finalVariable)
-                this.emit(`${EventNames.VARIABLE_UPDATED}:${key}`, key, finalVariable)
+                const finalVariable = newVariable || null
+                this.emit(
+                    `${EventNames.VARIABLE_UPDATED}:*`,
+                    key,
+                    finalVariable
+                )
+                this.emit(
+                    `${EventNames.VARIABLE_UPDATED}:${key}`,
+                    key,
+                    finalVariable
+                )
             }
         })
         if (newVariables) {
@@ -114,17 +138,28 @@ export class EventEmitter {
         }
     }
 
-    emitFeatureUpdates(oldFeatureSet: DVCFeatureSet, newFeatureSet: DVCFeatureSet): void {
-        const keys = Object.keys(oldFeatureSet).concat(Object.keys(newFeatureSet))
+    emitFeatureUpdates(
+        oldFeatureSet: DVCFeatureSet,
+        newFeatureSet: DVCFeatureSet
+    ): void {
+        const keys = Object.keys(oldFeatureSet).concat(
+            Object.keys(newFeatureSet)
+        )
         keys.forEach((key) => {
-            const oldFeatureVariation = oldFeatureSet[key] && oldFeatureSet[key]._variation
+            const oldFeatureVariation =
+                oldFeatureSet[key] && oldFeatureSet[key]._variation
             const newFeature = newFeatureSet[key]
-            const newFeatureVariation = newFeature && newFeatureSet[key]._variation
+            const newFeatureVariation =
+                newFeature && newFeatureSet[key]._variation
 
-            const finalFeature = newFeature || null 
+            const finalFeature = newFeature || null
             if (oldFeatureVariation !== newFeatureVariation) {
                 this.emit(`${EventNames.FEATURE_UPDATED}:*`, key, finalFeature)
-                this.emit(`${EventNames.FEATURE_UPDATED}:${key}`, key, finalFeature)
+                this.emit(
+                    `${EventNames.FEATURE_UPDATED}:${key}`,
+                    key,
+                    finalFeature
+                )
             }
         })
     }

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -9,6 +9,7 @@ const EventNames = {
     VARIABLE_UPDATED: 'variableUpdated',
     FEATURE_UPDATED: 'featureUpdated',
     CONFIG_UPDATED: 'configUpdated',
+    VARIABLE_EVALUATED: 'variableEvaluated',
 }
 
 type EventHandler = (...args: any[]) => void
@@ -18,7 +19,8 @@ const isInvalidEventKey = (key: string): boolean => {
         !Object.values(EventNames).includes(key) &&
         !key.startsWith(EventNames.VARIABLE_UPDATED) &&
         !key.startsWith(EventNames.FEATURE_UPDATED) &&
-        !key.startsWith(EventNames.NEW_VARIABLES)
+        !key.startsWith(EventNames.NEW_VARIABLES) &&
+        !key.startsWith(EventNames.VARIABLE_EVALUATED)
     )
 }
 
@@ -83,6 +85,10 @@ export class EventEmitter {
 
     emitConfigUpdate(newVariableSet: DVCVariableSet): void {
         this.emit(EventNames.CONFIG_UPDATED, newVariableSet)
+    }
+
+    emitVariableEvaluated(variable: DVCVariable<any>): void {
+        this.emit(EventNames.VARIABLE_EVALUATED, variable)
     }
 
     emitVariableUpdates(


### PR DESCRIPTION
In order to hook up to datadogs feature flag monitoring, we need to know when a variable has been evaluated. Possibly overkill, but I created a new event that is emitted whenever a variable is evaluated, and plan to try hooking datadog's tracking up to that. Apologies for the first commit in this PR, which is exclusively auto-formatting. Real changes are in the second commit.