### PR TITLE
[feat] add support for using devcycle in esm runtime

### DIFF
--- a/lib/shared/bucketing-assembly-script/index.js
+++ b/lib/shared/bucketing-assembly-script/index.js
@@ -11,7 +11,12 @@ const instantiate = async (debug = false, imports = {}) => {
             const source = await globalThis.fetch(url)
             return await globalThis.WebAssembly.compileStreaming(source)
         } catch {
-            const fs = require('node:fs/promises')
+            let fs
+            try {
+                fs = require('node:fs/promises')
+            } catch {
+                fs = require('fs/promises')
+            }
             return globalThis.WebAssembly.compile(await fs.readFile(url))
         }
     })()
@@ -27,5 +32,5 @@ const instantiate = async (debug = false, imports = {}) => {
 
 module.exports = {
     instantiate,
-    ProtobufTypes
+    ProtobufTypes,
 }


### PR DESCRIPTION
this allows for devcycle to be used in esm runtime as `node:fs/promises`  since this error is being thrown 

```
Error initializing DevCycle: UserError: Cannot find module 'node:fs/promises'
```