### PR TITLE
add variableValue() method to NodeJS Local / Cloud + JS SDK

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,19 @@
                 "after": true,
                 "overrides": { "colon": { "before": false }}
             }],
-            "@typescript-eslint/explicit-module-boundary-types": ["error"]
+            "@typescript-eslint/explicit-module-boundary-types": ["error"],
+            "@typescript-eslint/indent": [
+                "error",
+                4,
+                {
+                    "ignoredNodes": [
+                        "FunctionExpression > .params[decorators.length > 0]",
+                        "FunctionExpression > .params > :matches(Decorator, :not(:first-child))",
+                        "ClassBody.body > PropertyDefinition[decorators.length > 0] > .key"
+                    ],
+                    "SwitchCase": 1
+                }
+            ]
         }
     },
     {

--- a/examples/js/web-elements-app/src/app/app.element.ts
+++ b/examples/js/web-elements-app/src/app/app.element.ts
@@ -15,12 +15,12 @@ export class AppElement extends HTMLElement {
     ]
 
     updateInnerHTML(): void {
-        const titleVariable = client.variable('titlevariable', 'Welcome 👋')
-        const variableKey = client.variable('feature-release', true)
-        const variableKeyString = client.variable('variable-key-string', 'default')
-        const variableKeyNumber = client.variable('variable-key-number', 100)
-        const variableKeyBoolean = client.variable('variable-key-boolean', true)
-        const variableKeyJsonString = client.variable('variable-json-key-string', { 'jsonStringKeyDefault': 'json default' })
+        const titleVariable = client.variableValue('titlevariable', 'Welcome 👋')
+        const variableKey = client.variableValue('feature-release', true)
+        const variableKeyString = client.variableValue('variable-key-string', 'default')
+        const variableKeyNumber = client.variableValue('variable-key-number', 100)
+        const variableKeyBoolean = client.variableValue('variable-key-boolean', true)
+        const variableKeyJsonString = client.variableValue('variable-json-key-string', { 'jsonStringKeyDefault': 'json default' })
 
         this.innerHTML =  `
           <div class="wrapper">
@@ -29,7 +29,7 @@ export class AppElement extends HTMLElement {
               <div id="welcome">
                 <h1>
                   <span> Hello there, </span>
-                  ${titleVariable.value}
+                  ${titleVariable}
                 </h1>
               </div>
               <div id="variableKey">
@@ -40,31 +40,31 @@ export class AppElement extends HTMLElement {
               <div id="variableKey">
               <h1>
                 <span>variable feature-release = </span>
-                ${JSON.stringify(variableKey.value)}
+                ${JSON.stringify(variableKey)}
               </h1>
             </div>
               <div id="variableKeyString">
                 <h1>
                   <span>variable variable-key-string = </span>
-                  ${JSON.stringify(variableKeyString.value)}
+                  ${JSON.stringify(variableKeyString)}
                 </h1>
               </div>
               <div id="variableKeyNumber">
                 <h1>
                   <span>variable variable-key-number = </span>
-                  ${JSON.stringify(variableKeyNumber.value)}
+                  ${JSON.stringify(variableKeyNumber)}
                 </h1>
               </div>
               <div id="variableKeyBoolean">
                 <h1>
                   <span>variable variable-key-boolean = </span>
-                  ${JSON.stringify(variableKeyBoolean.value)}
+                  ${JSON.stringify(variableKeyBoolean)}
                 </h1>
               </div>
               <div id="variableKeyJsonString">
               <h1>
               <span>variable variable-json-key-string = </span>
-                ${JSON.stringify(variableKeyJsonString.value)}
+                ${JSON.stringify(variableKeyJsonString)}
               </h1>
             </div>
 

--- a/examples/nodejs-cloud/js/src/main.js
+++ b/examples/nodejs-cloud/js/src/main.js
@@ -2,22 +2,11 @@ const DVC = require('@devcycle/nodejs-server-sdk')
 const express = require('express')
 const bodyParser = require('body-parser')
 
-const app = express()
-const port = 5000
-const defaultHeaders = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Access-Control-Allow-Origin, Content-Type',
-    'Access-Control-Allow-Methods': 'GET, OPTIONS'
-}
-
-app.use(bodyParser.urlencoded({ extended: false }))
-app.use(bodyParser.json())
-
+const DVC_SERVER_SDK_KEY = process.env['DVC_SERVER_SDK_KEY'] || '<YOUR_DVC_SERVER_SDK_KEY>'
 let dvcClient
 
 async function startDVC() {
-    dvcClient = DVC.initialize('<DVC_SERVER_SDK_KEY>', { logLevel: 'info', enableCloudBucketing: true })
+    dvcClient = DVC.initialize(DVC_SERVER_SDK_KEY, { logLevel: 'info', enableCloudBucketing: true })
     console.log('DVC Cloud Bucketing JS Client Ready')
 
     const user = {
@@ -25,8 +14,8 @@ async function startDVC() {
         country: 'CA'
     }
 
-    const partyTime = await dvcClient.variable(user, 'elliot-test', false)
-    if (partyTime.value) {
+    const partyTime = await dvcClient.variableValue(user, 'elliot-test', false)
+    if (partyTime) {
         const invitation = dvcClient.variable(
             user,
             'invitation-message',
@@ -46,8 +35,8 @@ async function startDVC() {
         }
     }
 
-    const defaultVariable = dvcClient.variable(user, 'noWay-thisisA-realKEY', true)
-    console.log(`Value of the variable is ${defaultVariable.value} \n`)
+    const defaultVariable = dvcClient.variableValue(user, 'noWay-thisisA-realKEY', true)
+    console.log(`Value of the variable is ${defaultVariable} \n`)
     const variables = await dvcClient.allVariables(user)
     console.log('Variables: ')
     console.dir(variables)
@@ -57,6 +46,18 @@ async function startDVC() {
 }
 
 startDVC()
+
+const app = express()
+const port = 5000
+const defaultHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Access-Control-Allow-Origin, Content-Type',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS'
+}
+
+app.use(bodyParser.urlencoded({ extended: false }))
+app.use(bodyParser.json())
 
 function createUserFromQueryParams(queryParams) {
     let user = {}

--- a/examples/nodejs-local/js/src/main.js
+++ b/examples/nodejs-local/js/src/main.js
@@ -3,19 +3,6 @@ const express = require('express')
 const bodyParser = require('body-parser')
 
 const DVC_SERVER_SDK_KEY = process.env['DVC_SERVER_SDK_KEY'] || '<YOUR_DVC_SERVER_SDK_KEY>'
-
-const app = express()
-const port = 5000
-const defaultHeaders = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Access-Control-Allow-Origin, Content-Type',
-    'Access-Control-Allow-Methods': 'GET, OPTIONS'
-}
-
-app.use(bodyParser.urlencoded({ extended: false }))
-app.use(bodyParser.json())
-
 let dvcClient
 
 async function startDVC() {
@@ -27,8 +14,8 @@ async function startDVC() {
         country: 'CA'
     }
 
-    const partyTime = dvcClient.variable(user, 'elliot-test', false)
-    if (partyTime.value) {
+    const partyTime = dvcClient.variableValue(user, 'elliot-test', false)
+    if (partyTime) {
         const invitation = dvcClient.variable(
             user,
             'invitation-message',
@@ -48,8 +35,8 @@ async function startDVC() {
         }
     }
 
-    const defaultVariable = dvcClient.variable(user, 'noWay-thisisA-realKEY', true)
-    console.log(`Value of the variable is ${defaultVariable.value} \n`)
+    const defaultVariable = dvcClient.variableValue(user, 'noWay-thisisA-realKEY', true)
+    console.log(`Value of the variable is ${defaultVariable} \n`)
     const variables = dvcClient.allVariables(user)
     console.log('Variables: ')
     console.dir(variables)
@@ -59,6 +46,18 @@ async function startDVC() {
 }
 
 startDVC()
+
+const app = express()
+const port = 5000
+const defaultHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Access-Control-Allow-Origin, Content-Type',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS'
+}
+
+app.use(bodyParser.urlencoded({ extended: false }))
+app.use(bodyParser.json())
 
 function createUserFromQueryParams(queryParams) {
     let user = {}

--- a/examples/nodejs-local/typescript/src/main.ts
+++ b/examples/nodejs-local/typescript/src/main.ts
@@ -7,7 +7,6 @@ import bodyParser from 'body-parser'
 import { benchDVC } from './benchmarkDVC'
 
 const DVC_SERVER_SDK_KEY = process.env['DVC_SERVER_SDK_KEY'] || '<YOUR_DVC_SERVER_SDK_KEY>'
-
 let dvcClient: DVCClient
 
 async function startDVC() {
@@ -19,8 +18,8 @@ async function startDVC() {
         country: 'CA'
     }
 
-    const partyTime = dvcClient.variable(user, 'party-time', false)
-    if (partyTime.value) {
+    const partyTime = dvcClient.variableValue(user, 'party-time', false)
+    if (partyTime) {
         const invitation = dvcClient.variable(
             user,
             'invitation-message',
@@ -40,8 +39,8 @@ async function startDVC() {
         }
     }
 
-    const defaultVariable = dvcClient.variable(user, 'not-real', true)
-    console.log(`Value of the variable is ${defaultVariable.value} \n`)
+    const defaultVariable = dvcClient.variableValue(user, 'not-real', true)
+    console.log(`Value of the variable is ${defaultVariable} \n`)
     const variables = dvcClient.allVariables(user)
     console.log('Variables: ')
     console.dir(variables)

--- a/lib/shared/types/src/types/config/models/variable.ts
+++ b/lib/shared/types/src/types/config/models/variable.ts
@@ -43,7 +43,7 @@ export type DVCJSON = { [key: string]: string | boolean | number }
 export type VariableValue = string | boolean | number | DVCJSON
 
 type UnionToIntersection<U> =
-    (U extends any ? (k: U)=>void : never) extends ((k: infer I)=>void) ? I : never
+    (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
 type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
 
 // alias to resolve a generic type constrained by `VariableValue` back into its original type

--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -240,6 +240,7 @@ describe('DVCClient tests', () => {
             client = createClientWithDelay(0)
             await client.onClientInitialized()
             const variable = client.variable('key', 'default_value')
+            expect(client.variableValue('key', 'default_value')).toBe('value1')
             expect(variable.value).toBe('value1')
             expect(variable.defaultValue).toBe('default_value')
         })
@@ -248,6 +249,7 @@ describe('DVCClient tests', () => {
             client = createClientWithDelay(0)
             await client.onClientInitialized()
             const variable = client.variable('key', false)
+            expect(client.variableValue('key', false)).toBe(false)
             expect(variable.value).toBe(false)
             expect(variable.defaultValue).toBe(false)
         })
@@ -258,6 +260,7 @@ describe('DVCClient tests', () => {
             })
             await client.onClientInitialized()
             const variable = client.variable('key', 'default_value')
+            expect(client.variableValue('key', 'default_value')).toBe('default_value')
             expect(variable.value).toBe('default_value')
             expect(variable.defaultValue).toBe('default_value')
         })
@@ -272,11 +275,15 @@ describe('DVCClient tests', () => {
             client.variable('key', 'default_value')
             expect(Object.values(client.variableDefaultMap['key']).length).toBe(1)
             expect(client.variableDefaultMap['key']['default_value']).toEqual(variable)
+            client.variableValue('key', 'default_value')
+            expect(Object.values(client.variableDefaultMap['key']).length).toBe(1)
+            expect(client.variableDefaultMap['key']['default_value']).toEqual(variable)
         })
 
         it('should have no value and default value if config not done fetching', () => {
             client = createClientWithDelay(500)
             const variable = client.variable('key', 'default_value')
+            expect(client.variableValue('key', 'default_value')).toBe('default_value')
             expect(variable.value).toBe('default_value')
             expect(variable.defaultValue).toBe('default_value')
         })
@@ -350,7 +357,6 @@ describe('DVCClient tests', () => {
             expect(variable.value).toEqual(cachedConfig.variables.key.value)
             expect(onUpdate).toBeCalledTimes(1)
         })
-
     })
 
     describe('identifyUser', () => {

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -43,13 +43,13 @@ type variableEvaluatedHandler = (
 ) => void
 
 export class DVCClient<
-  Variables extends VariableDefinitions = VariableDefinitions
+    Variables extends VariableDefinitions = VariableDefinitions
 > implements Client<Variables> {
     private options: DVCOptions
     private onInitialized: Promise<DVCClient<Variables>>
     private variableDefaultMap: {
-    [key: string]: { [key: string]: DVCVariable<any> };
-  }
+        [key: string]: { [key: string]: DVCVariable<any> };
+    }
     private sdkKey: string
     private userSaved = false
     private _closing = false
@@ -69,7 +69,7 @@ export class DVCClient<
 
     constructor(sdkKey: string, user: DVCUser, options: DVCOptions = {}) {
         this.logger =
-      options.logger || dvcDefaultLogger({ level: options.logLevel })
+            options.logger || dvcDefaultLogger({ level: options.logLevel })
         this.store = new CacheStore(
             options.storage || new DefaultStorage(),
             this.logger
@@ -152,9 +152,9 @@ export class DVCClient<
     }
 
     variable<
-    K extends string & keyof Variables,
-    T extends DVCVariableValue & Variables[K]
-  >(key: K, defaultValue: T): DVCVariable<T> {
+        K extends string & keyof Variables,
+        T extends DVCVariableValue & Variables[K]
+    >(key: K, defaultValue: T): DVCVariable<T> {
         if (defaultValue === undefined || defaultValue === null) {
             throw new Error('Default value is a required param')
         }
@@ -167,19 +167,16 @@ export class DVCClient<
             true
         )
 
-        const defaultValueKey =
-      typeof defaultValue === 'string'
-          ? defaultValue
-          : JSON.stringify(defaultValue)
+        const defaultValueKey = typeof defaultValue === 'string'
+            ? defaultValue
+            : JSON.stringify(defaultValue)
 
         let variable
         if (
             this.variableDefaultMap[key] &&
-      this.variableDefaultMap[key][defaultValueKey]
+            this.variableDefaultMap[key][defaultValueKey]
         ) {
-            variable = this.variableDefaultMap[key][
-                defaultValueKey
-            ] as DVCVariable<T>
+            variable = this.variableDefaultMap[key][defaultValueKey] as DVCVariable<T>
         } else {
             const configVariable = this.config?.variables?.[key]
 
@@ -232,6 +229,13 @@ export class DVCClient<
 
         this.eventEmitter.emitVariableEvaluated(variable)
         return variable
+    }
+
+    variableValue<
+        K extends string & keyof Variables,
+        T extends DVCVariableValue & Variables[K]
+    >(key: K, defaultValue: T): VariableTypeAlias<T> {
+        return this.variable(key, defaultValue).value
     }
 
     identifyUser(user: DVCUser): Promise<DVCVariableSet>

--- a/sdk/js/src/User.ts
+++ b/sdk/js/src/User.ts
@@ -4,7 +4,7 @@ import packageJson from '../package.json'
 import UAParser from 'ua-parser-js'
 
 type StaticData = Pick<DVCPopulatedUser, 'createdDate' | 'platform' |
-    'platformVersion' | 'deviceModel' | 'sdkType' | 'sdkVersion'>
+'platformVersion' | 'deviceModel' | 'sdkType' | 'sdkVersion'>
 
 export class DVCPopulatedUser implements DVCUser {
     readonly isAnonymous: boolean

--- a/sdk/js/src/User.ts
+++ b/sdk/js/src/User.ts
@@ -4,7 +4,7 @@ import packageJson from '../package.json'
 import UAParser from 'ua-parser-js'
 
 type StaticData = Pick<DVCPopulatedUser, 'createdDate' | 'platform' |
-'platformVersion' | 'deviceModel' | 'sdkType' | 'sdkVersion'>
+    'platformVersion' | 'deviceModel' | 'sdkType' | 'sdkVersion'>
 
 export class DVCPopulatedUser implements DVCUser {
     readonly isAnonymous: boolean

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -16,10 +16,7 @@ export interface ErrorCallback<T> {
 }
 
 export type DVCVariableSet = {
-    [key: string]: Pick<
-    DVCVariable<DVCVariableValue>,
-    'key' | 'value' | 'evalReason'
-    > & {
+    [key: string]: Pick<DVCVariable<DVCVariableValue>, 'key' | 'value' | 'evalReason'> & {
         _id: string
         type: string
     }

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -17,8 +17,8 @@ export interface ErrorCallback<T> {
 
 export type DVCVariableSet = {
     [key: string]: Pick<
-        DVCVariable<DVCVariableValue>,
-        'key' | 'value' | 'evalReason'
+    DVCVariable<DVCVariableValue>,
+    'key' | 'value' | 'evalReason'
     > & {
         _id: string
         type: string

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -36,10 +36,6 @@ describe('variable', () => {
             private: 'private'
         }
     }
-    const expectedUser = expect.objectContaining({
-        user_id: 'node_sdk_test',
-        country: 'CA'
-    })
 
     let client: DVCClient
 
@@ -58,12 +54,16 @@ describe('variable', () => {
         const variable = client.variable(user, 'test-key', false)
         expect(variable.value).toEqual(true)
         expect(variable.type).toEqual('Boolean')
+
+        expect(client.variableValue(user, 'test-key', false)).toEqual(true)
     })
 
     it('returns a valid variable object for a variable that is in the config with a DVCUser instance', () => {
         const dvcUser = new DVCUser(user)
         const variable = client.variable(dvcUser, 'test-key', false)
         expect(variable.value).toEqual(true)
+
+        expect(client.variableValue(dvcUser, 'test-key', false)).toEqual(true)
     })
 
     it('returns a valid variable object for a variable that is not in the config', () => {
@@ -72,6 +72,10 @@ describe('variable', () => {
         const variable = client.variable(user, 'test-key2', false)
         expect(variable.value).toEqual(false)
         expect(variable.isDefaulted).toEqual(true)
+
+        // @ts-ignore
+        getBucketingLib().variableForUser_PB.mockReturnValueOnce(null)
+        expect(client.variableValue(user, 'test-key2', false)).toEqual(false)
     })
 
     it('returns a defaulted variable object for a variable that is in the config but the wrong type', () => {
@@ -80,6 +84,8 @@ describe('variable', () => {
         const variable = client.variable(user, 'test-key', 'test')
         expect(variable.value).toEqual('test')
         expect(variable.isDefaulted).toEqual(true)
+
+        expect(client.variableValue(user, 'test-key', 'test')).toEqual('test')
     })
 
     it('returns a variable with the correct type for string', () => {
@@ -91,6 +97,8 @@ describe('variable', () => {
         // should allow assignment to different string
         variable.value = 'test2'
         expect(variable.type).toEqual('String')
+
+        expect(client.variableValue(user, 'test-key', 'test')).toEqual('test')
     })
 
     it('returns a variable with the correct type for number', () => {
@@ -99,6 +107,8 @@ describe('variable', () => {
         expect(variable.type).toBe('Number')
         // this will be a type error for non-numbers
         variable.value.toFixed()
+
+        expect(client.variableValue(user, 'test-key', 1)).toEqual(1)
     })
 
     it('returns a variable with the correct type for JSON', () => {
@@ -106,79 +116,7 @@ describe('variable', () => {
         expect(variable.value).toBeInstanceOf(Object)
         expect(variable.type).toBe('JSON')
         expect(variable.value).toEqual({ key: 'test' })
-    })
-})
 
-describe('variableValue', () => {
-    const user = {
-        user_id: 'node_sdk_test',
-        country: 'CA',
-        customData: {
-            test: 'test',
-            canBeNull: null
-        },
-        privateCustomData: {
-            private: 'private'
-        }
-    }
-    const expectedUser = expect.objectContaining({
-        user_id: 'node_sdk_test',
-        country: 'CA'
-    })
-
-    let client: DVCClient
-
-    beforeAll(async () => {
-        client = new DVCClient('token')
-        await client.onClientInitialized()
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        client.eventQueue.queueAggregateEvent = jest.fn()
-    })
-    beforeEach(() => {
-        jest.clearAllMocks()
-    })
-
-    it('returns a valid variable object for a variable that is in the config', () => {
-        expect(client.variableValue(user, 'test-key', false)).toEqual(true)
-    })
-
-    it('returns a valid variable object for a variable that is in the config with a DVCUser instance', () => {
-        const dvcUser = new DVCUser(user)
-        expect(client.variableValue(dvcUser, 'test-key', false)).toEqual(true)
-    })
-
-    it('returns a valid variable object for a variable that is not in the config', () => {
-        // @ts-ignore
-        getBucketingLib().variableForUser_PB.mockReturnValueOnce(null)
-        expect(client.variableValue(user, 'test-key2', false)).toEqual(false)
-    })
-
-    it('returns a defaulted variable object for a variable that is in the config but the wrong type', () => {
-        // @ts-ignore
-        getBucketingLib().variableForUser.mockReturnValueOnce(null)
-        expect(client.variableValue(user, 'test-key', 'test')).toEqual('test')
-    })
-
-    it('returns a variable with the correct type for string', () => {
-        let value = client.variableValue(user, 'test-key', 'test')
-        expect(typeof value).toEqual('string')
-        // this will be a type error for non-strings
-        value.concat()
-        // should allow assignment to different string
-        value = 'test2'
-    })
-
-    it('returns a variable with the correct type for number', () => {
-        const value = client.variableValue(user, 'test-key', 1)
-        expect(typeof value).toEqual('number')
-        // this will be a type error for non-numbers
-        value.toFixed()
-    })
-
-    it('returns a variable with the correct type for JSON', () => {
-        const value = client.variableValue(user, 'test-key', { key: 'test' })
-        expect(value).toBeInstanceOf(Object)
-        expect(value).toEqual({ key: 'test' })
+        expect(client.variableValue(user, 'test-key', { key: 'test' })).toEqual({ key: 'test' })
     })
 })

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -108,3 +108,77 @@ describe('variable', () => {
         expect(variable.value).toEqual({ key: 'test' })
     })
 })
+
+describe('variableValue', () => {
+    const user = {
+        user_id: 'node_sdk_test',
+        country: 'CA',
+        customData: {
+            test: 'test',
+            canBeNull: null
+        },
+        privateCustomData: {
+            private: 'private'
+        }
+    }
+    const expectedUser = expect.objectContaining({
+        user_id: 'node_sdk_test',
+        country: 'CA'
+    })
+
+    let client: DVCClient
+
+    beforeAll(async () => {
+        client = new DVCClient('token')
+        await client.onClientInitialized()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        client.eventQueue.queueAggregateEvent = jest.fn()
+    })
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('returns a valid variable object for a variable that is in the config', () => {
+        expect(client.variableValue(user, 'test-key', false)).toEqual(true)
+    })
+
+    it('returns a valid variable object for a variable that is in the config with a DVCUser instance', () => {
+        const dvcUser = new DVCUser(user)
+        expect(client.variableValue(dvcUser, 'test-key', false)).toEqual(true)
+    })
+
+    it('returns a valid variable object for a variable that is not in the config', () => {
+        // @ts-ignore
+        getBucketingLib().variableForUser_PB.mockReturnValueOnce(null)
+        expect(client.variableValue(user, 'test-key2', false)).toEqual(false)
+    })
+
+    it('returns a defaulted variable object for a variable that is in the config but the wrong type', () => {
+        // @ts-ignore
+        getBucketingLib().variableForUser.mockReturnValueOnce(null)
+        expect(client.variableValue(user, 'test-key', 'test')).toEqual('test')
+    })
+
+    it('returns a variable with the correct type for string', () => {
+        let value = client.variableValue(user, 'test-key', 'test')
+        expect(typeof value).toEqual('string')
+        // this will be a type error for non-strings
+        value.concat()
+        // should allow assignment to different string
+        value = 'test2'
+    })
+
+    it('returns a variable with the correct type for number', () => {
+        const value = client.variableValue(user, 'test-key', 1)
+        expect(typeof value).toEqual('number')
+        // this will be a type error for non-numbers
+        value.toFixed()
+    })
+
+    it('returns a variable with the correct type for JSON', () => {
+        const value = client.variableValue(user, 'test-key', { key: 'test' })
+        expect(value).toBeInstanceOf(Object)
+        expect(value).toEqual({ key: 'test' })
+    })
+})

--- a/sdk/nodejs/__tests__/cloudClient.spec.ts
+++ b/sdk/nodejs/__tests__/cloudClient.spec.ts
@@ -32,6 +32,8 @@ describe('DVCCloudClient without EdgeDB', () => {
             expect(res.isDefaulted).toBe(false)
             expect(res.key).not.toContain('edgedb')
             expect(res.type).toEqual('Boolean')
+
+            await expect(client.variableValue(user, 'test-key', false)).resolves.toBe(true)
         })
 
         it('to return default if type doesnt align with the type of defaultValue', async () => {
@@ -40,6 +42,8 @@ describe('DVCCloudClient without EdgeDB', () => {
             expect(res.isDefaulted).toBe(true)
             expect(res.key).not.toContain('edgedb')
             expect(res.type).toEqual('String')
+
+            await expect(client.variableValue(user, 'test-key', 'string')).resolves.toBe('string')
         })
 
         it('to return the Default Value and be defaulted', async () => {
@@ -47,15 +51,21 @@ describe('DVCCloudClient without EdgeDB', () => {
             expect(res.value).toBe(false)
             expect(res.isDefaulted).toBe(true)
             expect(res.type).toEqual('Boolean')
+
+            await expect(client.variableValue(user, 'test-key-not-in-config', false)).resolves.toBe(false)
         })
 
         it('to throw an error if key is not defined', async () => {
             try {
                 await client.variable(user, undefined as unknown as string, false)
             } catch (ex) {
-                expect(ex.message).toBe(
-                    'Missing parameter: key'
-                )
+                expect(ex.message).toBe('Missing parameter: key')
+            }
+
+            try {
+                await client.variableValue(user, undefined as unknown as string, false)
+            } catch (ex) {
+                expect(ex.message).toBe('Missing parameter: key')
             }
         })
 
@@ -63,9 +73,13 @@ describe('DVCCloudClient without EdgeDB', () => {
             try {
                 await client.variable(user, 'test-key', undefined as unknown as string)
             } catch (ex) {
-                expect(ex.message).toBe(
-                    'Missing parameter: defaultValue'
-                )
+                expect(ex.message).toBe('Missing parameter: defaultValue')
+            }
+
+            try {
+                await client.variableValue(user, 'test-key', undefined as unknown as string)
+            } catch (ex) {
+                expect(ex.message).toBe('Missing parameter: defaultValue')
             }
         })
 
@@ -73,6 +87,8 @@ describe('DVCCloudClient without EdgeDB', () => {
             const res = await client.variable(respond500User, 'test-key', false)
             expect(res.value).toBe(false)
             expect(res.isDefaulted).toBe(true)
+
+            await expect(client.variableValue(respond500User, 'test-key', false)).resolves.toBe(false)
         })
     })
 
@@ -198,9 +214,11 @@ describe('DVCCloudClient with EdgeDB Enabled', () => {
     describe('variable', () => {
         it('to return a Value and not be defaulted', async () => {
             const res = await client.variable(user, 'test-key', false)
-            expect(res.key).toContain('edgedb')
+            expect(res.key).toContain('test-key')
             expect(res.value).toBe(true)
             expect(res.isDefaulted).toBe(false)
+
+            await expect(client.variableValue(user, 'test-key', false)).resolves.toBe(true)
         })
 
         it('to return the Default Value and be defaulted', async () => {
@@ -208,15 +226,21 @@ describe('DVCCloudClient with EdgeDB Enabled', () => {
             expect(res.key).not.toContain('edgedb')
             expect(res.value).toBe(false)
             expect(res.isDefaulted).toBe(true)
+
+            await expect(client.variableValue(user, 'test-key-not-in-config', false)).resolves.toBe(false)
         })
 
         it('to throw an error if key is not defined', async () => {
             try {
                 await client.variable(user, undefined as unknown as string, false)
             } catch (ex) {
-                expect(ex.message).toBe(
-                    'Missing parameter: key'
-                )
+                expect(ex.message).toBe('Missing parameter: key')
+            }
+
+            try {
+                await client.variableValue(user, undefined as unknown as string, false)
+            } catch (ex) {
+                expect(ex.message).toBe('Missing parameter: key')
             }
         })
 
@@ -224,9 +248,13 @@ describe('DVCCloudClient with EdgeDB Enabled', () => {
             try {
                 await client.variable(user, 'test-key', undefined as unknown as string)
             } catch (ex) {
-                expect(ex.message).toBe(
-                    'Missing parameter: defaultValue'
-                )
+                expect(ex.message).toBe('Missing parameter: defaultValue')
+            }
+
+            try {
+                await client.variableValue(user, 'test-key', undefined as unknown as string)
+            } catch (ex) {
+                expect(ex.message).toBe('Missing parameter: defaultValue')
             }
         })
 
@@ -234,6 +262,8 @@ describe('DVCCloudClient with EdgeDB Enabled', () => {
             const res = await client.variable(respond500User, 'test-key', false)
             expect(res.value).toBe(false)
             expect(res.isDefaulted).toBe(true)
+
+            await expect(client.variableValue(respond500User, 'test-key', false)).resolves.toBe(false)
         })
     })
 

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -157,6 +157,10 @@ export class DVCClient {
         return new DVCVariable(options)
     }
 
+    variableValue<T extends DVCVariableValue>(user: DVCUser, key: string, defaultValue: T): VariableTypeAlias<T> {
+        return this.variable(user, key, defaultValue).value
+    }
+
     allVariables(user: DVCUser): DVCVariableSet {
         const incomingUser = castIncomingUser(user)
 


### PR DESCRIPTION
Adding `variableValue()` method to all our JS SDKs so that you can retrieve a variable's value without needing to do: `dvc.variable('key', true).value`