### PR TITLE
ci: Add a skeleton release workflow to allow testing on GA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Prerelease"
+        required: true
+        default: false
+        type: boolean
+      draft:
+        description: "Draft"
+        required: true
+        default: false
+        type: boolean
+      version-increment-type:
+          description: 'Which part of the version to increment:'
+          required: true
+          type: choice
+          options:
+            - major
+            - minor
+            - patch
+          default: 'patch'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the repo with credentials that can bypass branch protection, and fetch git history instead of just latest commit
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+          fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,38 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      prerelease:
-        description: "Prerelease"
-        required: true
-        default: false
-        type: boolean
-      draft:
-        description: "Draft"
-        required: true
-        default: false
-        type: boolean
-      version-increment-type:
-          description: 'Which part of the version to increment:'
-          required: true
-          type: choice
-          options:
-            - major
-            - minor
-            - patch
-          default: 'patch'
+    workflow_dispatch:
+        inputs:
+            prerelease:
+                description: 'Prerelease'
+                required: true
+                default: false
+                type: boolean
+            draft:
+                description: 'Draft'
+                required: true
+                default: false
+                type: boolean
+            version-increment-type:
+                description: 'Which part of the version to increment:'
+                required: true
+                type: choice
+                options:
+                    - major
+                    - minor
+                    - patch
+                default: 'patch'
 
 permissions:
-  contents: write
+    contents: write
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+    release:
+        runs-on: ubuntu-latest
 
-    steps:
-      # Check out the repo with credentials that can bypass branch protection, and fetch git history instead of just latest commit
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
-          fetch-depth: 0
+        steps:
+            # Check out the repo with credentials that can bypass branch protection, and fetch git history instead of just latest commit
+            - uses: actions/checkout@v3
+              with:
+                  token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+                  fetch-depth: 0


### PR DESCRIPTION
This just allows testing the workflow on a branch later - the file needs to be merged first.