### PR TITLE
fix: running debug WASM when debug logging is set, fix 'Failed to download config' debug log from 304 response

### DIFF
--- a/examples/nodejs-local/typescript/src/benchmarkDVC.ts
+++ b/examples/nodejs-local/typescript/src/benchmarkDVC.ts
@@ -12,7 +12,7 @@ export async function benchmarkDevCycle(): Promise<void> {
         devcycleClient = await initializeDevCycle(DEVCYCLE_SERVER_SDK_KEY, {
             logLevel: 'debug',
             enableCloudBucketing: false,
-            disableAutomaticEventLogging: true,
+            disableAutomaticEventLogging: false,
             reporter: {
                 reportMetric: (report) => {
                     console.log(report)

--- a/sdk/nodejs/__tests__/environmentConfigManager.spec.ts
+++ b/sdk/nodejs/__tests__/environmentConfigManager.spec.ts
@@ -107,7 +107,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
         await envConfig._fetchConfig()
 
         getEnvironmentConfig_mock.mockImplementation(async () =>
-            mockFetchResponse({ status: 304 }),
+            mockFetchResponse({ status: 304, ok: false, data: null }),
         )
 
         await envConfig._fetchConfig()

--- a/sdk/nodejs/src/bucketing.ts
+++ b/sdk/nodejs/src/bucketing.ts
@@ -13,7 +13,7 @@ export const importBucketingLib = async ({
         await InstantiatePromise
         return
     }
-    const debugWASM = options?.logLevel === 'debug'
+    const debugWASM = process.env.DEVCYCLE_DEBUG_WASM === '1'
     InstantiatePromise = instantiate(debugWASM).then((exports) => {
         Bucketing = exports
         return Bucketing

--- a/sdk/nodejs/src/environmentConfigManager.ts
+++ b/sdk/nodejs/src/environmentConfigManager.ts
@@ -82,7 +82,7 @@ export class EnvironmentConfigManager {
                 `Request to get config failed for url: ${url}, ` +
                 `response message: ${error.message}, response data: ${projectConfig}`
             if (this.hasConfig) {
-                this.logger.debug(errMsg)
+                this.logger.warn(errMsg)
             } else {
                 this.logger.error(errMsg)
             }
@@ -131,7 +131,7 @@ export class EnvironmentConfigManager {
         }
 
         if (this.hasConfig) {
-            this.logger.debug(
+            this.logger.warn(
                 `Failed to download config, using cached version. url: ${url}.`,
             )
         } else if (responseError?.status === 403) {

--- a/sdk/nodejs/src/request.ts
+++ b/sdk/nodejs/src/request.ts
@@ -48,7 +48,8 @@ const retryOnRequestError: retryOnRequestErrorFunc = (retries) => {
 }
 
 const handleResponse = async (res: Response) => {
-    if (!res.ok) {
+    // res.ok only checks for 200-299 status codes
+    if (!res.ok && res.status >= 400) {
         let error
         try {
             error = new ResponseError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11268,7 +11268,7 @@ __metadata:
 "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json":
   version: 1.1.0
   resolution: "assemblyscript-json@https://github.com/DevCycleHQ/assemblyscript-json.git#commit=d2ce65ec18b305e1f3db8a4fe4394b417631b024"
-  checksum: 7485348b948af8a6c8dde91714d09dd1d966597a670fb3d4d484135a58151f17b71caaf423c0d2b46869cc9d06d0febb10e69064c849f501d1396f071369a82b
+  checksum: 480283ed02d57eacb400facc060f293b7dcb773a90dc5b7c80eae86b0007e3a748b2cb6c298a1a32010cba41e48686fcd0078c02c6db1d917fda85bb7c08ded1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix a couple of small issues found when debugging the NodeJS SDK
- fix the nodeJS SDK failing to use the debug WASM when debug logging is set.
- fix 'Failed to download config' debug log from 304 response

