### PR TITLE
fix: issue with re-rendering component React SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "@react-native-community/cli-platform-android": "10.2.0",
         "@react-native-community/cli-platform-ios": "10.2.1",
         "@svgr/webpack": "^6.1.2",
+        "@testing-library/jest-dom": "5.16.5",
         "@testing-library/jest-native": "5.4.2",
         "@testing-library/react": "14.0.0",
         "@testing-library/react-native": "12.1.2",

--- a/sdk/react/__mocks__/@devcycle/js-client-sdk.ts
+++ b/sdk/react/__mocks__/@devcycle/js-client-sdk.ts
@@ -11,9 +11,28 @@ const mockVariableFunction = jest
 
         return variable
     })
+
+const mockSubscribeFunction = jest.
+    fn()
+    .mockImplementation((key: string, handler: () => void) => {
+       return
+    })
+
+const mockUnsubscribeFunction = jest
+    .fn()
+    .mockImplementation((key: string, handler: () => void) => {
+        return
+    })
+
 class Client {
     variable(key: string, defaultValue: unknown) {
         return mockVariableFunction(key, defaultValue)
+    }
+    subscribe(key: string, handler: () => void) {
+        return mockSubscribeFunction(key, handler)
+    }
+    unsubscribe(key: string, handler: () => void) {
+        return mockUnsubscribeFunction(key, handler)
     }
     close() {
         // no-op
@@ -23,6 +42,7 @@ class Client {
 module.exports = {
     ...jsSDK,
     mockVariableFunction,
+    mockSubscribeFunction,
     initializeDevCycle: () => new Client(),
     initialize: () => new Client(),
 }

--- a/sdk/react/__mocks__/@devcycle/js-client-sdk.ts
+++ b/sdk/react/__mocks__/@devcycle/js-client-sdk.ts
@@ -12,10 +12,10 @@ const mockVariableFunction = jest
         return variable
     })
 
-const mockSubscribeFunction = jest.
-    fn()
+const mockSubscribeFunction = jest
+    .fn()
     .mockImplementation((key: string, handler: () => void) => {
-       return
+        return
     })
 
 const mockUnsubscribeFunction = jest

--- a/sdk/react/mockData/mockConfig.ts
+++ b/sdk/react/mockData/mockConfig.ts
@@ -1,0 +1,42 @@
+export const mockConfig = {
+  "project": {
+      "_id": "34550f3abcc96f7cf4a49321",
+      "key": "test-project",
+      "settings": {
+          "edgeDB": {
+              "enabled": false
+          },
+      }
+  },
+  "environment": {
+      "_id": "1234567d69160a4f77654321",
+      "key": "development"
+  },
+  "features": {
+      "test-feature": {
+          "_id": "63f68914661225c485aa3a02",
+          "key": "test-feature",
+          "type": "release",
+          "_variation": "63f68914661225c485aa3a09",
+          "variationName": "Variation On",
+          "variationKey": "variation-on"
+      }
+  },
+  "featureVariationMap": {
+      "63f68914661225c485aa3a02": "63f68914661225c485aa3a09"
+  },
+  "variableVariationMap": {},
+  "variables": {
+      "string-var": {
+          "_id": "63633c566cf0fcb7e2123456",
+          "key": "string-var",
+          "type": "String",
+          "value": "Bonjour",
+      }
+  },
+  "sse": {
+      "url": "https://realtime.ably.io/event-stream?channels=fake_channel",
+      "inactivityDelay": 120000
+  },
+  "etag": "\"000000ca4b53334a777ed32053111111\""
+}

--- a/sdk/react/mockData/mockConfig.ts
+++ b/sdk/react/mockData/mockConfig.ts
@@ -1,42 +1,42 @@
 export const mockConfig = {
-  "project": {
-      "_id": "34550f3abcc96f7cf4a49321",
-      "key": "test-project",
-      "settings": {
-          "edgeDB": {
-              "enabled": false
-          },
-      }
-  },
-  "environment": {
-      "_id": "1234567d69160a4f77654321",
-      "key": "development"
-  },
-  "features": {
-      "test-feature": {
-          "_id": "63f68914661225c485aa3a02",
-          "key": "test-feature",
-          "type": "release",
-          "_variation": "63f68914661225c485aa3a09",
-          "variationName": "Variation On",
-          "variationKey": "variation-on"
-      }
-  },
-  "featureVariationMap": {
-      "63f68914661225c485aa3a02": "63f68914661225c485aa3a09"
-  },
-  "variableVariationMap": {},
-  "variables": {
-      "string-var": {
-          "_id": "63633c566cf0fcb7e2123456",
-          "key": "string-var",
-          "type": "String",
-          "value": "Bonjour",
-      }
-  },
-  "sse": {
-      "url": "https://realtime.ably.io/event-stream?channels=fake_channel",
-      "inactivityDelay": 120000
-  },
-  "etag": "\"000000ca4b53334a777ed32053111111\""
+    project: {
+        _id: '34550f3abcc96f7cf4a49321',
+        key: 'test-project',
+        settings: {
+            edgeDB: {
+                enabled: false,
+            },
+        },
+    },
+    environment: {
+        _id: '1234567d69160a4f77654321',
+        key: 'development',
+    },
+    features: {
+        'test-feature': {
+            _id: '63f68914661225c485aa3a02',
+            key: 'test-feature',
+            type: 'release',
+            _variation: '63f68914661225c485aa3a09',
+            variationName: 'Variation On',
+            variationKey: 'variation-on',
+        },
+    },
+    featureVariationMap: {
+        '63f68914661225c485aa3a02': '63f68914661225c485aa3a09',
+    },
+    variableVariationMap: {},
+    variables: {
+        'string-var': {
+            _id: '63633c566cf0fcb7e2123456',
+            key: 'string-var',
+            type: 'String',
+            value: 'Bonjour',
+        },
+    },
+    sse: {
+        url: 'https://realtime.ably.io/event-stream?channels=fake_channel',
+        inactivityDelay: 120000,
+    },
+    etag: '"000000ca4b53334a777ed32053111111"',
 }

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -17,5 +17,8 @@
     },
     "dependencies": {
         "hoist-non-react-statics": "^3.3.2"
+    },
+    "devDependencies": {
+        "nock": "^13.3.1"
     }
 }

--- a/sdk/react/src/useVariable.ts
+++ b/sdk/react/src/useVariable.ts
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import context from './context'
 import type { DVCVariable, DVCVariableValue } from '@devcycle/js-client-sdk'
 
@@ -8,17 +8,19 @@ export const useVariable = <T extends DVCVariableValue>(
 ): DVCVariable<T> => {
     const dvcContext = useContext(context)
     const [_, forceRerender] = useState({})
-    const ref = useRef<DVCVariable<T>>()
+    const forceRerenderCallback = useCallback(() => forceRerender({}), [])
 
     if (dvcContext === undefined)
         throw new Error('useVariable must be used within DevCycleProvider')
 
-    if (!ref.current) {
-        ref.current = dvcContext?.client.variable(key, defaultValue)
-        ref.current.onUpdate(() => forceRerender({}))
-    }
+    useEffect(() => {
+        dvcContext.client.subscribe(`variableUpdated:${key}`, forceRerenderCallback)
+        return () => {
+            dvcContext.client.unsubscribe(`variableUpdated:${key}`, forceRerenderCallback)
+        }
+    }, [dvcContext, key, forceRerenderCallback])
 
-    return ref.current
+    return dvcContext.client.variable(key, defaultValue)
 }
 
 export default useVariable

--- a/sdk/react/src/useVariable.ts
+++ b/sdk/react/src/useVariable.ts
@@ -14,9 +14,15 @@ export const useVariable = <T extends DVCVariableValue>(
         throw new Error('useVariable must be used within DevCycleProvider')
 
     useEffect(() => {
-        dvcContext.client.subscribe(`variableUpdated:${key}`, forceRerenderCallback)
+        dvcContext.client.subscribe(
+            `variableUpdated:${key}`,
+            forceRerenderCallback,
+        )
         return () => {
-            dvcContext.client.unsubscribe(`variableUpdated:${key}`, forceRerenderCallback)
+            dvcContext.client.unsubscribe(
+                `variableUpdated:${key}`,
+                forceRerenderCallback,
+            )
         }
     }, [dvcContext, key, forceRerenderCallback])
 

--- a/sdk/react/src/useVariableValue.integration.test.tsx
+++ b/sdk/react/src/useVariableValue.integration.test.tsx
@@ -38,50 +38,54 @@ describe('useVariableValue', () => {
         )
     }
 
-    it('should re-render all components that call useVariableValue with the same variable key when an update occurs', async () => {
-        const scope = nock('https://sdk-api.devcycle.com/v1')
-        scope
-            .defaultReplyHeaders({
-                'access-control-allow-origin': '*',
-            })
-            .get('/sdkConfig')
-            .query((query) => query.user_id === 'test_user')
-            .reply(200, mockConfig)
-            .persist()
+    it(
+        'should re-render all components that call useVariableValue with ' +
+            'the same variable key when an update occurs',
+        async () => {
+            const scope = nock('https://sdk-api.devcycle.com/v1')
+            scope
+                .defaultReplyHeaders({
+                    'access-control-allow-origin': '*',
+                })
+                .get('/sdkConfig')
+                .query((query) => query.user_id === 'test_user')
+                .reply(200, mockConfig)
+                .persist()
 
-        const updatedConfig = {
-            ...mockConfig,
-            variables: {
-                'string-var': {
-                    _id: '63633c566cf0fcb7e2123456',
-                    key: 'string-var',
-                    type: 'String',
-                    value: 'Hola',
+            const updatedConfig = {
+                ...mockConfig,
+                variables: {
+                    'string-var': {
+                        _id: '63633c566cf0fcb7e2123456',
+                        key: 'string-var',
+                        type: 'String',
+                        value: 'Hola',
+                    },
                 },
-            },
-        }
-        scope
-            .defaultReplyHeaders({
-                'access-control-allow-origin': '*',
-            })
-            .get('/sdkConfig')
-            .query((query) => query.user_id === 'identified_user')
-            .reply(200, updatedConfig)
-            .persist()
+            }
+            scope
+                .defaultReplyHeaders({
+                    'access-control-allow-origin': '*',
+                })
+                .get('/sdkConfig')
+                .query((query) => query.user_id === 'identified_user')
+                .reply(200, updatedConfig)
+                .persist()
 
-        const App = withDevCycleProvider({
-            user: { user_id: 'test_user' },
-            sdkKey: 'dvc_test_key',
-        })(TestApp)
+            const App = withDevCycleProvider({
+                user: { user_id: 'test_user' },
+                sdkKey: 'dvc_test_key',
+            })(TestApp)
 
-        render(<App />)
+            render(<App />)
 
-        expect(
-            await screen.findAllByText('Variable Value: Bonjour'),
-        ).toHaveLength(3)
-        screen.getByText('Identify User').click()
-        expect(await screen.findAllByText('Variable Value: Hola')).toHaveLength(
-            3,
-        )
-    })
+            expect(
+                await screen.findAllByText('Variable Value: Bonjour'),
+            ).toHaveLength(3)
+            screen.getByText('Identify User').click()
+            expect(
+                await screen.findAllByText('Variable Value: Hola'),
+            ).toHaveLength(3)
+        },
+    )
 })

--- a/sdk/react/src/useVariableValue.integration.test.tsx
+++ b/sdk/react/src/useVariableValue.integration.test.tsx
@@ -1,0 +1,82 @@
+import { useVariableValue } from './useVariableValue'
+import { render, screen } from '@testing-library/react'
+import nock from 'nock'
+import { useDevCycleClient, useIsDevCycleInitialized, withDevCycleProvider } from '.'
+import { mockConfig } from '../mockData/mockConfig'
+
+jest.unmock('@devcycle/devcycle-js-sdk')
+
+describe('useVariableValue', () => {
+
+  const Component = () => {
+      const variableValue = useVariableValue('string-var', 'Hello')
+
+      return (
+          <div>
+              Variable Value: {variableValue}
+          </div>
+      )
+  }
+
+  const TestApp = () => {
+      const isReady = useIsDevCycleInitialized()
+      const dvcClient = useDevCycleClient()
+      const identifyUser = () => {
+          dvcClient.identifyUser({ user_id: 'identified_user' })
+      }
+
+      if (!isReady) {
+          return <div>Loading...</div>
+      }
+
+      return (
+          <>
+              <button onClick={identifyUser}>Identify User</button>
+              <Component/>
+              <Component/>
+              <Component/>
+          </>
+      )
+  }
+
+  it(
+      "should re-render all components that call useVariableValue with the same variable key when an update occurs",
+  async () => {
+      const scope = nock('https://sdk-api.devcycle.com/v1')
+      scope.defaultReplyHeaders({
+              'access-control-allow-origin': '*',
+          })
+          .get('/sdkConfig')
+          .query((query) => query.user_id === 'test_user')
+          .reply(200, mockConfig)
+          .persist()
+
+      const updatedConfig = {
+          ...mockConfig,
+          variables: {
+              'string-var': {
+                  '_id': '63633c566cf0fcb7e2123456',
+                  'key': 'string-var',
+                  'type': 'String',
+                  'value': 'Hola' 
+              }
+          },
+      }
+      scope.defaultReplyHeaders({
+              'access-control-allow-origin': '*',
+          })
+          .get('/sdkConfig')
+          .query((query) => query.user_id === 'identified_user')
+          .reply(200, updatedConfig)
+          .persist()
+
+      const App = withDevCycleProvider({ user: { user_id: 'test_user'}, sdkKey: 'dvc_test_key' })(TestApp)
+
+      render(<App />)
+
+      expect(await screen.findAllByText("Variable Value: Bonjour")).toHaveLength(3);
+      screen.getByText('Identify User').click()
+      expect(await screen.findAllByText("Variable Value: Hola")).toHaveLength(3);
+  })
+})
+

--- a/sdk/react/src/useVariableValue.integration.test.tsx
+++ b/sdk/react/src/useVariableValue.integration.test.tsx
@@ -1,82 +1,87 @@
 import { useVariableValue } from './useVariableValue'
 import { render, screen } from '@testing-library/react'
 import nock from 'nock'
-import { useDevCycleClient, useIsDevCycleInitialized, withDevCycleProvider } from '.'
+import {
+    useDevCycleClient,
+    useIsDevCycleInitialized,
+    withDevCycleProvider,
+} from '.'
 import { mockConfig } from '../mockData/mockConfig'
 
-jest.unmock('@devcycle/devcycle-js-sdk')
+jest.unmock('@devcycle/js-client-sdk')
 
 describe('useVariableValue', () => {
+    const Component = () => {
+        const variableValue = useVariableValue('string-var', 'Hello')
 
-  const Component = () => {
-      const variableValue = useVariableValue('string-var', 'Hello')
+        return <div>Variable Value: {variableValue}</div>
+    }
 
-      return (
-          <div>
-              Variable Value: {variableValue}
-          </div>
-      )
-  }
+    const TestApp = () => {
+        const isReady = useIsDevCycleInitialized()
+        const dvcClient = useDevCycleClient()
+        const identifyUser = () => {
+            dvcClient.identifyUser({ user_id: 'identified_user' })
+        }
 
-  const TestApp = () => {
-      const isReady = useIsDevCycleInitialized()
-      const dvcClient = useDevCycleClient()
-      const identifyUser = () => {
-          dvcClient.identifyUser({ user_id: 'identified_user' })
-      }
+        if (!isReady) {
+            return <div>Loading...</div>
+        }
 
-      if (!isReady) {
-          return <div>Loading...</div>
-      }
+        return (
+            <>
+                <button onClick={identifyUser}>Identify User</button>
+                <Component />
+                <Component />
+                <Component />
+            </>
+        )
+    }
 
-      return (
-          <>
-              <button onClick={identifyUser}>Identify User</button>
-              <Component/>
-              <Component/>
-              <Component/>
-          </>
-      )
-  }
+    it('should re-render all components that call useVariableValue with the same variable key when an update occurs', async () => {
+        const scope = nock('https://sdk-api.devcycle.com/v1')
+        scope
+            .defaultReplyHeaders({
+                'access-control-allow-origin': '*',
+            })
+            .get('/sdkConfig')
+            .query((query) => query.user_id === 'test_user')
+            .reply(200, mockConfig)
+            .persist()
 
-  it(
-      "should re-render all components that call useVariableValue with the same variable key when an update occurs",
-  async () => {
-      const scope = nock('https://sdk-api.devcycle.com/v1')
-      scope.defaultReplyHeaders({
-              'access-control-allow-origin': '*',
-          })
-          .get('/sdkConfig')
-          .query((query) => query.user_id === 'test_user')
-          .reply(200, mockConfig)
-          .persist()
+        const updatedConfig = {
+            ...mockConfig,
+            variables: {
+                'string-var': {
+                    _id: '63633c566cf0fcb7e2123456',
+                    key: 'string-var',
+                    type: 'String',
+                    value: 'Hola',
+                },
+            },
+        }
+        scope
+            .defaultReplyHeaders({
+                'access-control-allow-origin': '*',
+            })
+            .get('/sdkConfig')
+            .query((query) => query.user_id === 'identified_user')
+            .reply(200, updatedConfig)
+            .persist()
 
-      const updatedConfig = {
-          ...mockConfig,
-          variables: {
-              'string-var': {
-                  '_id': '63633c566cf0fcb7e2123456',
-                  'key': 'string-var',
-                  'type': 'String',
-                  'value': 'Hola' 
-              }
-          },
-      }
-      scope.defaultReplyHeaders({
-              'access-control-allow-origin': '*',
-          })
-          .get('/sdkConfig')
-          .query((query) => query.user_id === 'identified_user')
-          .reply(200, updatedConfig)
-          .persist()
+        const App = withDevCycleProvider({
+            user: { user_id: 'test_user' },
+            sdkKey: 'dvc_test_key',
+        })(TestApp)
 
-      const App = withDevCycleProvider({ user: { user_id: 'test_user'}, sdkKey: 'dvc_test_key' })(TestApp)
+        render(<App />)
 
-      render(<App />)
-
-      expect(await screen.findAllByText("Variable Value: Bonjour")).toHaveLength(3);
-      screen.getByText('Identify User').click()
-      expect(await screen.findAllByText("Variable Value: Hola")).toHaveLength(3);
-  })
+        expect(
+            await screen.findAllByText('Variable Value: Bonjour'),
+        ).toHaveLength(3)
+        screen.getByText('Identify User').click()
+        expect(await screen.findAllByText('Variable Value: Hola')).toHaveLength(
+            3,
+        )
+    })
 })
-

--- a/sdk/react/src/useVariableValue.test.tsx
+++ b/sdk/react/src/useVariableValue.test.tsx
@@ -1,13 +1,12 @@
 import { useVariableValue } from './useVariableValue'
 import { renderHook } from '@testing-library/react'
 import { DevCycleProvider } from './DevCycleProvider'
+import '@testing-library/jest-dom'
 import type { DVCJSON } from '@devcycle/js-client-sdk'
 import { ReactElement } from 'react'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { mockVariableFunction } from '@devcycle/js-client-sdk' // defined in the mock
-
-jest.mock('@devcycle/js-client-sdk')
+import { mockSubscribeFunction } from '@devcycle/js-client-sdk' // defined in the mock
 
 const ProviderWrapper = ({ children }: { children: ReactElement }) => {
     return (
@@ -26,6 +25,7 @@ describe('useVariableValue', () => {
     beforeEach(() => {
         jest.clearAllMocks()
     })
+
     it('uses the correct type for string', () => {
         const { result } = renderHook(
             () => useVariableValue('test', 'default'),
@@ -78,14 +78,16 @@ describe('useVariableValue', () => {
         const _testJSON: DVCJSON = result.current
     })
 
-    it('calls the variable method on the SDK once per hook instance, not per invocation', () => {
-        const { result, rerender } = renderHook(
-            () => useVariableValue('test', 'default'),
+    it("Should register a handler for each useVariableValue call with same variable key", () => {
+        renderHook(
+            () => useVariableValue('test', true),
             { wrapper: ProviderWrapper },
         )
-        expect(result.current).toEqual('default')
-        rerender()
-        expect(result.current).toEqual('default')
-        expect(mockVariableFunction).toHaveBeenCalledTimes(1)
+        renderHook(
+            () => useVariableValue('test', true),
+            { wrapper: ProviderWrapper },
+        )
+
+        expect(mockSubscribeFunction).toHaveBeenCalledTimes(2)
     })
 })

--- a/sdk/react/src/useVariableValue.test.tsx
+++ b/sdk/react/src/useVariableValue.test.tsx
@@ -8,6 +8,8 @@ import { ReactElement } from 'react'
 // @ts-ignore
 import { mockSubscribeFunction } from '@devcycle/js-client-sdk' // defined in the mock
 
+jest.mock('@devcycle/js-client-sdk')
+
 const ProviderWrapper = ({ children }: { children: ReactElement }) => {
     return (
         <DevCycleProvider
@@ -78,15 +80,13 @@ describe('useVariableValue', () => {
         const _testJSON: DVCJSON = result.current
     })
 
-    it("Should register a handler for each useVariableValue call with same variable key", () => {
-        renderHook(
-            () => useVariableValue('test', true),
-            { wrapper: ProviderWrapper },
-        )
-        renderHook(
-            () => useVariableValue('test', true),
-            { wrapper: ProviderWrapper },
-        )
+    it('Should register a handler for each useVariableValue call with same variable key', () => {
+        renderHook(() => useVariableValue('test', true), {
+            wrapper: ProviderWrapper,
+        })
+        renderHook(() => useVariableValue('test', true), {
+            wrapper: ProviderWrapper,
+        })
 
         expect(mockSubscribeFunction).toHaveBeenCalledTimes(2)
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,32 +4554,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@devcycle/devcycle-js-sdk@workspace:sdk/js":
+"@devcycle/js-client-sdk@workspace:sdk/js":
   version: 0.0.0-use.local
-  resolution: "@devcycle/devcycle-js-sdk@workspace:sdk/js"
-  languageName: unknown
-  linkType: soft
-
-"@devcycle/devcycle-react-native-sdk@workspace:sdk/react-native":
-  version: 0.0.0-use.local
-  resolution: "@devcycle/devcycle-react-native-sdk@workspace:sdk/react-native"
-  dependencies:
-    "@react-native-async-storage/async-storage": ^1.17.11
-    react-native-device-info: ^8.7.0
-    react-native-get-random-values: ^1.7.2
-  peerDependencies:
-    react-native: ">=0.64.0"
-  languageName: unknown
-  linkType: soft
-
-"@devcycle/devcycle-react-sdk@workspace:sdk/react":
-  version: 0.0.0-use.local
-  resolution: "@devcycle/devcycle-react-sdk@workspace:sdk/react"
-  dependencies:
-    hoist-non-react-statics: ^3.3.2
-    nock: ^13.3.1
-  peerDependencies:
-    react: ">=16.8.0"
+  resolution: "@devcycle/js-client-sdk@workspace:sdk/js"
   languageName: unknown
   linkType: soft
 
@@ -4597,6 +4574,29 @@ __metadata:
   resolution: "@devcycle/openfeature-nodejs-provider@workspace:sdk/openfeature-nodejs-provider"
   dependencies:
     "@devcycle/bucketing-test-data": ^1.2.12
+  languageName: unknown
+  linkType: soft
+
+"@devcycle/react-client-sdk@workspace:sdk/react":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/react-client-sdk@workspace:sdk/react"
+  dependencies:
+    hoist-non-react-statics: ^3.3.2
+    nock: ^13.3.1
+  peerDependencies:
+    react: ">=16.8.0"
+  languageName: unknown
+  linkType: soft
+
+"@devcycle/react-native-client-sdk@workspace:sdk/react-native":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/react-native-client-sdk@workspace:sdk/react-native"
+  dependencies:
+    "@react-native-async-storage/async-storage": ^1.17.11
+    react-native-device-info: ^8.7.0
+    react-native-get-random-values: ^1.7.2
+  peerDependencies:
+    react-native: ">=0.64.0"
   languageName: unknown
   linkType: soft
 
@@ -10667,7 +10667,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
+  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@adobe/css-tools@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@adobe/css-tools@npm:4.2.0"
+  checksum: dc5cc92ba3d562e7ffddb79d6d222c7e00b65f255fd2725b3d71490ff268844be322f917415d8c4ab39eca646343b632058db8bd5b1d646193fcc94d1d3e420b
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -4083,6 +4090,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.9.2":
+  version: 7.22.6
+  resolution: "@babel/runtime@npm:7.22.6"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: e585338287c4514a713babf4fdb8fc2a67adcebab3e7723a739fc62c79cfda875b314c90fd25f827afb150d781af97bc16c85bfdbfa2889f06053879a1ddb597
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.0.0, @babel/template@npm:^7.16.7, @babel/template@npm:^7.3.3":
   version: 7.16.7
   resolution: "@babel/template@npm:7.16.7"
@@ -4538,9 +4554,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@devcycle/js-client-sdk@workspace:sdk/js":
+"@devcycle/devcycle-js-sdk@workspace:sdk/js":
   version: 0.0.0-use.local
-  resolution: "@devcycle/js-client-sdk@workspace:sdk/js"
+  resolution: "@devcycle/devcycle-js-sdk@workspace:sdk/js"
+  languageName: unknown
+  linkType: soft
+
+"@devcycle/devcycle-react-native-sdk@workspace:sdk/react-native":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/devcycle-react-native-sdk@workspace:sdk/react-native"
+  dependencies:
+    "@react-native-async-storage/async-storage": ^1.17.11
+    react-native-device-info: ^8.7.0
+    react-native-get-random-values: ^1.7.2
+  peerDependencies:
+    react-native: ">=0.64.0"
+  languageName: unknown
+  linkType: soft
+
+"@devcycle/devcycle-react-sdk@workspace:sdk/react":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/devcycle-react-sdk@workspace:sdk/react"
+  dependencies:
+    hoist-non-react-statics: ^3.3.2
+    nock: ^13.3.1
+  peerDependencies:
+    react: ">=16.8.0"
   languageName: unknown
   linkType: soft
 
@@ -4558,28 +4597,6 @@ __metadata:
   resolution: "@devcycle/openfeature-nodejs-provider@workspace:sdk/openfeature-nodejs-provider"
   dependencies:
     "@devcycle/bucketing-test-data": ^1.2.12
-  languageName: unknown
-  linkType: soft
-
-"@devcycle/react-client-sdk@workspace:sdk/react":
-  version: 0.0.0-use.local
-  resolution: "@devcycle/react-client-sdk@workspace:sdk/react"
-  dependencies:
-    hoist-non-react-statics: ^3.3.2
-  peerDependencies:
-    react: ">=16.8.0"
-  languageName: unknown
-  linkType: soft
-
-"@devcycle/react-native-client-sdk@workspace:sdk/react-native":
-  version: 0.0.0-use.local
-  resolution: "@devcycle/react-native-client-sdk@workspace:sdk/react-native"
-  dependencies:
-    "@react-native-async-storage/async-storage": ^1.17.11
-    react-native-device-info: ^8.7.0
-    react-native-get-random-values: ^1.7.2
-  peerDependencies:
-    react-native: ">=0.64.0"
   languageName: unknown
   linkType: soft
 
@@ -8618,6 +8635,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:5.16.5":
+  version: 5.16.5
+  resolution: "@testing-library/jest-dom@npm:5.16.5"
+  dependencies:
+    "@adobe/css-tools": ^4.0.1
+    "@babel/runtime": ^7.9.2
+    "@types/testing-library__jest-dom": ^5.9.1
+    aria-query: ^5.0.0
+    chalk: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  checksum: 94911f901a8031f3e489d04ac057cb5373621230f5d92bed80e514e24b069fb58a3166d1dd86963e55f078a1bd999da595e2ab96ed95f452d477e272937d792a
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-native@npm:5.4.2":
   version: 5.4.2
   resolution: "@testing-library/jest-native@npm:5.4.2"
@@ -8984,6 +9018,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:*":
+  version: 29.5.3
+  resolution: "@types/jest@npm:29.5.3"
+  dependencies:
+    expect: ^29.0.0
+    pretty-format: ^29.0.0
+  checksum: e36bb92e0b9e5ea7d6f8832baa42f087fc1697f6cd30ec309a07ea4c268e06ec460f1f0cfd2581daf5eff5763475190ec1ad8ac6520c49ccfe4f5c0a48bfa676
+  languageName: node
+  linkType: hard
+
 "@types/jest@npm:29.4.4":
   version: 29.4.4
   resolution: "@types/jest@npm:29.4.4"
@@ -9311,6 +9355,15 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/testing-library__jest-dom@npm:^5.9.1":
+  version: 5.14.8
+  resolution: "@types/testing-library__jest-dom@npm:5.14.8"
+  dependencies:
+    "@types/jest": "*"
+  checksum: 18f5ba7d0db8ebd91667b544537762ce63f11c4fd02b3d57afa92f9457a384d3ecf9bc7b50b6b445af1b3ea38b69862b4f95130720d4dd23621d598ac074d93a
   languageName: node
   linkType: hard
 
@@ -10614,7 +10667,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
+  checksum: 045c8dc54cb8ee61d022c017e483f6c8729347a2e30167a4e3227b9d4d80293b032a8cff7fcaf83040b23eacc23bf62188ebb9f2091df85ef2ee21425f8957f7
   languageName: node
   linkType: hard
 
@@ -11887,6 +11940,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chalk@npm:3.0.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -13048,6 +13111,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "css@npm:^3.0.0":
   version: 3.0.0
   resolution: "css@npm:3.0.0"
@@ -13808,6 +13878,7 @@ __metadata:
     "@react-native-community/cli-platform-android": 10.2.0
     "@react-native-community/cli-platform-ios": 10.2.1
     "@svgr/webpack": ^6.1.2
+    "@testing-library/jest-dom": 5.16.5
     "@testing-library/jest-native": 5.4.2
     "@testing-library/react": 14.0.0
     "@testing-library/react-native": 12.1.2
@@ -14012,6 +14083,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.6":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
   languageName: node
   linkType: hard
 
@@ -23025,6 +23103,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nock@npm:^13.3.1":
+  version: 13.3.1
+  resolution: "nock@npm:13.3.1"
+  dependencies:
+    debug: ^4.1.0
+    json-stringify-safe: ^5.0.1
+    lodash: ^4.17.21
+    propagate: ^2.0.0
+  checksum: 0f2a73e8432f6b5650656c53eef99f9e5bbde3df538dc2f07057edc4438cfc61a394c9d06dd82e60f6e86d42433f20f3c04364a1f088beee7bf03a24e3f0fdd0
+  languageName: node
+  linkType: hard
+
 "node-abort-controller@npm:^3.0.1":
   version: 3.0.1
   resolution: "node-abort-controller@npm:3.0.1"
@@ -25402,6 +25492,13 @@ __metadata:
     object-assign: ^4.1.1
     react-is: ^16.13.1
   checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
+"propagate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "propagate@npm:2.0.1"
+  checksum: c4febaee2be0979e82fb6b3727878fd122a98d64a7fa3c9d09b0576751b88514a9e9275b1b92e76b364d488f508e223bd7e1dcdc616be4cdda876072fbc2a96c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Changes
* the `useVariable` method now uses the JS SDK client's `subscribe` method to listen for variable updates instead of a variable's `onUpdate` method. This fixes the bug where multiple components calling `useVariable`/`useVariableValue` would result in only the last calling component to re-render when there is an update