### PR TITLE
fix: enable inline sources to avoid parsing errors

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": false,
     "moduleResolution": "node16",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Addresses: https://github.com/DevCycleHQ/js-sdks/issues/488