### PR TITLE
chore: fix release by allowing nextjs tags

### DIFF
--- a/scripts/lerna-version-ci.sh
+++ b/scripts/lerna-version-ci.sh
@@ -94,7 +94,7 @@ PACKAGES=$(IFS=','; echo "${PACKAGES[*]}")
 
 echo -e "::info::Applying version increment $VERSION_INCREMENT_TYPE to packages:\n$PACKAGES"
 
-yarn lerna version --force-publish=$PACKAGES --ignore-changes --message "chore(release): publish" --no-push --yes "$VERSION_INCREMENT_TYPE"
+yarn lerna version --force-publish=$PACKAGES --message "chore(release): publish" --no-push --yes "$VERSION_INCREMENT_TYPE"
 
 # store the tags created for this commit
 RELEASE_TAGS=$(git tag --points-at HEAD)

--- a/sdk/nextjs/package.json
+++ b/sdk/nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devcycle/nextjs-sdk",
-    "version": "0.0.1-beta.2",
+    "version": "0.0.1",
     "dependencies": {
         "@devcycle/bucketing": "^1.7.1",
         "@devcycle/js-client-sdk": "^1.16.1",


### PR DESCRIPTION
- fix the release process by allowing nextjs releases to be tagged
- the sdk still has no "publish" task so it won't publish any of these versions