### PR TITLE
fix: Use dynamic import of bucketing-lib for debug/release

### DIFF
--- a/lib/shared/bucketing-assembly-script/index.js
+++ b/lib/shared/bucketing-assembly-script/index.js
@@ -32,15 +32,7 @@ const instantiate = async (debug = false, imports = {}) => {
     })()
 
     // call the instantiate function with the compiled source to execute the WASM and set up the bindings to native code
-    if (debug) {
-        // use .js extension to disambiguate with the .wasm and .wat files
-        const {
-            instantiate: instantiateDebug,
-        } = require('./build/bucketing-lib.debug.js')
-        return await instantiateDebug(compiled, imports)
-    } else {
-        return await instantiate(compiled, imports)
-    }
+    return await instantiate(compiled, imports)
 }
 
 module.exports = {


### PR DESCRIPTION
When bundling a project with webpack that contains the node sdk, the build will fail because `bucketing-lib.debug.js` cannot be found

`instantiate` is already loaded based on the release type `const { instantiate } = require(`./build/bucketing-lib.${releaseStr}.js`)`

Remove extra `require` that is specific to debug import