### PR TITLE
chore: patch nx js package to avoid adding devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 lerna-debug.log
 yarn-error.log
 .tmp/
+tmp/
 /.dockerignore
 .idea
 coverage

--- a/.yarn/patches/@nx-js-npm-16.3.2-a543eca792.patch
+++ b/.yarn/patches/@nx-js-npm-16.3.2-a543eca792.patch
@@ -1,0 +1,16 @@
+diff --git a/src/utils/package-json/update-package-json.js b/src/utils/package-json/update-package-json.js
+index 1190b046c4b3668afe1b824d48ee699689d2498e..9d26d8e5e789c9794e219d83d351e585b68ad19f 100644
+--- a/src/utils/package-json/update-package-json.js
++++ b/src/utils/package-json/update-package-json.js
+@@ -73,7 +73,11 @@ function addMissingDependencies(packageJson, { projectName, targetName, configur
+         else {
+             const packageName = entry.name;
+             if (!((_f = packageJson.dependencies) === null || _f === void 0 ? void 0 : _f[packageName]) &&
++                !((_f = packageJson.devDependencies) === null || _f === void 0 ? void 0 : _f[packageName]) &&
+                 !((_g = packageJson.peerDependencies) === null || _g === void 0 ? void 0 : _g[packageName])) {
++                if ((_d = workspacePackageJson.devDependencies) === null || _d === void 0 ? void 0 : _d[packageName]) {
++                    return;
++                }
+                 const outputs = (0, devkit_1.getOutputsForTargetAndConfiguration)({
+                     overrides: {},
+                     target: {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
         "moment": "^2.29.4",
         "terser-webpack-plugin": "^5.3.6",
         "nx": "16.3.2",
-        "@nrwl/devkit": "16.3.2"
+        "@nrwl/devkit": "16.3.2",
+        "@nx/js@16.3.2": "patch:@nx/js@npm%3A16.3.2#./.yarn/patches/@nx-js-npm-16.3.2-a543eca792.patch"
     },
     "config": {
         "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7052,6 +7052,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/js@patch:@nx/js@npm%3A16.3.2#./.yarn/patches/@nx-js-npm-16.3.2-a543eca792.patch::locator=devcycle-js-sdks%40workspace%3A.":
+  version: 16.3.2
+  resolution: "@nx/js@patch:@nx/js@npm%3A16.3.2#./.yarn/patches/@nx-js-npm-16.3.2-a543eca792.patch::version=16.3.2&hash=39f3b0&locator=devcycle-js-sdks%40workspace%3A."
+  dependencies:
+    "@babel/core": ^7.15.0
+    "@babel/plugin-proposal-class-properties": ^7.14.5
+    "@babel/plugin-proposal-decorators": ^7.14.5
+    "@babel/plugin-transform-runtime": ^7.15.0
+    "@babel/preset-env": ^7.15.0
+    "@babel/preset-typescript": ^7.15.0
+    "@babel/runtime": ^7.14.8
+    "@nrwl/js": 16.3.2
+    "@nx/devkit": 16.3.2
+    "@nx/workspace": 16.3.2
+    "@phenomnomnominal/tsquery": ~5.0.1
+    babel-plugin-const-enum: ^1.0.1
+    babel-plugin-macros: ^2.8.0
+    babel-plugin-transform-typescript-metadata: ^0.3.1
+    chalk: ^4.1.0
+    fast-glob: 3.2.7
+    fs-extra: ^11.1.0
+    ignore: ^5.0.4
+    js-tokens: ^4.0.0
+    minimatch: 3.0.5
+    semver: 7.3.4
+    source-map-support: 0.5.19
+    tslib: ^2.3.0
+  peerDependencies:
+    verdaccio: ^5.0.4
+  peerDependenciesMeta:
+    verdaccio:
+      optional: true
+  checksum: 5a871d1cf3d04a8cc3d62aa3f091975817ad95cc6f4a87c0326b88ac38077d129ae428af0a2773f7827ea0cc68d511c0c6ee79123663e3d41158af6539ba742e
+  languageName: node
+  linkType: hard
+
 "@nx/linter@npm:16.3.2":
   version: 16.3.2
   resolution: "@nx/linter@npm:16.3.2"
@@ -10578,7 +10614,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 7485348b948af8a6c8dde91714d09dd1d966597a670fb3d4d484135a58151f17b71caaf423c0d2b46869cc9d06d0febb10e69064c849f501d1396f071369a82b
+  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Temporarily patch the `@nx/js` package using `yarn patch` to fix the bug where Nx is adding devDependencies to dependencies, breaking our build.

The issue is described here:
https://github.com/nrwl/nx/issues/17758

For a diff with the changes being applied in the patch, see this Nx PR:
https://github.com/nrwl/nx/pull/17802