### PR TITLE
fix: add tests for init in deferred mode and with boostrap config

### DIFF
--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -75,8 +75,8 @@ describe('DevCycleClient tests', () => {
         const spy = jest.spyOn(window.localStorage.__proto__, 'getItem')
         const client = new DevCycleClient('test_sdk_key', { user_id: 'user1' })
         await client.onInitialized
-        // one call to get anon ID, one to get cached config
-        expect(spy).toHaveBeenCalledTimes(2)
+        // one call to get cached config
+        expect(spy).toHaveBeenCalledTimes(1)
         // construct another client to test if it reads from the cache populated by the initialization of the first
         // client
         const client2 = new DevCycleClient(
@@ -85,8 +85,7 @@ describe('DevCycleClient tests', () => {
             { bootstrapConfig: testConfig },
         )
         await client2.onInitialized
-        // one more call to get anon ID
-        expect(spy).toHaveBeenCalledTimes(3)
+        expect(spy).toHaveBeenCalledTimes(1)
         expect(client2.config).toStrictEqual(testConfig)
     })
 

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -132,7 +132,7 @@ export class DevCycleClient<
             if (!user) {
                 throw new Error('User must be provided to initialize SDK')
             }
-            this.clientInitialization(user)
+            void this.clientInitialization(user)
         } else if (this.options.bootstrapConfig) {
             throw new Error(
                 'bootstrapConfig option can not be combined with deferred initialization!',
@@ -167,7 +167,9 @@ export class DevCycleClient<
         }
         this.initializeTriggered = true
 
-        const storedAnonymousId = await this.store.loadAnonUserId()
+        const storedAnonymousId = initialUser.user_id
+            ? undefined
+            : await this.store.loadAnonUserId()
 
         this.user = new DVCPopulatedUser(
             initialUser,

--- a/sdk/react/src/useIsDevCycleInitialized.test.tsx
+++ b/sdk/react/src/useIsDevCycleInitialized.test.tsx
@@ -103,6 +103,7 @@ describe('useIsDevCycleInitialized', () => {
 
         const App = withDevCycleProvider({
             sdkKey: 'dvc_test_key',
+            user: { user_id: 'test_user' },
             options: {
                 bootstrapConfig: {} as BucketedUserConfig,
             },

--- a/sdk/react/src/useIsDevCycleInitialized.test.tsx
+++ b/sdk/react/src/useIsDevCycleInitialized.test.tsx
@@ -1,8 +1,15 @@
 import { act, render, screen } from '@testing-library/react'
 import nock from 'nock'
-import { useIsDevCycleInitialized, withDevCycleProvider } from '.'
+import {
+    DevCycleClient,
+    useDevCycleClient,
+    useIsDevCycleInitialized,
+    withDevCycleProvider,
+} from '.'
 import { mockConfig } from '../mockData/mockConfig'
 import { useState } from 'react'
+import { setTimeout } from '@testing-library/react-native/build/helpers/timers'
+import { BucketedUserConfig } from '@devcycle/types'
 
 jest.unmock('@devcycle/js-client-sdk')
 
@@ -37,6 +44,72 @@ describe('useIsDevCycleInitialized', () => {
 
         expect(await screen.findAllByText('Loading...')).toHaveLength(1)
         await new Promise((resolve) => scope.on('replied', resolve))
+        expect(await screen.findAllByText('Done')).toHaveLength(1)
+    })
+
+    it('should render after identification with deferred initialization', async () => {
+        const scope = nock('https://sdk-api.devcycle.com/v1')
+        scope
+            .defaultReplyHeaders({
+                'access-control-allow-origin': '*',
+            })
+            .get('/sdkConfig')
+            .query((query) => query.user_id === 'test_user')
+            .delay(1000)
+            .reply(200, mockConfig)
+
+        let client: DevCycleClient
+
+        const TestApp = () => {
+            const isReady = useIsDevCycleInitialized()
+            client = useDevCycleClient()
+
+            if (!isReady) {
+                return <div>Loading...</div>
+            }
+
+            return <div>Done</div>
+        }
+
+        const App = withDevCycleProvider({
+            sdkKey: 'dvc_test_key',
+            options: {
+                deferInitialization: true,
+            },
+        })(TestApp)
+
+        render(<App />)
+
+        expect(await screen.findAllByText('Loading...')).toHaveLength(1)
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+        expect(scope.isDone()).toBe(false)
+        act(() => {
+            client.identifyUser({ user_id: 'test_user' })
+        })
+        await new Promise((resolve) => scope.on('replied', resolve))
+        expect(await screen.findAllByText('Done')).toHaveLength(1)
+    })
+
+    it('should render skipping loading state if bootstrapped', async () => {
+        const TestApp = () => {
+            const isReady = useIsDevCycleInitialized()
+
+            if (!isReady) {
+                return <div>Loading...</div>
+            }
+
+            return <div>Done</div>
+        }
+
+        const App = withDevCycleProvider({
+            sdkKey: 'dvc_test_key',
+            options: {
+                bootstrapConfig: {} as BucketedUserConfig,
+            },
+        })(TestApp)
+
+        render(<App />)
+
         expect(await screen.findAllByText('Done')).toHaveLength(1)
     })
 

--- a/sdk/react/src/useIsDevCycleInitialized.test.tsx
+++ b/sdk/react/src/useIsDevCycleInitialized.test.tsx
@@ -110,7 +110,7 @@ describe('useIsDevCycleInitialized', () => {
 
         render(<App />)
 
-        expect(await screen.findAllByText('Done')).toHaveLength(1)
+        expect(screen.getAllByText('Done')).toHaveLength(1)
     })
 
     it('should immediately render if the client is already initialized', async () => {


### PR DESCRIPTION
- add tests for deferred mode and bootstrap  config mode for react sdk initialization
- ensure that boostrap config leads to an "initialized" first render
