### PR TITLE
fix: add protobufjs dependency to assemblyscript lib

### DIFF
--- a/lib/shared/bucketing-assembly-script/package.json
+++ b/lib/shared/bucketing-assembly-script/package.json
@@ -11,6 +11,9 @@
         "index*",
         "README.md"
     ],
+    "dependencies": {
+        "protobufjs": "^7.2.2"
+    },
     "devDependencies": {
         "@devcycle/bucketing-test-data": "^1.2.19"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4796,6 +4796,7 @@ __metadata:
   resolution: "@devcycle/bucketing-assembly-script@workspace:lib/shared/bucketing-assembly-script"
   dependencies:
     "@devcycle/bucketing-test-data": ^1.2.19
+    protobufjs: ^7.2.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- explicitly depend on protobufjs for the assemblyscript lib, because it requires it in its source files
- fixes using the nodejs sdk in pnpm installations