### PR TITLE
fix: cleanup EventListener for Page Hide event 

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -80,6 +80,7 @@ export class DevCycleClient<
     private pageVisibilityHandler?: () => void
     private inactivityHandlerId?: number
     private windowMessageHandler?: (event: MessageEvent) => void
+    private windowPageHideHandler?: () => void
 
     constructor(
         sdkKey: string,
@@ -134,6 +135,11 @@ export class DevCycleClient<
                 }
             }
             window.addEventListener('message', this.windowMessageHandler)
+
+            this.windowPageHideHandler = () => {
+                this.flushEvents()
+            }
+            window.addEventListener('pagehide', this.windowPageHideHandler)
         }
     }
 
@@ -564,6 +570,10 @@ export class DevCycleClient<
 
         if (this.windowMessageHandler) {
             window.removeEventListener('message', this.windowMessageHandler)
+        }
+
+        if (this.windowPageHideHandler) {
+            window.removeEventListener('pagehide', this.windowPageHideHandler)
         }
 
         this.streamingConnection?.close()

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -115,12 +115,6 @@ export function initializeDevCycle<
             client.logger.error(`Error initializing DevCycle: ${err}`),
         )
 
-    if (!options?.reactNative && typeof window !== 'undefined') {
-        window.addEventListener('pagehide', () => {
-            client.flushEvents()
-        })
-    }
-
     return client
 }
 


### PR DESCRIPTION
- refactor addEventListener for page hide events to be within the Client definition instead of on initialize
- add removeEventListener for page hide events (if defined)
- proposed fix for: https://github.com/DevCycleHQ/js-sdks/issues/550