### PR TITLE
add support for initial variable values before config loads

### DIFF
--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -103,6 +103,11 @@ export interface DevCycleOptions {
      * Controls the maximum size the event queue can grow to until events are dropped. Defaults to `1000`.
      */
     maxEventQueueSize?: number
+
+    /**
+     * Provide initial values to use for variables until a fresh config has been loaded
+     */
+    initialVariableValues?: Record<string, string>
 }
 
 export interface DevCycleUser {


### PR DESCRIPTION
- add option to specify initialVariableValues
- these values will be used for variable evaluations until a fresh config is downloaded
- update type comparison between config variables and default values to use the actual inferred type of the value rather than the server's `type` field. 
- use this type comparison to also make initialVariableValues safe