### PR TITLE
feat: move OF provider to js-cloud-server sdk, setup common DevCycleClient interface, update tests

### DIFF
--- a/sdk/js-cloud-server/.eslintrc.json
+++ b/sdk/js-cloud-server/.eslintrc.json
@@ -11,6 +11,7 @@
                     {
                         "ignoredDependencies": [
                             "@devcycle/server-request",
+                            "@openfeature/core",
                             "fetch-retry",
                             "cross-fetch"
                         ]

--- a/sdk/js-cloud-server/__tests__/initialize.spec.ts
+++ b/sdk/js-cloud-server/__tests__/initialize.spec.ts
@@ -1,4 +1,5 @@
 import { initializeDevCycle } from '../src/index'
+import { OpenFeature } from '@openfeature/server-sdk'
 
 describe('JS Cloud Bucketing Server SDK Initialize', () => {
     afterAll(() => {
@@ -7,6 +8,17 @@ describe('JS Cloud Bucketing Server SDK Initialize', () => {
 
     it('successfully calls initialize with no options', async () => {
         const client = initializeDevCycle('dvc_server_token')
+        expect(client).toBeDefined()
+    })
+
+    it('successfully creates a OpenFeature provider', async () => {
+        const provider =
+            initializeDevCycle('dvc_server_token').getOpenFeatureProvider()
+        expect(provider).toBeDefined()
+        expect(provider.status).toBe('READY') // isInitialized() always returns true
+        await OpenFeature.setProviderAndWait(provider)
+        expect(provider.status).toBe('READY')
+        const client = OpenFeature.getClient()
         expect(client).toBeDefined()
     })
 

--- a/sdk/js-cloud-server/__tests__/open-feature-provider/DevCycleProvider.test.ts
+++ b/sdk/js-cloud-server/__tests__/open-feature-provider/DevCycleProvider.test.ts
@@ -3,12 +3,11 @@ import {
     Client,
     StandardResolutionReasons,
 } from '@openfeature/server-sdk'
-import { DevCycleClient, DevCycleUser } from '../../src/index'
+import { DevCycleCloudClient, DevCycleUser } from '../../src/index'
 
-jest.mock('../../src/bucketing')
 jest.mock('@devcycle/config-manager')
 
-const variableMock = jest.spyOn(DevCycleClient.prototype, 'variable')
+const variableMock = jest.spyOn(DevCycleCloudClient.prototype, 'variable')
 const logger = {
     debug: jest.fn(),
     info: jest.fn(),
@@ -18,10 +17,17 @@ const logger = {
 
 async function initOFClient(): Promise<{
     ofClient: Client
-    dvcClient: DevCycleClient
+    dvcClient: DevCycleCloudClient
 }> {
     const options = { logger }
-    const dvcClient = new DevCycleClient('DEVCYCLE_SERVER_SDK_KEY', options)
+    const dvcClient = new DevCycleCloudClient(
+        'DEVCYCLE_SERVER_SDK_KEY',
+        options,
+        {
+            platform: 'NodeJS',
+            sdkType: 'server',
+        },
+    )
     await OpenFeature.setProviderAndWait(dvcClient.getOpenFeatureProvider())
     const ofClient = OpenFeature.getClient()
     ofClient.setContext({ targetingKey: 'node_sdk_test' })
@@ -41,7 +47,7 @@ describe('DevCycleProvider Unit Tests', () => {
 
     describe('User Context', () => {
         beforeEach(() => {
-            variableMock.mockReturnValue({
+            variableMock.mockResolvedValue({
                 key: 'boolean-flag',
                 value: true,
                 defaultValue: false,
@@ -197,7 +203,7 @@ describe('DevCycleProvider Unit Tests', () => {
 
     describe('Boolean Flags', () => {
         beforeEach(() => {
-            variableMock.mockReturnValue({
+            variableMock.mockResolvedValue({
                 key: 'boolean-flag',
                 value: true,
                 defaultValue: false,
@@ -226,7 +232,7 @@ describe('DevCycleProvider Unit Tests', () => {
         })
 
         it('should return default value if flag is not found', async () => {
-            variableMock.mockReturnValue({
+            variableMock.mockResolvedValue({
                 key: 'boolean-flag',
                 value: false,
                 defaultValue: false,
@@ -247,7 +253,7 @@ describe('DevCycleProvider Unit Tests', () => {
 
     describe('String Flags', () => {
         beforeEach(() => {
-            variableMock.mockReturnValue({
+            variableMock.mockResolvedValue({
                 key: 'string-flag',
                 value: 'string-value',
                 defaultValue: 'string-default',
@@ -278,7 +284,7 @@ describe('DevCycleProvider Unit Tests', () => {
 
     describe('Number Flags', () => {
         beforeEach(() => {
-            variableMock.mockReturnValue({
+            variableMock.mockResolvedValue({
                 key: 'num-flag',
                 value: 610,
                 defaultValue: 2056,
@@ -309,7 +315,7 @@ describe('DevCycleProvider Unit Tests', () => {
 
     describe('JSON Flags', () => {
         beforeEach(() => {
-            variableMock.mockReturnValue({
+            variableMock.mockResolvedValue({
                 key: 'json-flag',
                 value: { hello: 'world' },
                 defaultValue: { default: 'value' },

--- a/sdk/js-cloud-server/package.json
+++ b/sdk/js-cloud-server/package.json
@@ -5,6 +5,8 @@
     "license": "MIT",
     "dependencies": {
         "@devcycle/types": "^1.6.0",
+        "@openfeature/core": "^0.0.23",
+        "@openfeature/server-sdk": "^1.9.1",
         "cross-fetch": "^3.1.8",
         "fetch-retry": "^5.0.3",
         "lodash": "^4.17.21"

--- a/sdk/js-cloud-server/src/index.ts
+++ b/sdk/js-cloud-server/src/index.ts
@@ -1,9 +1,15 @@
 import { DevCycleServerSDKOptions } from '@devcycle/types'
-import { DevCycleCloudClient } from './cloudClient'
+import { DevCycleCloudClient, DevCycleCommonClient } from './cloudClient'
 import { isValidServerSDKKey } from './utils/paramUtils'
 import { DevCycleUser } from './models/user'
+import DevCycleProvider from './open-feature-provider/DevCycleProvider'
 
-export { DevCycleCloudClient, DevCycleUser }
+export {
+    DevCycleCloudClient,
+    DevCycleCommonClient,
+    DevCycleUser,
+    DevCycleProvider,
+}
 export * from './models/populatedUser'
 export * from './models/user'
 export * from './models/variable'

--- a/sdk/js-cloud-server/src/open-feature-provider/DevCycleProvider.ts
+++ b/sdk/js-cloud-server/src/open-feature-provider/DevCycleProvider.ts
@@ -12,16 +12,18 @@ import {
     ProviderStatus,
 } from '@openfeature/server-sdk'
 import {
-    DevCycleClient,
-    DevCycleCloudClient,
-    DevCycleOptions,
+    DevCycleCommonClient,
     DVCVariableInterface,
     DevCycleUser,
     DVCJSON,
     DVCCustomDataJSON,
     dvcDefaultLogger,
 } from '../index'
-import { DVCLogger, VariableValue } from '@devcycle/types'
+import {
+    DVCLogger,
+    VariableValue,
+    DevCycleServerSDKOptions,
+} from '@devcycle/types'
 
 const DVCKnownPropertyKeyTypes: Record<string, string> = {
     email: 'string',
@@ -48,8 +50,8 @@ export default class DevCycleProvider implements Provider {
     private readonly logger: DVCLogger
 
     constructor(
-        private readonly devcycleClient: DevCycleClient | DevCycleCloudClient,
-        options: DevCycleOptions = {},
+        private readonly devcycleClient: DevCycleCommonClient,
+        options: Pick<DevCycleServerSDKOptions, 'logger' | 'logLevel'> = {},
     ) {
         this.logger =
             options.logger ?? dvcDefaultLogger({ level: options.logLevel })
@@ -62,13 +64,13 @@ export default class DevCycleProvider implements Provider {
     }
 
     async initialize(context?: EvaluationContext): Promise<void> {
-        if (this.devcycleClient instanceof DevCycleCloudClient) return
+        if (!this.devcycleClient.onClientInitialized) return
 
         await this.devcycleClient.onClientInitialized()
     }
 
     async onClose(): Promise<void> {
-        if (this.devcycleClient instanceof DevCycleCloudClient) return
+        if (!this.devcycleClient.close) return
 
         await this.devcycleClient.close()
     }

--- a/sdk/nodejs/.eslintrc.json
+++ b/sdk/nodejs/.eslintrc.json
@@ -13,7 +13,6 @@
                             "@devcycle/server-request",
                             "@devcycle/config-manager",
                             "@devcycle/bucketing-assembly-script",
-                            "@openfeature/core",
                             "fetch-retry",
                             "cross-fetch"
                         ]

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -7,8 +7,6 @@
         "@devcycle/bucketing-assembly-script": "^1.13.0",
         "@devcycle/js-cloud-server-sdk": "^1.5.0",
         "@devcycle/types": "^1.6.0",
-        "@openfeature/core": "^0.0.23",
-        "@openfeature/server-sdk": "^1.9.1",
         "cross-fetch": "^3.1.8",
         "fetch-retry": "^5.0.3"
     },

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -20,6 +20,7 @@ import {
 } from '@devcycle/types'
 import os from 'os'
 import {
+    DevCycleCommonClient,
     DevCycleUser,
     DVCVariable,
     VariableParam,
@@ -29,9 +30,9 @@ import {
     DVCVariableSet,
     DVCFeatureSet,
     DevCycleEvent,
+    DevCycleProvider,
 } from '@devcycle/js-cloud-server-sdk'
 import { DVCPopulatedUserFromDevCycleUser } from './models/populatedUserHelpers'
-import DevCycleProvider from './open-feature-provider/DevCycleProvider'
 
 interface IPlatformData {
     platform: string
@@ -48,7 +49,7 @@ const castIncomingUser = (user: DevCycleUser) => {
     return user
 }
 
-export class DevCycleClient {
+export class DevCycleClient implements DevCycleCommonClient {
     private sdkKey: string
     private configHelper: EnvironmentConfigManager
     private eventQueue: EventQueue
@@ -128,7 +129,9 @@ export class DevCycleClient {
     getOpenFeatureProvider(): DevCycleProvider {
         if (this.openFeatureProvider) return this.openFeatureProvider
 
-        this.openFeatureProvider = new DevCycleProvider(this)
+        this.openFeatureProvider = new DevCycleProvider(this, {
+            logger: this.logger,
+        })
         return this.openFeatureProvider
     }
 

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -14,10 +14,10 @@ import {
     DVCVariableInterface,
     DVCFeature,
     DVCFeatureSet,
+    DevCycleProvider,
 } from '@devcycle/js-cloud-server-sdk'
 import { DevCycleServerSDKOptions } from '@devcycle/types'
 import { getNodeJSPlatformDetails } from './utils/platformDetails'
-import DevCycleProvider from './open-feature-provider/DevCycleProvider'
 
 export {
     DevCycleClient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5146,6 +5146,8 @@ __metadata:
   resolution: "@devcycle/js-cloud-server-sdk@workspace:sdk/js-cloud-server"
   dependencies:
     "@devcycle/types": ^1.6.0
+    "@openfeature/core": ^0.0.23
+    "@openfeature/server-sdk": ^1.9.1
     cross-fetch: ^3.1.8
     fetch-retry: ^5.0.3
     lodash: ^4.17.21
@@ -5200,8 +5202,6 @@ __metadata:
     "@devcycle/bucketing-assembly-script": ^1.13.0
     "@devcycle/js-cloud-server-sdk": ^1.5.0
     "@devcycle/types": ^1.6.0
-    "@openfeature/core": ^0.0.23
-    "@openfeature/server-sdk": ^1.9.1
     cross-fetch: ^3.1.8
     fetch-retry: ^5.0.3
   languageName: unknown


### PR DESCRIPTION
Re-factored how the `DevCycleProvider` is setup, moved it to the `js-cloud-server` SDK so it works with the `DevCycleCloudClient`. Setup a common `DevCycleCommonClient` interface that is implemented by the `DevCycleClient` and `DevCycleCloudClient` for the `DevCycleProvider` to use.