### PR TITLE
fix: call close on correct reference to client

### DIFF
--- a/sdk/react/src/DevCycleProvider.tsx
+++ b/sdk/react/src/DevCycleProvider.tsx
@@ -25,7 +25,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
         throw new Error('You must provide a sdkKey to DevCycleProvider')
     }
 
-    const [client] = useState<DevCycleClient>(
+    const [client] = useState<DevCycleClient>(() =>
         initializeDevCycleClient(sdkKey, user, {
             ...options,
         }),

--- a/sdk/react/src/DevCycleProvider.tsx
+++ b/sdk/react/src/DevCycleProvider.tsx
@@ -44,7 +44,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
             })
 
         return () => {
-            client?.close()
+            void client.close()
         }
     }, [client])
 

--- a/sdk/react/src/DevCycleProvider.tsx
+++ b/sdk/react/src/DevCycleProvider.tsx
@@ -32,8 +32,6 @@ export function DevCycleProvider(props: Props): React.ReactElement {
     )
 
     useEffect(() => {
-        // assert this is defined otherwise we have a bug
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         client
             .onClientInitialized()
             .then(() => {
@@ -51,7 +49,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
     }, [client])
 
     return (
-        <Provider value={{ client: client }}>
+        <Provider value={{ client }}>
             <initializedContext.Provider
                 value={{
                     isInitialized: isInitialized || client.isInitialized,

--- a/sdk/react/src/DevCycleProvider.tsx
+++ b/sdk/react/src/DevCycleProvider.tsx
@@ -33,10 +33,11 @@ export function DevCycleProvider(props: Props): React.ReactElement {
     }
 
     useEffect(() => {
+        const client = clientRef.current
         // assert this is defined otherwise we have a bug
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        clientRef
-            .current!.onClientInitialized()
+        client!
+            .onClientInitialized()
             .then(() => {
                 setIsInitialized(true)
             })
@@ -47,7 +48,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
             })
 
         return () => {
-            clientRef.current?.close()
+            client?.close()
         }
     }, [])
 

--- a/sdk/react/src/useIsDevCycleInitialized.test.tsx
+++ b/sdk/react/src/useIsDevCycleInitialized.test.tsx
@@ -14,16 +14,6 @@ import { BucketedUserConfig } from '@devcycle/types'
 jest.unmock('@devcycle/js-client-sdk')
 
 describe('useIsDevCycleInitialized', () => {
-    const TestApp = () => {
-        const isReady = useIsDevCycleInitialized()
-
-        if (!isReady) {
-            return <div>Loading...</div>
-        }
-
-        return <div>Done</div>
-    }
-
     it('should render the app once the SDK initializes', async () => {
         const scope = nock('https://sdk-api.devcycle.com/v1')
         scope
@@ -34,6 +24,16 @@ describe('useIsDevCycleInitialized', () => {
             .query((query) => query.user_id === 'test_user')
             .delay(1000)
             .reply(200, mockConfig)
+
+        const TestApp = () => {
+            const isReady = useIsDevCycleInitialized()
+
+            if (!isReady) {
+                return <div>Loading...</div>
+            }
+
+            return <div>Done</div>
+        }
 
         const App = withDevCycleProvider({
             user: { user_id: 'test_user' },


### PR DESCRIPTION
React in strict mode mounts and renders a component twice in development.

Our current DevCycleProvider calls `client.close` in its useEffect cleanup function, which is normally fine, except in strict mode it seems that the ref is "shared" between multiple mounts of a component. I think this is actually a bug in React:
https://github.com/facebook/react/issues/24670

To fix it, we basically need to not use a ref here and store the client in state instead. The state is properly "reset" when the component is re-mounted, so the "close" call that happens on the first instance's cleanup function does not cause the client instance on the second mount to close.
