### PR TITLE
chore: bump react native expo sdk version to match react native sdk

### DIFF
--- a/sdk/react-native-expo/package.json
+++ b/sdk/react-native-expo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devcycle/react-native-expo-client-sdk",
-    "version": "1.5.3",
+    "version": "1.5.10",
     "description": "The DevCycle React Native Expo SDK used for feature management.",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
- previous PR was stale and did not have the correct version 