### PR TITLE
fix: separate es5 build outputs and patch bundlefy to use the correct target

### DIFF
--- a/.yarn/patches/@altack-nx-bundlefy-npm-0.16.0-fc464002e3.patch
+++ b/.yarn/patches/@altack-nx-bundlefy-npm-0.16.0-fc464002e3.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/index.js b/dist/index.js
+index 7af9fca6297b30f9a59f77dc5330200a37f0c432..904cfcfaade5eeb5e6b55e7d6e097087e474cf9e 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -23,7 +23,7 @@ function updateBundledDependencies(root, projectName, configurationName, node, d
+         overrides: {},
+         target: {
+             project: projectName,
+-            target: 'build',
++            target: 'build:es5',
+             configuration: configurationName,
+         }
+     }, node);
+@@ -72,7 +72,7 @@ function toBundableDependency(context, projectGraph, dependencyName) {
+         overrides: {},
+         target: {
+             project: context.projectName,
+-            target: 'build',
++            target: 'build:es5',
+             configuration: context.configurationName
+         }
+     }, projectGraph.nodes[dependencyName]);

--- a/lib/shared/types/project.json
+++ b/lib/shared/types/project.json
@@ -45,7 +45,7 @@
                 "format": ["cjs"],
                 "external": "all",
                 "project": "lib/shared/types/package.json",
-                "outputPath": "dist/lib/shared/types",
+                "outputPath": "dist/lib/shared/es5/types",
                 "entryFile": "lib/shared/types/src/index.ts",
                 "tsConfig": "lib/shared/types/tsconfig.lib.es5.json",
                 "assets": [

--- a/package.json
+++ b/package.json
@@ -203,7 +203,8 @@
         "semver@7.0.0": "^7.5.2",
         "semver@7.3.4": "^7.5.2",
         "semver@7.3.7": "^7.5.2",
-        "semver@7.5.3": "^7.5.2"
+        "semver@7.5.3": "^7.5.2",
+        "@altack/nx-bundlefy@^0.16.0": "patch:@altack/nx-bundlefy@npm%3A0.16.0#./.yarn/patches/@altack-nx-bundlefy-npm-0.16.0-fc464002e3.patch"
     },
     "config": {
         "commitizen": {

--- a/sdk/js/project.json
+++ b/sdk/js/project.json
@@ -51,7 +51,7 @@
             "executor": "@nx/js:tsc",
             "outputs": ["{options.outputPath}"],
             "options": {
-                "outputPath": "dist/sdk/js",
+                "outputPath": "dist/sdk/es5/js",
                 "tsConfig": "sdk/js/tsconfig.lib.es5.json",
                 "packageJson": "sdk/js/package.json",
                 "main": "sdk/js/src/index.ts",

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -25,7 +25,11 @@
         "build:es5": {
             "dependsOn": [
                 "shared-types:build:es5",
+                "shared-types:build",
                 "js:build:es5",
+                "js:build",
+                "react:build:es5",
+                "react:build",
                 "react:build:es5"
             ],
             "executor": "@nrwl/rollup:rollup",

--- a/sdk/react/project.json
+++ b/sdk/react/project.json
@@ -36,7 +36,7 @@
             "executor": "@nrwl/rollup:rollup",
             "outputs": ["{options.outputPath}"],
             "options": {
-                "outputPath": "dist/sdk/react",
+                "outputPath": "dist/sdk/es5/react",
                 "tsConfig": "sdk/react/tsconfig.lib.es5.json",
                 "project": "sdk/react/package.json",
                 "entryFile": "sdk/react/src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altack/nx-bundlefy@npm:^0.16.0":
+"@altack/nx-bundlefy@npm:0.16.0":
   version: 0.16.0
   resolution: "@altack/nx-bundlefy@npm:0.16.0"
   dependencies:
@@ -30,6 +30,20 @@ __metadata:
     "@nrwl/workspace": ">=16.5.5"
     validate-npm-package-name: ">=5.0.0"
   checksum: 94debc979520f1953c1f516a712fdbba2e28918cf46a11e8cacc97aec35095a90a6d6c27fb58774ac980d3b19bbaff967132fcf2a5420acf6c4db5fdeefcedd3
+  languageName: node
+  linkType: hard
+
+"@altack/nx-bundlefy@patch:@altack/nx-bundlefy@npm%3A0.16.0#./.yarn/patches/@altack-nx-bundlefy-npm-0.16.0-fc464002e3.patch::locator=devcycle-js-sdks%40workspace%3A.":
+  version: 0.16.0
+  resolution: "@altack/nx-bundlefy@patch:@altack/nx-bundlefy@npm%3A0.16.0#./.yarn/patches/@altack-nx-bundlefy-npm-0.16.0-fc464002e3.patch::version=0.16.0&hash=6ef5ca&locator=devcycle-js-sdks%40workspace%3A."
+  dependencies:
+    tslib: ^2.5.0
+  peerDependencies:
+    "@nrwl/devkit": ">=16.5.5"
+    "@nrwl/js": ">=16.5.5"
+    "@nrwl/workspace": ">=16.5.5"
+    validate-npm-package-name: ">=5.0.0"
+  checksum: 32403eaf889b6a6a28f1f695210fa0eebf1d450afbcf6d6c6e54bcd393e0f907b5ac3e9ac0aef5c9e74e951c9b5ff13070e4a8fe5390c3f2a626b9ac1c05e4a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- output es5 builds to an es5 subdirectory in dist/
- patch the bundlefy package so that it looks at our build:es5 target to determine the path to copy the output files from
