### PR TITLE
fix: Use populated user when checking if user is anonymous

### DIFF
--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -233,6 +233,19 @@ describe('DevCycleClient tests', () => {
         expect(window.localStorage.getItem(StoreKey.AnonUserId)).toBeNull()
     })
 
+    it('should not clear the anonymous user id from local storage when initialized without user_id and isAnonymous', async () => {
+        window.localStorage.setItem(
+            StoreKey.AnonUserId,
+            JSON.stringify('anon_user_id'),
+        )
+        const client = new DevCycleClient('test_sdk_key', {})
+        await client.onClientInitialized()
+        expect(client.user.user_id).toEqual('anon_user_id')
+        expect(window.localStorage.getItem(StoreKey.AnonUserId)).toEqual(
+            JSON.stringify('anon_user_id'),
+        )
+    })
+
     describe('onClientInitialized', () => {
         beforeEach(() => {
             getConfigJson_mock.mockImplementation(() => {

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -216,7 +216,7 @@ export class DevCycleClient<
 
         this.eventEmitter.emitInitialized(true)
 
-        if (initialUser.isAnonymous) {
+        if (this.user.isAnonymous) {
             this.store.saveAnonUserId(this.user.user_id)
         } else {
             this.store.removeAnonUserId()

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -117,14 +117,13 @@ export interface DevCycleOptions {
 
 export interface DevCycleUser {
     /**
-     * Users must be explicitly defined as anonymous, where the SDK will
-     * generate a random `user_id` for them. If they are `isAnonymous = false`
-     * a `user_id` value must be provided.
+     * If a user is anonymous a unique anonymous user id will be generated and stored in the cache.
+     * If no user_id is provided, the user is assumed to be anonymous.
      */
     isAnonymous?: boolean
 
     /**
-     * Must be defined if `isAnonymous = false`
+     * A unique user ID. If not provided, an anonymous user ID will be generated.
      */
     user_id?: string
 


### PR DESCRIPTION
In [this PR](https://github.com/DevCycleHQ/js-sdks/commit/beed17838888d8aedc53e520721fa5d3a934ec56#diff-7e88ae7eb811449dfe4a792952dab7d8accab565833b6a8a5764488a232d4325R191) there was a change that switched from using the populated user to using the initial user to check if the user is anonymous. 

`isAnonymous` would only be true on the initial user if the SDK is explicitly called with this property. The populated user will have isAnonymous set to true if a user id is not specified.

This would cause the cached anonymous user ID to be cleared on every initialization, resulting in more MAUs than expected.