### PR TITLE
fix: type generic arg on js client

### DIFF
--- a/lib/shared/types/src/types/config/models/variable.ts
+++ b/lib/shared/types/src/types/config/models/variable.ts
@@ -39,7 +39,9 @@ export enum VariableType {
 /**
  * Supported variable values
  */
-export type DVCJSON = { [key: string]: string | boolean | number }
+export type DVCJSON = {
+    [key: string]: string | boolean | number | DVCJSON | unknown[] | null
+}
 export type VariableValue = string | boolean | number | DVCJSON
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (

--- a/sdk/js/src/index.test.ts
+++ b/sdk/js/src/index.test.ts
@@ -1,0 +1,17 @@
+import { initialize } from './index'
+jest.mock('./Request')
+jest.mock('./StreamingConnection')
+
+type VariableTypes = {
+    some_key: string
+    my_array_json: { test: string[] }
+}
+
+describe('initialize', () => {
+    it('allows a generic to be passed to initialize', () => {
+        const client = initialize<VariableTypes>('test', { user_id: 'test' })
+        client.variableValue('my_array_json', { test: [] })
+        // @ts-expect-error - should not allow invalid variable keys
+        client.variableValue('bad-key', false)
+    })
+})

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -1,4 +1,4 @@
-import { DVCOptions, DVCUser } from './types'
+import { DVCOptions, DVCUser, VariableDefinitions } from './types'
 import {
     DVCClient,
     DVCOptionsWithDeferredInitialization,
@@ -7,20 +7,22 @@ import {
 
 export * from './types'
 
-export function initialize(
+export function initialize<
+    Variables extends VariableDefinitions = VariableDefinitions,
+>(
     sdkKey: string,
     options: DVCOptionsWithDeferredInitialization,
-): DVCClient
-export function initialize(
-    sdkKey: string,
-    user: DVCUser,
-    options?: DVCOptions,
-): DVCClient
-export function initialize(
+): DVCClient<Variables>
+export function initialize<
+    Variables extends VariableDefinitions = VariableDefinitions,
+>(sdkKey: string, user: DVCUser, options?: DVCOptions): DVCClient<Variables>
+export function initialize<
+    Variables extends VariableDefinitions = VariableDefinitions,
+>(
     sdkKey: string,
     userOrOptions: DVCUser | DVCOptionsWithDeferredInitialization,
     optionsArg: DVCOptions = {},
-): DVCClient {
+): DVCClient<Variables> {
     // TODO: implement logger
     if (typeof window === 'undefined') {
         console.warn(

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -39,20 +39,6 @@ export type DVCFeatureSet = {
     [key: string]: DVCFeature
 }
 
-/**
- * Initialize the SDK
- * @param sdkKey
- * @param user
- * @param options
- */
-export type initialize = <
-    Variables extends VariableDefinitions = VariableDefinitions,
->(
-    sdkKey: string,
-    user: DVCUser,
-    options?: DVCOptions,
-) => DVCClient<Variables>
-
 export interface DVCOptions {
     eventFlushIntervalMS?: number
     reactNative?: boolean

--- a/sdk/openfeature-nodejs-provider/src/DevCycleProvider.ts
+++ b/sdk/openfeature-nodejs-provider/src/DevCycleProvider.ts
@@ -166,7 +166,7 @@ export default class DevCycleProvider implements Provider {
 
         // Hard casting here because our DVCJSON typing enforces a flat object when we actually support
         // a JSON Object of any depth. Will be fixed soon.
-        return jsonValue as DVCJSON
+        return jsonValue
     }
 
     /**


### PR DESCRIPTION
- fix not being able to pass a type generic to the `initialize` call for the JS SDK
- fix the definition of DVCJSON to accurately reflect what the platform currently supports.