### PR TITLE
fix: streaming in cases where the promise resolves before the layout is rendered

### DIFF
--- a/e2e/nextjs/app-router/app/app/layout.tsx
+++ b/e2e/nextjs/app-router/app/app/layout.tsx
@@ -16,7 +16,7 @@ export default async function RootLayout({
     return (
         <html lang="en">
             <body>
-                <DevCycleClientsideProvider context={await getClientContext()}>
+                <DevCycleClientsideProvider context={getClientContext()}>
                     {children}
                 </DevCycleClientsideProvider>
             </body>

--- a/e2e/nextjs/app-router/app/app/page.tsx
+++ b/e2e/nextjs/app-router/app/app/page.tsx
@@ -3,7 +3,7 @@ import { ServerComponent } from '@/app/ServerComponent'
 import React, { Suspense } from 'react'
 import Link from 'next/link'
 
-export const Home = ({
+const Home = ({
     searchParams,
 }: {
     searchParams: { [key: string]: string | string[] | undefined }

--- a/e2e/nextjs/app-router/app/app/shared.ts
+++ b/e2e/nextjs/app-router/app/app/shared.ts
@@ -2,7 +2,6 @@ import { setupDevCycle } from '@devcycle/nextjs-sdk/server'
 const { getVariableValue, getClientContext } = setupDevCycle(
     process.env.NEXT_PUBLIC_E2E_NEXTJS_KEY ?? '',
     async () => {
-        // await new Promise((resolve) => setTimeout(resolve, 5000))
         return {
             user_id: '123',
         }

--- a/e2e/nextjs/app-router/app/app/shared.ts
+++ b/e2e/nextjs/app-router/app/app/shared.ts
@@ -1,9 +1,12 @@
 import { setupDevCycle } from '@devcycle/nextjs-sdk/server'
 const { getVariableValue, getClientContext } = setupDevCycle(
     process.env.NEXT_PUBLIC_E2E_NEXTJS_KEY ?? '',
-    async () => ({
-        user_id: '123',
-    }),
+    async () => {
+        // await new Promise((resolve) => setTimeout(resolve, 5000))
+        return {
+            user_id: '123',
+        }
+    },
     { enableStreaming: true },
 )
 

--- a/e2e/nextjs/app-router/app/package.json
+++ b/e2e/nextjs/app-router/app/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@devcycle/nextjs-sdk": "file:../../../../dist/sdk/nextjs",
-        "next": "14.0.4",
+        "next": "14.0.5-canary.38",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/e2e/nextjs/app-router/app/yarn.lock
+++ b/e2e/nextjs/app-router/app/yarn.lock
@@ -42,7 +42,7 @@ __metadata:
 
 "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs::locator=app%40workspace%3A.":
   version: 0.0.4
-  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=855a37&locator=app%40workspace%3A."
+  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=054769&locator=app%40workspace%3A."
   dependencies:
     "@devcycle/bucketing": "npm:^1.7.4"
     "@devcycle/js-client-sdk": "npm:^1.16.3"
@@ -53,7 +53,7 @@ __metadata:
   peerDependencies:
     next: ^14.0.0
     react: ^18.2.0
-  checksum: 1e08e3ad45df8dab2ca68cab44b7e63a8d962eac66cd0a26aebad4e80e0f72638b7591e8a3ac0b2b02cb67f14a3c109cf445818c7a8b890e67b7954dde4f1ab2
+  checksum: 715278aacb7e506c179faee89b47f3927a7349f32b208d7870ad2921bdc1bc40dcbaf620570785d0d7d90c847e86168ef6d0c382fcf51791eadc486a58622545
   languageName: node
   linkType: hard
 

--- a/e2e/nextjs/app-router/app/yarn.lock
+++ b/e2e/nextjs/app-router/app/yarn.lock
@@ -42,7 +42,7 @@ __metadata:
 
 "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs::locator=app%40workspace%3A.":
   version: 0.0.4
-  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=054769&locator=app%40workspace%3A."
+  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=a24e4a&locator=app%40workspace%3A."
   dependencies:
     "@devcycle/bucketing": "npm:^1.7.4"
     "@devcycle/js-client-sdk": "npm:^1.16.3"
@@ -53,7 +53,7 @@ __metadata:
   peerDependencies:
     next: ^14.0.0
     react: ^18.2.0
-  checksum: 715278aacb7e506c179faee89b47f3927a7349f32b208d7870ad2921bdc1bc40dcbaf620570785d0d7d90c847e86168ef6d0c382fcf51791eadc486a58622545
+  checksum: 95187ce7a8e6a4e6068bdf03c32f7ff352a8413b58fe31c919859b86be6e621413b2791f19a677fc823325cf91b4cdbfd849bbf1edf68c60db6d0b6908651a67
   languageName: node
   linkType: hard
 

--- a/e2e/nextjs/pages-router/app/package.json
+++ b/e2e/nextjs/pages-router/app/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@devcycle/nextjs-sdk": "file:../../../../dist/sdk/nextjs",
-        "next": "14.0.4",
+        "next": "14.0.5-canary.38",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/e2e/nextjs/pages-router/app/yarn.lock
+++ b/e2e/nextjs/pages-router/app/yarn.lock
@@ -28,7 +28,7 @@ __metadata:
 
 "@devcycle/js-client-sdk@file:../../../../dist/sdk/js::locator=app%40workspace%3A.":
   version: 1.16.3
-  resolution: "@devcycle/js-client-sdk@file:../../../../dist/sdk/js#../../../../dist/sdk/js::hash=6237d3&locator=app%40workspace%3A."
+  resolution: "@devcycle/js-client-sdk@file:../../../../dist/sdk/js#../../../../dist/sdk/js::hash=9f1169&locator=app%40workspace%3A."
   dependencies:
     "@devcycle/types": "npm:^1.4.3"
     axios: "npm:^1.0.0"
@@ -36,13 +36,13 @@ __metadata:
     lodash: "npm:^4.17.21"
     ua-parser-js: "npm:^1.0.36"
     uuid: "npm:^8.3.2"
-  checksum: 8534e04d4c4206a3d592c67c34e4d3e1678ab579fc427a21541b744ddb6cecd478e552c449aa64afea3cf190768f61d9466ceaf53fe2adce046cfe7f477e1e08
+  checksum: 55969603a19f6d6dd8736896c7e82ea6a05c061b5c47f05c795f837163b3f0b54765ac8a6182b32933bdbcf1ee8370d0b5b75e17ea2c801491c5b35c5b8684b6
   languageName: node
   linkType: hard
 
 "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs::locator=app%40workspace%3A.":
   version: 0.0.4
-  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=11f915&locator=app%40workspace%3A."
+  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=a24e4a&locator=app%40workspace%3A."
   dependencies:
     "@devcycle/bucketing": "npm:^1.7.4"
     "@devcycle/js-client-sdk": "npm:^1.16.3"
@@ -53,20 +53,20 @@ __metadata:
   peerDependencies:
     next: ^14.0.0
     react: ^18.2.0
-  checksum: 3b1947b28c1cbf2ac2eded4d30d48312a4b33e8d606b0cc3c13431ddf0f5bdbc608248ce9ed4ee0cb9a188e61563f325d9c003903d2ea4038bb194a18c5e2dca
+  checksum: 95187ce7a8e6a4e6068bdf03c32f7ff352a8413b58fe31c919859b86be6e621413b2791f19a677fc823325cf91b4cdbfd849bbf1edf68c60db6d0b6908651a67
   languageName: node
   linkType: hard
 
 "@devcycle/react-client-sdk@file:../../../../dist/sdk/react::locator=app%40workspace%3A.":
   version: 1.14.3
-  resolution: "@devcycle/react-client-sdk@file:../../../../dist/sdk/react#../../../../dist/sdk/react::hash=7e87a5&locator=app%40workspace%3A."
+  resolution: "@devcycle/react-client-sdk@file:../../../../dist/sdk/react#../../../../dist/sdk/react::hash=270cdd&locator=app%40workspace%3A."
   dependencies:
     "@devcycle/js-client-sdk": "npm:^1.16.3"
     "@devcycle/types": "npm:^1.4.3"
     hoist-non-react-statics: "npm:^3.3.2"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: 188179d78fd65ad77faafee06f6c394c0e1e719a4d94c3d4884349aab1802884b8740477cf3d5c6f639c232c588ec487f20ce0c36d3a44fa21d566ac6fddd7f9
+  checksum: 9cef0c3d4540ca394c37ceb25e4a2781e0801609c2ee2f4c9b401567477432d1e8dd38a4cf0317c6dc99f5ba2713c4108605e6662e32195f84cd5681d21bdc05
   languageName: node
   linkType: hard
 

--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -1,0 +1,131 @@
+'use client'
+import React, { Suspense, use, useContext, useRef, useState } from 'react'
+import { DevCycleClient, initializeDevCycle } from '@devcycle/js-client-sdk'
+import { useRouter } from 'next/navigation'
+import { invalidateConfig } from '../../common/invalidateConfig'
+import { DevCycleServerData } from '../../common/types'
+import { DevCycleProviderContext } from './context'
+
+export type DevCycleClientContext = {
+    serverDataPromise: Promise<DevCycleServerData>
+    serverData?: DevCycleServerData
+    sdkKey: string
+    enableStreaming: boolean
+    userAgent?: string
+}
+
+type DevCycleClientsideProviderProps = {
+    context: DevCycleClientContext
+    promiseResolved: boolean
+    children: React.ReactNode
+}
+
+/**
+ * Component which renders nothing, but runs code to keep client state in sync with server
+ * Also waits for the server's data promise with the `use` hook. This triggers the nearest suspense boundary,
+ * so this component is being rendered inside of a Suspense by the DevCycleClientsideProvider.
+ * @param serverDataPromise
+ * @param userAgent
+ * @constructor
+ */
+export const SuspendedProviderInitialization = ({
+    serverDataPromise,
+    userAgent,
+}: Pick<
+    DevCycleClientContext,
+    'serverDataPromise' | 'userAgent'
+>): React.ReactElement => {
+    const serverData = use(serverDataPromise)
+    const [previousContext, setPreviousContext] = useState<
+        DevCycleServerData | undefined
+    >()
+    const context = useContext(DevCycleProviderContext)
+    if (previousContext !== serverData) {
+        // change user and config data to match latest server data
+        // if the data has changed since the last invocation
+        context.client.synchronizeBootstrapData(
+            serverData.config,
+            serverData.user,
+            userAgent,
+        )
+        setPreviousContext(serverData)
+    }
+    return <></>
+}
+
+export const InternalDevCycleClientsideProvider = ({
+    context,
+    children,
+    promiseResolved,
+}: DevCycleClientsideProviderProps): React.ReactElement => {
+    const router = useRouter()
+    const clientRef = useRef<DevCycleClient>()
+
+    const { serverDataPromise, serverData, sdkKey, enableStreaming } = context
+
+    const revalidateConfig = (lastModified?: number) => {
+        invalidateConfig(sdkKey, lastModified).finally(() => {
+            router.refresh()
+        })
+    }
+
+    let resolvedServerData = serverData
+
+    if (!serverData && promiseResolved) {
+        // here the provider is being told from above that this promise has already resolved, so we can safely "use"
+        // it without blocking rendering, even in streaming mode
+        resolvedServerData = use(serverDataPromise)
+    }
+
+    if (!clientRef.current) {
+        if (resolvedServerData || !enableStreaming) {
+            // we expect that either the promise has resolved and we got the server data that way, or we weren't in
+            // streaming mode and so the promise was awaited at a higher level and passed in here as serverData
+            if (!resolvedServerData) {
+                throw new Error(
+                    'Server data should be available. Please contact DevCycle support.',
+                )
+            }
+            clientRef.current = initializeDevCycle(
+                sdkKey,
+                resolvedServerData.user,
+                {
+                    deferInitialization: false,
+                    disableConfigCache: true,
+                    bootstrapConfig: resolvedServerData.config,
+                    next: {
+                        configRefreshHandler: revalidateConfig,
+                    },
+                },
+            )
+        } else {
+            clientRef.current = initializeDevCycle(sdkKey, {
+                deferInitialization: true,
+                disableConfigCache: true,
+                next: {
+                    configRefreshHandler: revalidateConfig,
+                },
+            })
+        }
+    }
+
+    return (
+        <DevCycleProviderContext.Provider
+            value={{
+                client: clientRef.current,
+                sdkKey: sdkKey,
+                enableStreaming,
+                serverDataPromise,
+            }}
+        >
+            {enableStreaming && (
+                <Suspense>
+                    <SuspendedProviderInitialization
+                        serverDataPromise={serverDataPromise}
+                    />
+                </Suspense>
+            )}
+            {children}
+        </DevCycleProviderContext.Provider>
+    )
+}

--- a/sdk/nextjs/src/common/types.ts
+++ b/sdk/nextjs/src/common/types.ts
@@ -3,8 +3,3 @@ import type { getDevCycleServerData } from '../server/devcycleServerData'
 export type DevCycleServerData = Awaited<
     ReturnType<typeof getDevCycleServerData>
 >
-
-export type DevCycleServerDataForClient = Omit<
-    DevCycleServerData,
-    'populatedUser'
->

--- a/sdk/nextjs/src/server/getVariableValue.ts
+++ b/sdk/nextjs/src/server/getVariableValue.ts
@@ -2,36 +2,11 @@ import { getClient, getInitializedPromise } from './requestContext'
 import { DVCVariableValue } from '@devcycle/js-client-sdk'
 import { VariableTypeAlias } from '@devcycle/types'
 
-/**
- * keep waiting until next tick to ensure that root layout render has been started and the
- * initialization promise has been set. Counterintuitively, Next seems to call the render of pages before layouts
- * Will keep ticking up to 50 times then give up with an error
- */
-const waitForPromiseAvailable = async () => {
-    let initializedPromise = getInitializedPromise()
-    let attempts = 0
-
-    while (!initializedPromise && attempts < 50) {
-        await new Promise((resolve) => setTimeout(resolve))
-        initializedPromise = getInitializedPromise()
-        attempts++
-    }
-
-    if (!initializedPromise) {
-        throw new Error(
-            'DevCycle server context not found! Did you wrap the root layout in DevCycleServersideProvider?',
-        )
-    }
-
-    return { initializedPromise }
-}
-
 export async function getVariableValue<T extends DVCVariableValue>(
     key: string,
     defaultValue: T,
 ): Promise<VariableTypeAlias<T>> {
-    const { initializedPromise } = await waitForPromiseAvailable()
-    await initializedPromise
+    await getInitializedPromise()
 
     const client = getClient()
     if (!client) {


### PR DESCRIPTION
- sometimes the initialize promise will resolve before the layout or other parts of the page are rendered
- in this case the previous implementation of streaming would cause hydration errors because the server would render its contents with the variable values, while the client would wait for the promise and re-render on the next pass after realizing it was resolved
- to fix this, the server basically needs to wait for the promise in a non-blocking way and then notify the client during the first render whether it is safe to `use` the promise because it has already resolved, thus receiving its resolved contents on the first render pass without blocking anything in streaming mode
- this also removes the requirement to await the getClientContext method, and brings the waiting of the user's identity from the provided getter inside the streaming system. That means that the async process to determine the user's identity does not need to block rendering either, it can be part of the streaming process