### PR TITLE
feat: add react-native-expo package

### DIFF
--- a/lib/shared/types/project.json
+++ b/lib/shared/types/project.json
@@ -39,6 +39,26 @@
                 ]
             }
         },
+        "build:es5": {
+            "executor": "@nrwl/rollup:rollup",
+            "outputs": ["{options.outputPath}"],
+            "options": {
+                "format": ["cjs"],
+                "external": "all",
+                "project": "lib/shared/types/package.json",
+                "outputPath": "dist/lib/shared/types",
+                "entryFile": "lib/shared/types/src/index.ts",
+                "tsConfig": "lib/shared/types/tsconfig.lib.es5.json",
+                "buildableProjectDepsInPackageJsonType": "dependencies",
+                "assets": [
+                    {
+                        "glob": "*.md",
+                        "input": "lib/shared/types",
+                        "output": "."
+                    }
+                ]
+            }
+        },
         "build:emit-legacy-types": {
             "executor": "nx:run-commands",
             "options": {

--- a/lib/shared/types/tsconfig.lib.es5.json
+++ b/lib/shared/types/tsconfig.lib.es5.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "target": "es5"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "<rootDir>/build"
     ],
     "dependencies": {
+        "@altack/nx-bundlefy": "^0.16.0",
         "@devcycle/assemblyscript-json": "^2.0.0",
         "@nestjs/class-validator": "^0.13.4",
         "@openfeature/js-sdk": "^1.4.2",

--- a/sdk/js/project.json
+++ b/sdk/js/project.json
@@ -49,24 +49,15 @@
             }
         },
         "build:es5": {
-            "executor": "@nrwl/rollup:rollup",
+            "executor": "@nx/js:tsc",
             "outputs": ["{options.outputPath}"],
             "options": {
                 "outputPath": "dist/sdk/js",
                 "tsConfig": "sdk/js/tsconfig.lib.es5.json",
-                "project": "sdk/js/package.json",
-                "entryFile": "sdk/js/src/index.ts",
-                "format": ["esm", "cjs"],
-                "external": "none",
-                "rollupConfig": "@nx/react/plugins/bundle-rollup",
-                "compiler": "babel",
-                "assets": [
-                    {
-                        "glob": "sdk/js/README.md",
-                        "input": ".",
-                        "output": "."
-                    }
-                ]
+                "packageJson": "sdk/js/package.json",
+                "buildableProjectDepsInPackageJsonType": "dependencies",
+                "main": "sdk/js/src/index.ts",
+                "assets": ["sdk/js/*.md"]
             }
         },
         "build:emit-legacy-types": {

--- a/sdk/js/project.json
+++ b/sdk/js/project.json
@@ -48,6 +48,27 @@
                 "assets": ["sdk/js/*.md"]
             }
         },
+        "build:es5": {
+            "executor": "@nrwl/rollup:rollup",
+            "outputs": ["{options.outputPath}"],
+            "options": {
+                "outputPath": "dist/sdk/js",
+                "tsConfig": "sdk/js/tsconfig.lib.es5.json",
+                "project": "sdk/js/package.json",
+                "entryFile": "sdk/js/src/index.ts",
+                "format": ["esm", "cjs"],
+                "external": "none",
+                "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                "compiler": "babel",
+                "assets": [
+                    {
+                        "glob": "sdk/js/README.md",
+                        "input": ".",
+                        "output": "."
+                    }
+                ]
+            }
+        },
         "build:emit-legacy-types": {
             "executor": "nx:run-commands",
             "options": {

--- a/sdk/js/tsconfig.lib.es5.json
+++ b/sdk/js/tsconfig.lib.es5.json
@@ -1,6 +1,11 @@
 {
-    "extends": "./tsconfig.lib.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
         "target": "es5",
-    }
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"]
 }

--- a/sdk/js/tsconfig.lib.es5.json
+++ b/sdk/js/tsconfig.lib.es5.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "target": "es5",
+        "module": "CommonJS",
         "outDir": "../../dist/out-tsc",
         "declaration": true,
         "types": []

--- a/sdk/js/tsconfig.lib.es5.json
+++ b/sdk/js/tsconfig.lib.es5.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "target": "es5",
+    }
+}

--- a/sdk/react-native-expo/.eslintrc.json
+++ b/sdk/react-native-expo/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*", "public", ".cache", "node_modules"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/sdk/react-native-expo/README.md
+++ b/sdk/react-native-expo/README.md
@@ -1,0 +1,7 @@
+# react-native
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test react-native` to execute the unit tests via [Jest](https://jestjs.io).

--- a/sdk/react-native-expo/babel.config.json
+++ b/sdk/react-native-expo/babel.config.json
@@ -1,0 +1,17 @@
+{
+    "presets": [
+        [
+            "@nx/react/babel",
+            {
+                "runtime": "automatic",
+                "useBuiltIns": "usage"
+            }
+        ]
+    ],
+    "plugins": [],
+    "env": {
+        "test": {
+            "presets": ["module:metro-react-native-babel-preset"]
+        }
+    }
+}

--- a/sdk/react-native-expo/jest.config.ts
+++ b/sdk/react-native-expo/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+    displayName: 'react-native-lib',
+    preset: 'react-native',
+    resolver: '@nx/jest/plugins/resolver',
+    moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
+    setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+    moduleNameMapper: {
+        '.svg': '@nx/react-native/plugins/jest/svg-mock',
+    },
+}

--- a/sdk/react-native-expo/package.json
+++ b/sdk/react-native-expo/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@devcycle/react-native-expo-client-sdk",
+    "version": "1.5.3",
+    "description": "The DevCycle React Native Expo SDK used for feature management.",
+    "main": "dist/index.js",
+    "scripts": {
+        "clean": "rimraf dist",
+        "test": "jest",
+        "tsc": "tsc",
+        "build": "yarn clean && yarn tsc"
+    },
+    "types": "dist/index.d.ts",
+    "author": "",
+    "license": "MIT",
+    "peerDependencies": {
+        "react-native": ">=0.64.0"
+    },
+    "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.17.11",
+        "react-native-device-info": "^8.7.0",
+        "react-native-get-random-values": "^1.7.2"
+    }
+}

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -19,6 +19,11 @@
             "outputs": ["{options.outputFile}"]
         },
         "build:es5": {
+            "dependsOn": [
+                "shared-types:build:es5",
+                "js:build:es5",
+                "react:build:es5"
+            ],
             "executor": "@nrwl/rollup:rollup",
             "outputs": ["{options.outputPath}"],
             "options": {

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -1,0 +1,69 @@
+{
+    "name": "react-native-expo",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "sdk/react-native-expo/src",
+    "projectType": "library",
+    "tags": [],
+    "targets": {
+        "check-types": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "yarn run -T tsc -b --incremental",
+                "cwd": "sdk/react-native-expo"
+            }
+        },
+        "build:expo": {
+            "executor": "@altack/nx-bundlefy:run",
+            "configurations": {},
+            "dependsOn": ["build:es5"],
+            "outputs": ["{options.outputFile}"]
+        },
+        "build:es5": {
+            "executor": "@nrwl/rollup:rollup",
+            "outputs": ["{options.outputPath}"],
+            "options": {
+                "outputPath": "dist/sdk/react-native-expo",
+                "tsConfig": "sdk/react-native-expo/tsconfig.lib.json",
+                "project": "sdk/react-native-expo/package.json",
+                "entryFile": "sdk/react-native-expo/src/index.ts",
+                "format": ["esm", "cjs"],
+                "external": "none",
+                "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                "compiler": "babel",
+                "assets": [
+                    {
+                        "glob": "sdk/react-native-expo/README.md",
+                        "input": ".",
+                        "output": "."
+                    }
+                ]
+            }
+        },
+        "lint": {
+            "executor": "@nx/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": [
+                    "sdk/react-native-expo/**/*.{ts,tsx,js,jsx}"
+                ]
+            }
+        },
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": ["{workspaceRoot}/coverage/sdk/react-native"],
+            "options": {
+                "jestConfig": "sdk/react-native-expo/jest.config.ts",
+                "passWithNoTests": true,
+                "codeCoverage": true
+            }
+        },
+        "npm-publish": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "../../../scripts/npm-safe-publish.sh \"@devcycle/react-native-expo-client-sdk\"",
+                "cwd": "dist/sdk/react-native-expo",
+                "forwardAllArgs": true
+            }
+        }
+    }
+}

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -27,7 +27,7 @@
                 "project": "sdk/react-native-expo/package.json",
                 "entryFile": "sdk/react-native-expo/src/index.ts",
                 "format": ["esm", "cjs"],
-                "external": "none",
+                "external": "all",
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "babel",
                 "assets": [

--- a/sdk/react-native-expo/src/DevCycleProvider.tsx
+++ b/sdk/react-native-expo/src/DevCycleProvider.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { DevCycleProvider as ReactDVCProvider } from '@devcycle/react-client-sdk'
+import ReactNativeStore from './ReactNativeCacheStore'
+
+type PropsType = Parameters<typeof ReactDVCProvider>[0]
+
+export const DevCycleProvider: typeof ReactDVCProvider = (props) => {
+    const config = getReactNativeConfig(props.config)
+
+    return <ReactDVCProvider config={config}>{props.children}</ReactDVCProvider>
+}
+
+/**
+ * @deprecated Use DevCycleProvider instead
+ */
+export const DVCProvider = DevCycleProvider
+
+export const getReactNativeConfig = (
+    config: PropsType['config'],
+): PropsType['config'] => {
+    const rnConfig = {
+        ...config,
+        options: {
+            ...config.options,
+            reactNative: true,
+        },
+    }
+    if (!config.options?.storage) {
+        rnConfig.options.storage = new ReactNativeStore()
+    }
+    return rnConfig
+}

--- a/sdk/react-native-expo/src/ReactNativeCacheStore.ts
+++ b/sdk/react-native-expo/src/ReactNativeCacheStore.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { DVCStorage } from '@devcycle/js-client-sdk'
+
+export class ReactNativeStore implements DVCStorage {
+    store: typeof AsyncStorage
+
+    constructor() {
+        this.store = AsyncStorage
+    }
+
+    save(storeKey: string, data: unknown): void {
+        this.store.setItem(storeKey, JSON.stringify(data))
+    }
+
+    load<T>(storeKey: string): Promise<T | undefined> {
+        return this.store.getItem(storeKey).then((item) => {
+            return item ? JSON.parse(item) : undefined
+        })
+    }
+
+    remove(storeKey: string): void {
+        this.store.removeItem(storeKey)
+    }
+}
+
+export default ReactNativeStore

--- a/sdk/react-native-expo/src/index.ts
+++ b/sdk/react-native-expo/src/index.ts
@@ -1,0 +1,33 @@
+import {
+    useDevCycleClient,
+    useDVCClient,
+    useVariable,
+    useVariableValue,
+    useIsDevCycleInitialized,
+    useIsDVCInitialized,
+} from '@devcycle/react-client-sdk'
+import { withDevCycleProvider, withDVCProvider } from './withDevCycleProvider'
+import { DevCycleProvider, DVCProvider } from './DevCycleProvider'
+export type {
+    DevCycleClient,
+    DVCClient,
+    DevCycleUser,
+    DVCUser,
+    DVCVariableValue,
+    DVCVariable,
+    DevCycleEvent,
+    DVCEvent,
+} from '@devcycle/react-client-sdk'
+
+export {
+    DevCycleProvider,
+    DVCProvider,
+    useDevCycleClient,
+    useDVCClient,
+    useVariable,
+    useVariableValue,
+    withDevCycleProvider,
+    withDVCProvider,
+    useIsDevCycleInitialized,
+    useIsDVCInitialized,
+}

--- a/sdk/react-native-expo/src/withDevCycleProvider.ts
+++ b/sdk/react-native-expo/src/withDevCycleProvider.ts
@@ -1,0 +1,14 @@
+import { withDevCycleProvider as ReactWithDevCycleProvider } from '@devcycle/react-client-sdk'
+import { getReactNativeConfig } from './DevCycleProvider'
+
+export const withDevCycleProvider: typeof ReactWithDevCycleProvider = (
+    config,
+) => {
+    const reactNativeConfig = getReactNativeConfig(config)
+    return ReactWithDevCycleProvider(reactNativeConfig)
+}
+
+/**
+ * @deprecated Use withDevCycleProvider instead
+ */
+export const withDVCProvider = withDevCycleProvider

--- a/sdk/react-native-expo/test-setup.ts
+++ b/sdk/react-native-expo/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-native/extend-expect'

--- a/sdk/react-native-expo/tsconfig.json
+++ b/sdk/react-native-expo/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "module": "ESNext",
+        "allowJs": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/sdk/react-native-expo/tsconfig.lib.json
+++ b/sdk/react-native-expo/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "target": "es5",
+        "outDir": "../../dist/out-tsc",
+        "types": ["node"],
+        "jsx": "react-native"
+    },
+    "exclude": [
+        "jest.config.ts",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "test-setup.ts"
+    ],
+    "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/sdk/react-native-expo/tsconfig.lib.json
+++ b/sdk/react-native-expo/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "es5",
         "outDir": "../../dist/out-tsc",
         "types": ["node"],
         "jsx": "react-native"

--- a/sdk/react-native-expo/tsconfig.spec.json
+++ b/sdk/react-native-expo/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "jest.config.ts",
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/sdk/react/project.json
+++ b/sdk/react/project.json
@@ -16,7 +16,7 @@
             "outputs": ["{options.outputPath}"],
             "options": {
                 "outputPath": "dist/sdk/react",
-                "tsConfig": "sdk/react/tsconfig.lib.json",
+                "tsConfig": "sdk/react/tsconfig.lib.es5.json",
                 "project": "sdk/react/package.json",
                 "entryFile": "sdk/react/src/index.ts",
                 "format": ["esm", "cjs"],
@@ -42,8 +42,9 @@
                 "project": "sdk/react/package.json",
                 "entryFile": "sdk/react/src/index.ts",
                 "format": ["esm", "cjs"],
-                "external": "none",
+                "external": "all",
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                "buildableProjectDepsInPackageJsonType": "dependencies",
                 "compiler": "babel",
                 "assets": [
                     {

--- a/sdk/react/project.json
+++ b/sdk/react/project.json
@@ -33,6 +33,27 @@
                 ]
             }
         },
+        "build:es5": {
+            "executor": "@nrwl/rollup:rollup",
+            "outputs": ["{options.outputPath}"],
+            "options": {
+                "outputPath": "dist/sdk/react",
+                "tsConfig": "sdk/react/tsconfig.lib.es5.json",
+                "project": "sdk/react/package.json",
+                "entryFile": "sdk/react/src/index.ts",
+                "format": ["esm", "cjs"],
+                "external": "none",
+                "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                "compiler": "babel",
+                "assets": [
+                    {
+                        "glob": "sdk/react/README.md",
+                        "input": ".",
+                        "output": "."
+                    }
+                ]
+            }
+        },
         "lint": {
             "executor": "@nx/linter:eslint",
             "outputs": ["{options.outputFile}"],

--- a/sdk/react/tsconfig.lib.es5.json
+++ b/sdk/react/tsconfig.lib.es5.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "target": "es5",
+    },
+}

--- a/sdk/react/tsconfig.lib.es5.json
+++ b/sdk/react/tsconfig.lib.es5.json
@@ -1,6 +1,26 @@
 {
-    "extends": "./tsconfig.lib.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "es5",
+        "target": "ES5",
+        "outDir": "../../dist/out-tsc",
+        "module": "ESNext",
+        "types": ["node"]
     },
+    "files": [
+        "../../node_modules/@nx/react/typings/cssmodule.d.ts",
+        "../../node_modules/@nx/react/typings/image.d.ts"
+    ],
+    "exclude": [
+        "**/*.spec.ts",
+        "**/*.test.ts",
+        "**/*.spec.tsx",
+        "**/*.test.tsx",
+        "**/*.spec.js",
+        "**/*.test.js",
+        "**/*.spec.jsx",
+        "**/*.test.jsx",
+        "**/__mocks__/**/*.ts",
+        "jest.config.ts"
+    ],
+    "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,6 +34,9 @@
             "@devcycle/react-native-client-sdk": [
                 "sdk/react-native/src/index.ts"
             ],
+            "@devcycle/react-native-expo-client-sdk": [
+                "sdk/react-native-expo/src/index.ts"
+            ],
             "@devcycle/types": ["lib/shared/types/src/index.ts"]
         }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@altack/nx-bundlefy@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@altack/nx-bundlefy@npm:0.16.0"
+  dependencies:
+    tslib: ^2.5.0
+  peerDependencies:
+    "@nrwl/devkit": ">=16.5.5"
+    "@nrwl/js": ">=16.5.5"
+    "@nrwl/workspace": ">=16.5.5"
+    validate-npm-package-name: ">=5.0.0"
+  checksum: 94debc979520f1953c1f516a712fdbba2e28918cf46a11e8cacc97aec35095a90a6d6c27fb58774ac980d3b19bbaff967132fcf2a5420acf6c4db5fdeefcedd3
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -14654,6 +14668,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "devcycle-js-sdks@workspace:."
   dependencies:
+    "@altack/nx-bundlefy": ^0.16.0
     "@babel/core": ^7.17.7
     "@babel/preset-react": ^7.14.5
     "@commitlint/cli": ^16.2.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -4914,6 +4914,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@devcycle/react-native-expo-client-sdk@workspace:sdk/react-native-expo":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/react-native-expo-client-sdk@workspace:sdk/react-native-expo"
+  dependencies:
+    "@react-native-async-storage/async-storage": ^1.17.11
+    react-native-device-info: ^8.7.0
+    react-native-get-random-values: ^1.7.2
+  peerDependencies:
+    react-native: ">=0.64.0"
+  languageName: unknown
+  linkType: soft
+
 "@devcycle/types@workspace:lib/shared/types":
   version: 0.0.0-use.local
   resolution: "@devcycle/types@workspace:lib/shared/types"


### PR DESCRIPTION
`nx run react-native-expo:build:expo`

Adds a new package, `react-native-expo`, that is mostly a duplicate of `react-native`, but it triggers new `build:es5` targets in each of the react-native sdk's dependencies, via an executor that then bundles the es5 transpiled dependencies into the package.

Ideally this doesn't remain necessary for long, objective here is to not compromise the react-native sdk, and to allow us to make expo related adjustments as they become necessary.

- DVC-5386