### PR TITLE
fix: DVC initialized hook rerender

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -57,6 +57,10 @@ export class DevCycleClient<
     logger: DVCLogger
     config?: BucketedUserConfig
     user?: DVCPopulatedUser
+    _isInitialized = false
+    public get isInitialized(): boolean {
+        return this._isInitialized
+    }
 
     private sdkKey: string
     private readonly options: DevCycleOptions
@@ -117,7 +121,10 @@ export class DevCycleClient<
         this.registerVisibilityChangeHandler()
 
         this.onInitialized = new Promise((resolve, reject) => {
-            this.resolveOnInitialized = resolve
+            this.resolveOnInitialized = (value) => {
+                this._isInitialized = true
+                resolve(value)
+            }
         })
 
         if (!this.options.deferInitialization) {

--- a/sdk/react/__mocks__/@devcycle/js-client-sdk.ts
+++ b/sdk/react/__mocks__/@devcycle/js-client-sdk.ts
@@ -37,6 +37,9 @@ class Client {
     close() {
         // no-op
     }
+    onClientInitialized() {
+        return Promise.resolve(this)
+    }
 }
 
 module.exports = {

--- a/sdk/react/src/context.ts
+++ b/sdk/react/src/context.ts
@@ -11,3 +11,10 @@ const { Provider, Consumer } = context
 export { Provider, Consumer }
 export type { DevCycleContext }
 export default context
+
+export type InitializedContext = {
+    isInitialized: boolean
+}
+export const initializedContext = createContext<InitializedContext>({
+    isInitialized: false,
+})

--- a/sdk/react/src/useIsDevCycleInitialized.test.tsx
+++ b/sdk/react/src/useIsDevCycleInitialized.test.tsx
@@ -1,0 +1,90 @@
+import { act, render, screen } from '@testing-library/react'
+import nock from 'nock'
+import { useIsDevCycleInitialized, withDevCycleProvider } from '.'
+import { mockConfig } from '../mockData/mockConfig'
+import { useState } from 'react'
+
+jest.unmock('@devcycle/js-client-sdk')
+
+describe('useIsDevCycleInitialized', () => {
+    const TestApp = () => {
+        const isReady = useIsDevCycleInitialized()
+
+        if (!isReady) {
+            return <div>Loading...</div>
+        }
+
+        return <div>Done</div>
+    }
+
+    it('should render the app once the SDK initializes', async () => {
+        const scope = nock('https://sdk-api.devcycle.com/v1')
+        scope
+            .defaultReplyHeaders({
+                'access-control-allow-origin': '*',
+            })
+            .get('/sdkConfig')
+            .query((query) => query.user_id === 'test_user')
+            .delay(1000)
+            .reply(200, mockConfig)
+
+        const App = withDevCycleProvider({
+            user: { user_id: 'test_user' },
+            sdkKey: 'dvc_test_key',
+        })(TestApp)
+
+        render(<App />)
+
+        expect(await screen.findAllByText('Loading...')).toHaveLength(1)
+        await new Promise((resolve) => scope.on('replied', resolve))
+        expect(await screen.findAllByText('Done')).toHaveLength(1)
+    })
+
+    it('should immediately render if the client is already initialized', async () => {
+        const SubComponent = () => {
+            const isReady = useIsDevCycleInitialized()
+            if (!isReady) {
+                return <div>Child Loading...</div>
+            }
+
+            return <div>Child Done</div>
+        }
+
+        const TestApp = () => {
+            const [showSubComponent, setShowSubComponent] = useState(false)
+            const isReady = useIsDevCycleInitialized()
+
+            return (
+                <div>
+                    <button onClick={() => setShowSubComponent(true)}>
+                        Check
+                    </button>
+                    {showSubComponent && <SubComponent />}
+                    {isReady && <div>Parent Ready</div>}
+                </div>
+            )
+        }
+        const scope = nock('https://sdk-api.devcycle.com/v1')
+        scope
+            .defaultReplyHeaders({
+                'access-control-allow-origin': '*',
+            })
+            .get('/sdkConfig')
+            .query((query) => query.user_id === 'test_user')
+            .reply(200, mockConfig)
+
+        const App = withDevCycleProvider({
+            user: { user_id: 'test_user' },
+            sdkKey: 'dvc_test_key',
+        })(TestApp)
+
+        render(<App />)
+
+        await screen.findByText('Parent Ready')
+        act(() => {
+            screen.getByText('Check').click()
+        })
+        expect(await screen.queryByText('Child Loading...')).toBeFalsy()
+        await screen.findByText('Child Done')
+    })
+})

--- a/sdk/react/src/useIsDevCycleInitialized.ts
+++ b/sdk/react/src/useIsDevCycleInitialized.ts
@@ -1,29 +1,14 @@
-import { useContext, useState } from 'react'
-import context from './context'
+import { useContext } from 'react'
+import { initializedContext } from './context'
 
 export const useIsDevCycleInitialized = (): boolean => {
-    const [isDVCReady, setIsDVCReady] = useState(false)
-    const dvcContext = useContext(context)
-
-    if (dvcContext === undefined)
+    const context = useContext(initializedContext)
+    if (context === undefined)
         throw new Error(
             'useIsDevCycleInitialized must be used within DevCycleProvider',
         )
 
-    if (isDVCReady) return isDVCReady
-
-    dvcContext.client
-        .onClientInitialized()
-        .then(() => {
-            setIsDVCReady(true)
-        })
-        .catch(() => {
-            // set to true to unblock app load
-            console.log('Error initializing DevCycle.')
-            setIsDVCReady(true)
-        })
-
-    return isDVCReady
+    return context.isInitialized
 }
 
 /**


### PR DESCRIPTION
- update React provider to include information on client initialization status
- update `useIsDevCycleInitialized` to read from that context rather than maintaining its own state and initialization listener
- add public `isInitialized` property to JS SDK client