### PR TITLE
chore: add targeting type field

### DIFF
--- a/lib/shared/types/src/types/config/models/featureConfiguration.ts
+++ b/lib/shared/types/src/types/config/models/featureConfiguration.ts
@@ -1,6 +1,10 @@
 import { Audience } from './audience'
 import { Type } from 'class-transformer'
 
+export enum TargetingRuleTypes {
+    override = 'override',
+}
+
 export class RolloutStage {
     /**
      * Defines the transition into this percentage level.
@@ -86,7 +90,7 @@ export class Target<IdType = string> {
      * Field indicating a special kind of targeting rule. Normally blank.
      * Currently indicates virtual targeting rules generated due to overrides.
      */
-    type?: 'override'
+    type?: TargetingRuleTypes
 }
 
 export class FeaturePrerequisites<IdType = string> {

--- a/lib/shared/types/src/types/config/models/featureConfiguration.ts
+++ b/lib/shared/types/src/types/config/models/featureConfiguration.ts
@@ -81,6 +81,12 @@ export class Target<IdType = string> {
      * Specifies variation distribution percentages for features
      */
     distribution: TargetDistribution<IdType>[]
+
+    /**
+     * Field indicating a special kind of targeting rule. Normally blank.
+     * Currently indicates virtual targeting rules generated due to overrides.
+     */
+    type?: 'override'
 }
 
 export class FeaturePrerequisites<IdType = string> {


### PR DESCRIPTION
- add field to denote an override targeting rule in the config