### PR TITLE
fix: make the invalidateConfig function importable and providable to SDK

### DIFF
--- a/sdk/nextjs/README.md
+++ b/sdk/nextjs/README.md
@@ -22,6 +22,8 @@ Official SDK for integrating DevCycle feature flags with your Next.js applicatio
 ### Wrap your app in the DevCycleServersideProvider
 In a server component (as early as possible in the tree):
 ```typescript jsx
+import { DevCycleServersideProvider, invalidateConfig } from '@devcycle/nextjs-sdk/server'
+
 export default async function RootLayout({
  children,
 }: {
@@ -39,6 +41,7 @@ export default async function RootLayout({
                     options={{
                         enableStreaming: true,
                     }}
+                    invalidateConfig={invalidateConfig}
                 >
                     {children}
                 </DevCycleServersideProvider>
@@ -47,6 +50,9 @@ export default async function RootLayout({
     )
 }
 ```
+It is important to import and provide the `invalidateConfig` function to the DevCycleServersideProvider. This works
+around a bug in NextJS where the server action is not bundled correctly due to being defined in an NPM module.
+
 Note: You _must_ use the client SDK key of your project, not the server SDK key. The key is used across the server and
 the client and will be sent to the clientside to bootstrap the client SDK.
 

--- a/sdk/nextjs/src/client/DevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/DevCycleClientsideProvider.tsx
@@ -12,7 +12,7 @@ type DevCycleClientsideProviderProps = {
     serverDataPromise: Promise<DevCycleServerDataForClient>
     sdkKey: string
     user: DevCycleUser
-    invalidateConfig: (sdkKey: string, date?: number) => Promise<void>
+    invalidateConfig?: (sdkKey: string, date?: number) => Promise<void>
     enableStreaming: boolean
     children: React.ReactNode
 }
@@ -70,15 +70,23 @@ export const DevCycleClientsideProvider = ({
     const clientRef = useRef<DevCycleClient>()
 
     const revalidateConfig = (lastModified?: number) => {
-        invalidateConfig(sdkKey, lastModified).finally(() => {
+        invalidateConfig?.(sdkKey, lastModified).finally(() => {
             router.refresh()
         })
+    }
+
+    if (!invalidateConfig) {
+        console.warn(
+            'DevCycle: invalidateConfig prop not provided. Realtime updates will not work. ' +
+                'Check documentation for details.',
+        )
     }
 
     if (!clientRef.current) {
         clientRef.current = initializeDevCycle(sdkKey, user, {
             deferInitialization: true,
             disableConfigCache: true,
+            disableRealtimeUpdates: !invalidateConfig,
             next: {
                 configRefreshHandler: revalidateConfig,
             },

--- a/sdk/nextjs/src/client/DevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/DevCycleClientsideProvider.tsx
@@ -6,13 +6,13 @@ import {
     initializeDevCycle,
 } from '@devcycle/js-client-sdk'
 import { useRouter } from 'next/navigation'
-import { invalidateConfig } from '../common/invalidateConfig'
 import { DevCycleServerDataForClient } from '../common/types'
 
 type DevCycleClientsideProviderProps = {
     serverDataPromise: Promise<DevCycleServerDataForClient>
     sdkKey: string
     user: DevCycleUser
+    invalidateConfig: (sdkKey: string, date?: number) => Promise<void>
     enableStreaming: boolean
     children: React.ReactNode
 }
@@ -62,6 +62,7 @@ export const DevCycleClientsideProvider = ({
     serverDataPromise,
     sdkKey,
     enableStreaming,
+    invalidateConfig,
     user,
     children,
 }: DevCycleClientsideProviderProps): React.ReactElement => {

--- a/sdk/nextjs/src/server/DevCycleServersideProvider.tsx
+++ b/sdk/nextjs/src/server/DevCycleServersideProvider.tsx
@@ -10,6 +10,7 @@ export type DevCycleServersideProviderProps = {
     sdkKey: string
     // server-side users must always be "identified" with a user id
     user: Omit<DevCycleUser, 'user_id' | 'isAnonymous'> & { user_id: string }
+    invalidateConfig: (sdkKey: string, time?: number) => Promise<void>
     options?: DevCycleNextOptions
     children: React.ReactNode
 }
@@ -18,6 +19,7 @@ export const DevCycleServersideProvider = async ({
     children,
     sdkKey,
     user,
+    invalidateConfig,
     options,
 }: DevCycleServersideProviderProps): Promise<React.ReactElement> => {
     const serverDataPromise = initialize(sdkKey, user, options)
@@ -42,6 +44,7 @@ export const DevCycleServersideProvider = async ({
         <DevCycleClientsideProvider
             serverDataPromise={serverDataPromise}
             user={identifiedUser}
+            invalidateConfig={invalidateConfig}
             sdkKey={getSDKKey()}
             enableStreaming={options?.enableStreaming ?? false}
         >

--- a/sdk/nextjs/src/server/DevCycleServersideProvider.tsx
+++ b/sdk/nextjs/src/server/DevCycleServersideProvider.tsx
@@ -10,7 +10,7 @@ export type DevCycleServersideProviderProps = {
     sdkKey: string
     // server-side users must always be "identified" with a user id
     user: Omit<DevCycleUser, 'user_id' | 'isAnonymous'> & { user_id: string }
-    invalidateConfig: (sdkKey: string, time?: number) => Promise<void>
+    invalidateConfig?: (sdkKey: string, time?: number) => Promise<void>
     options?: DevCycleNextOptions
     children: React.ReactNode
 }


### PR DESCRIPTION
- work around the problem where server actions in NPM packages don't work by requiring the user to import the action and pass it in to the sdk