### PR TITLE
fix: only return errorString when its defined

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -11,7 +11,7 @@ jobs:
             matrix:
                 node-version: [18.x]
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - name: Install protoc for protobuf compilation

--- a/examples/js/web-elements-app/src/main.ts
+++ b/examples/js/web-elements-app/src/main.ts
@@ -1,1 +1,1 @@
-import './app/app.element.ts'
+import './app/app.element'

--- a/sdk/js/src/Request.ts
+++ b/sdk/js/src/Request.ts
@@ -1,7 +1,7 @@
 import { DVCEvent, DVCOptions } from './types'
 import { DVCPopulatedUser } from './User'
 import { serializeUserSearchParams, generateEventPayload } from './utils'
-import axios, { AxiosRequestHeaders, AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import axiosRetry from 'axios-retry'
 import { BucketedUserConfig, DVCLogger } from '@devcycle/types'
 
@@ -106,13 +106,15 @@ export const getConfigJson = async (
         const res = await get(url)
         return res.data
     } catch (ex: any) {
-        const errorString = JSON.stringify(ex?.response?.data.data.errors)
+        const errorString = JSON.stringify(ex?.response?.data?.data?.errors)
         logger.error(
             `Request to get config failed for url: ${url}, ` +
-                `response message: ${ex.message}, response data: ${errorString}`,
+                `response message: ${ex.message}` +
+                (errorString ? `, response data: ${errorString}` : ''),
         )
         throw new Error(
-            `Failed to download DevCycle config. Error details: ${errorString}`,
+            `Failed to download DevCycle config.` +
+                (errorString ? ` Error details: ${errorString}` : ''),
         )
     }
 }


### PR DESCRIPTION
- add optional chaining to remove unwanted type errors
- fix: only return `errorString` when it's defined