### PR TITLE
chore: allow caching for shared bucketing assemblyscript

### DIFF
--- a/lib/shared/bucketing-assembly-script/project.json
+++ b/lib/shared/bucketing-assembly-script/project.json
@@ -65,6 +65,8 @@
     },
     "compile-pb-js": {
       "executor": "@nrwl/workspace:run-commands",
+      "inputs": ["{projectRoot}/protobuf/*.proto"],
+      "outputs": ["lib/shared/bucketing-assembly-script/protobuf/compiled.js", "lib/shared/bucketing-assembly-script/protobuf/compiled.d.ts"],
       "options": {
           "commands": [
               {
@@ -82,7 +84,9 @@
       }
     },
     "compile-pb-as": {
-        "executor": "@nrwl/workspace:run-commands",
+      "executor": "@nrwl/workspace:run-commands",
+      "inputs": ["{projectRoot}/protobuf/*.proto"],
+      "outputs": ["lib/shared/bucketing-assembly-script/assembly/types/protobuf-generated"],
         "options": {
             "commands": [
                 {
@@ -101,8 +105,11 @@
     },
     "build": {
       "executor": "@nrwl/workspace:run-commands",
+      "inputs": [
+        "!{projectRoot}/build/**/*"
+      ],
       "outputs": [
-        "lib/shared/bucketing-assembly-script"
+        "lib/shared/bucketing-assembly-script/build"
       ],
       "options": {
         "commands": [

--- a/lib/shared/bucketing-test-data/project.json
+++ b/lib/shared/bucketing-test-data/project.json
@@ -29,6 +29,8 @@
     },
     "build:json": {
       "executor": "@nrwl/node:node",
+      "inputs": ["!{projectRoot}/json-data/**/*"],
+      "outputs": ["lib/shared/bucketing-test-data/json-data"],
       "options": {
         "buildTarget": "shared-bucketing-test-data:build",
         "watch": false

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,10 @@
           "lint",
           "check-types",
           "package",
-          "prepare"
+          "prepare",
+          "build:json",
+          "compile-pb-js",
+          "compile-pb-as"
         ],
         "parallel": 1
       }


### PR DESCRIPTION
improve Nx caching for bucketing lib related tasks

- correctly cache protobuf compilation
- cache build:json for test data
- allow assemblyscript lib to be cached by ignoring `build/` directory for input cache computation