### PR TITLE
fix: Remove protoc installation in workflows

### DIFF
--- a/.github/workflows/nx-affected-test.yml
+++ b/.github/workflows/nx-affected-test.yml
@@ -17,8 +17,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
-            - name: Install protoc for protobuf compilation
-              run: sudo apt-get install -y protobuf-compiler
             - run: git fetch origin main
             - run: yarn --immutable
             - run: yarn affected:lint

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -19,8 +19,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
-            - name: Install protoc for protobuf compilation
-              run: sudo apt-get install -y protobuf-compiler
             - name: Run Yarn
               run: yarn --immutable
             - name: Check affected projects


### PR DESCRIPTION
This step takes a few minutes on every run, but I'm pretty sure it's no longer required.