### PR TITLE
chore: adopt existing signature, add types

### DIFF
--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -102,7 +102,10 @@ describe('EventEmitter tests', () => {
             }
             eventEmitter.subscribe('variableEvaluated:*', allUpdatesHandler)
             eventEmitter.emitVariableEvaluated(evaluatedVariable)
-            expect(allUpdatesHandler).toBeCalledWith(evaluatedVariable)
+            expect(allUpdatesHandler).toBeCalledWith(
+                evaluatedVariable.key,
+                evaluatedVariable
+            )
         })
         it('should emit variable evaluated event if subscribed to specific variable evaluations', () => {
             const allUpdatesHandler = jest.fn()
@@ -117,7 +120,10 @@ describe('EventEmitter tests', () => {
                 allUpdatesHandler
             )
             eventEmitter.emitVariableEvaluated(evaluatedVariable)
-            expect(allUpdatesHandler).toBeCalledWith(evaluatedVariable)
+            expect(allUpdatesHandler).toBeCalledWith(
+                evaluatedVariable.key,
+                evaluatedVariable
+            )
         })
         it('should not emit variable evaluated event if not subscribed to specific variable key', () => {
             const allUpdatesHandler = jest.fn()
@@ -132,7 +138,10 @@ describe('EventEmitter tests', () => {
                 allUpdatesHandler
             )
             eventEmitter.emitVariableEvaluated(evaluatedVariable)
-            expect(allUpdatesHandler).not.toBeCalledWith(evaluatedVariable)
+            expect(allUpdatesHandler).not.toBeCalledWith(
+                evaluatedVariable.key,
+                evaluatedVariable
+            )
         })
         it('should not emit variable evaluated events if not subscribed to variable evaluations', () => {
             const allUpdatesHandler = jest.fn()
@@ -143,7 +152,10 @@ describe('EventEmitter tests', () => {
                 type: 'my-type',
             }
             eventEmitter.emitVariableEvaluated(evaluatedVariable)
-            expect(allUpdatesHandler).not.toBeCalledWith(evaluatedVariable)
+            expect(allUpdatesHandler).not.toBeCalledWith(
+                evaluatedVariable.key,
+                evaluatedVariable
+            )
         })
     })
 

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -29,7 +29,7 @@ import { StreamingConnection } from './StreamingConnection'
 
 type variableUpdatedHandler = (
     key: string,
-    variable: DVCVariable<DVCVariableValue>
+    variable: DVCVariable<DVCVariableValue> | null
 ) => void
 type featureUpdatedHandler = (key: string, feature: DVCFeature | null) => void
 type newVariablesHandler = () => void

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -36,6 +36,10 @@ type newVariablesHandler = () => void
 type errorHandler = (error: unknown) => void
 type initializedHandler = (success: boolean) => void
 type configUpdatedHandler = (newVars: DVCVariableSet) => void
+type variableEvaluatedHandler = (
+    key: string,
+    variable: DVCVariable<DVCVariableValue> | null
+) => void
 
 export class DVCClient implements Client {
     private options: DVCOptions
@@ -337,6 +341,10 @@ export class DVCClient implements Client {
     subscribe(
         key: `featureUpdated:${string}`,
         handler: featureUpdatedHandler
+    ): void
+    subscribe(
+        key: `variableEvaluated:${string}`,
+        handler: variableEvaluatedHandler
     ): void
     subscribe(key: 'error', handler: errorHandler): void
     subscribe(key: 'initialized', handler: initializedHandler): void

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -29,7 +29,7 @@ import { StreamingConnection } from './StreamingConnection'
 
 type variableUpdatedHandler = (
     key: string,
-    variable: DVCVariable<DVCVariableValue> | null
+    variable: DVCVariable<DVCVariableValue>
 ) => void
 type featureUpdatedHandler = (key: string, feature: DVCFeature | null) => void
 type newVariablesHandler = () => void
@@ -38,7 +38,7 @@ type initializedHandler = (success: boolean) => void
 type configUpdatedHandler = (newVars: DVCVariableSet) => void
 type variableEvaluatedHandler = (
     key: string,
-    variable: DVCVariable<DVCVariableValue> | null
+    variable: DVCVariable<DVCVariableValue>
 ) => void
 
 export class DVCClient implements Client {

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -88,8 +88,12 @@ export class EventEmitter {
     }
 
     emitVariableEvaluated(variable: DVCVariable<any>): void {
-        this.emit(`${EventNames.VARIABLE_EVALUATED}:*`, variable)
-        this.emit(`${EventNames.VARIABLE_EVALUATED}:${variable.key}`, variable)
+        this.emit(`${EventNames.VARIABLE_EVALUATED}:*`, variable.key, variable)
+        this.emit(
+            `${EventNames.VARIABLE_EVALUATED}:${variable.key}`,
+            variable.key,
+            variable
+        )
     }
 
     emitVariableUpdates(

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -197,7 +197,7 @@ export interface DVCClient {
      *  - `featureUpdated:*` -> (key: string, feature: DVCFeature)
      *  - `featureUpdated:<feature.key>` -> (key: string, feature: DVCFeature)
      *  - `variableEvaluated:*` -> (key: string, variable: DVCVariable)
-     *  - `variableEvaluated:<varable.key>` -> (key: string, variable: DVCVariable)
+     *  - `variableEvaluated:<variable.key>` -> (key: string, variable: DVCVariable)
      *
      * @param key
      * @param onUpdate

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -4,7 +4,7 @@ import {
     VariableTypeAlias,
     VariableValue,
     DVCJSON,
-    DVCCustomDataJSON
+    DVCCustomDataJSON,
 } from '@devcycle/types'
 
 export type DVCVariableValue = VariableValue
@@ -16,9 +16,12 @@ export interface ErrorCallback<T> {
 }
 
 export type DVCVariableSet = {
-    [key: string]: Pick<DVCVariable<DVCVariableValue>, 'key' | 'value' | 'evalReason'> & {
-        '_id': string,
-        'type': string
+    [key: string]: Pick<
+        DVCVariable<DVCVariableValue>,
+        'key' | 'value' | 'evalReason'
+    > & {
+        _id: string
+        type: string
     }
 }
 
@@ -158,13 +161,8 @@ export interface DVCClient {
      * @param user
      * @param callback
      */
-    identifyUser(
-        user: DVCUser
-    ): Promise<DVCVariableSet>
-    identifyUser(
-        user: DVCUser,
-        callback: ErrorCallback<DVCVariableSet>
-    ): void
+    identifyUser(user: DVCUser): Promise<DVCVariableSet>
+    identifyUser(user: DVCUser, callback: ErrorCallback<DVCVariableSet>): void
 
     /**
      * Resets the user to an Anonymous user. `callback` or `Promise` can be used to return the
@@ -172,11 +170,8 @@ export interface DVCClient {
      *
      * @param callback
      */
-    resetUser(
-    ): Promise<DVCVariableSet>
-    resetUser(
-        callback: ErrorCallback<DVCVariableSet>
-    ): void
+    resetUser(): Promise<DVCVariableSet>
+    resetUser(callback: ErrorCallback<DVCVariableSet>): void
 
     /**
      * Retrieve all data on all Features, Object mapped by feature `key`.
@@ -201,6 +196,8 @@ export interface DVCClient {
      *  - `variableUpdated:<variable.key>` -> (key: string, variable: DVCVariable)
      *  - `featureUpdated:*` -> (key: string, feature: DVCFeature)
      *  - `featureUpdated:<feature.key>` -> (key: string, feature: DVCFeature)
+     *  - `variableEvaluated:*` -> (key: string, variable: DVCVariable)
+     *  - `variableEvaluated:<varable.key>` -> (key: string, variable: DVCVariable)
      *
      * @param key
      * @param onUpdate
@@ -316,7 +313,7 @@ export interface DVCStorage {
     /**
      * Get a value from the cache store
      * @param key
-    */
+     */
     load<T>(key: string): Promise<T | undefined>
 
     /**
@@ -337,6 +334,6 @@ type DeviceInfo = {
     getModel: () => string
 }
 declare global {
-   // eslint-disable-next-line no-var
-  var DeviceInfo: DeviceInfo | undefined
+    // eslint-disable-next-line no-var
+    var DeviceInfo: DeviceInfo | undefined
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8577,7 +8577,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
+  checksum: 510fc8e0828011e2257c1d4dc7fd236a8428f7f0869f59aaa0e74d8a27f9bbbc665ba74399faf466c87bcfe6fd694cd714cb130646476062bcee19c12cfc3243
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Noticed that variableUpdated was passing the key and the variable object to the handler so did the same with variableEvaluated, also updated the subscribe overrides and the accompanying jsdocs.