### PR TITLE
chore: update RN random values dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "react-is": "18.2.0",
         "react-native": "0.71.8",
         "react-native-device-info": "^8.7.0",
-        "react-native-get-random-values": "^1.7.2",
+        "react-native-get-random-values": "^1.9.0",
         "reflect-metadata": "^0.1.13",
         "regenerator-runtime": "0.13.7",
         "source-map-support": "^0.5.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14633,7 +14633,7 @@ __metadata:
     react-native: 0.71.8
     react-native-config: 1.5.0
     react-native-device-info: ^8.7.0
-    react-native-get-random-values: ^1.7.2
+    react-native-get-random-values: ^1.9.0
     react-native-svg: 13.9.0
     react-native-svg-transformer: ^1.0.0
     react-refresh: ^0.10.0
@@ -27329,7 +27329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-get-random-values@npm:*":
+"react-native-get-random-values@npm:*, react-native-get-random-values@npm:^1.9.0":
   version: 1.9.0
   resolution: "react-native-get-random-values@npm:1.9.0"
   dependencies:


### PR DESCRIPTION
- update the RN random values package to latest version for expo 48+ support