### PR TITLE
fix: dont open streaming connection when EventSource is not available

### DIFF
--- a/sdk/js/src/StreamingConnection.ts
+++ b/sdk/js/src/StreamingConnection.ts
@@ -1,7 +1,7 @@
 import { DVCLogger } from '@devcycle/types'
 
 export class StreamingConnection {
-    private connection: EventSource
+    private connection?: EventSource
 
     constructor(
         private url: string,
@@ -12,6 +12,12 @@ export class StreamingConnection {
     }
 
     private openConnection() {
+        if (typeof EventSource === 'undefined') {
+            this.logger.warn(
+                'StreamingConnection not opened. EventSource is not available.',
+            )
+            return
+        }
         this.connection = new EventSource(this.url, { withCredentials: true })
         this.connection.onmessage = (event) => {
             this.onMessage(event.data)
@@ -27,7 +33,7 @@ export class StreamingConnection {
     }
 
     isConnected(): boolean {
-        return this.connection.readyState === this.connection.OPEN
+        return this.connection?.readyState === this.connection?.OPEN
     }
 
     reopen(): void {
@@ -38,6 +44,6 @@ export class StreamingConnection {
     }
 
     close(): void {
-        this.connection.close()
+        this.connection?.close()
     }
 }


### PR DESCRIPTION
- an error was previously being thrown when using the React SDK in Next while server rendering, because the EventSource did not exist on the serverside
- the SDK in general is supposed to be fine with running on the server and just log appropriate warnings
- this error wasn't seen before because it was being caught by the previous implementation inside the promise
- if EventSource is not defined, skip starting the streaming connection and log a warning.