### PR TITLE
fix: move promise await to fix static builds

### DIFF
--- a/sdk/nextjs/src/server/allFeatures.ts
+++ b/sdk/nextjs/src/server/allFeatures.ts
@@ -1,9 +1,7 @@
-import { getClient, getInitializedPromise } from './requestContext'
+import { getClient } from './requestContext'
 import { DVCFeatureSet } from '@devcycle/js-client-sdk'
 
 export async function getAllFeatures(): Promise<DVCFeatureSet> {
-    await getInitializedPromise()
-
     const client = getClient()
     if (!client) {
         console.error(

--- a/sdk/nextjs/src/server/getAllVariables.ts
+++ b/sdk/nextjs/src/server/getAllVariables.ts
@@ -1,9 +1,7 @@
-import { getClient, getInitializedPromise } from './requestContext'
+import { getClient } from './requestContext'
 import { DVCVariableSet } from '@devcycle/js-client-sdk'
 
 export async function getAllVariables(): Promise<DVCVariableSet> {
-    await getInitializedPromise()
-
     const client = getClient()
     if (!client) {
         console.error(

--- a/sdk/nextjs/src/server/getVariableValue.ts
+++ b/sdk/nextjs/src/server/getVariableValue.ts
@@ -1,4 +1,4 @@
-import { getClient, getInitializedPromise } from './requestContext'
+import { getClient } from './requestContext'
 import { DVCVariableValue } from '@devcycle/js-client-sdk'
 import { VariableTypeAlias } from '@devcycle/types'
 
@@ -6,8 +6,6 @@ export async function getVariableValue<T extends DVCVariableValue>(
     key: string,
     defaultValue: T,
 ): Promise<VariableTypeAlias<T>> {
-    await getInitializedPromise()
-
     const client = getClient()
     if (!client) {
         console.error(

--- a/sdk/nextjs/src/server/setupDevCycle.ts
+++ b/sdk/nextjs/src/server/setupDevCycle.ts
@@ -39,17 +39,20 @@ export const setupDevCycle = (
         key,
         defaultValue,
     ) => {
-        ensureSetup(sdkKey, userGetter, options)
+        const { serverDataPromise } = ensureSetup(sdkKey, userGetter, options)
+        await serverDataPromise
         return getVariableValue(key, defaultValue)
     }
 
     const _getAllVariables: typeof getAllVariables = async () => {
-        ensureSetup(sdkKey, userGetter, options)
+        const { serverDataPromise } = ensureSetup(sdkKey, userGetter, options)
+        await serverDataPromise
         return getAllVariables()
     }
 
     const _getAllFeatures: typeof getAllFeatures = async () => {
-        ensureSetup(sdkKey, userGetter, options)
+        const { serverDataPromise } = ensureSetup(sdkKey, userGetter, options)
+        await serverDataPromise
         return getAllFeatures()
     }
 


### PR DESCRIPTION
- ensure that the callstack which originally kicks off the initialize promise ends up awaiting that promise directly, rather than indirectly through retrieving it back out of the React cache
- this should fix the DynamicRendering build errors 