### PR TITLE
feat: update NodeJS SDK to enable getOpenFeatureProvider() for cloud bucketing

### DIFF
--- a/sdk/js-cloud-server/src/cloudClient.ts
+++ b/sdk/js-cloud-server/src/cloudClient.ts
@@ -69,7 +69,7 @@ const throwIfUserError = (err: unknown) => {
 
 export class DevCycleCloudClient {
     private sdkKey: string
-    private logger: DVCLogger
+    protected logger: DVCLogger
     private options: DevCycleServerSDKOptions
     private platformDetails: DevCyclePlatformDetails
 

--- a/sdk/nodejs/__tests__/initialize.spec.ts
+++ b/sdk/nodejs/__tests__/initialize.spec.ts
@@ -16,11 +16,23 @@ describe('NodeJS SDK Initialize', () => {
         expect(client).toBeDefined()
     })
 
-    it('successfully creates a OpenFeature provider', async () => {
+    it('successfully creates a OpenFeature provider - local', async () => {
         const provider =
             initializeDevCycle('dvc_server_token').getOpenFeatureProvider()
         expect(provider).toBeDefined()
         expect(provider.status).toBe('NOT_READY')
+        await OpenFeature.setProviderAndWait(provider)
+        expect(provider.status).toBe('READY')
+        const client = OpenFeature.getClient()
+        expect(client).toBeDefined()
+    })
+
+    it('successfully creates a OpenFeature provider - cloud', async () => {
+        const provider = initializeDevCycle('dvc_server_token', {
+            enableCloudBucketing: true,
+        }).getOpenFeatureProvider()
+        expect(provider).toBeDefined()
+        expect(provider.status).toBe('READY') // onIntialized() is always true for cloud
         await OpenFeature.setProviderAndWait(provider)
         expect(provider.status).toBe('READY')
         const client = OpenFeature.getClient()

--- a/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
+++ b/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
@@ -1,4 +1,3 @@
-import DevCycleProvider from '../../src/open-feature-provider/DevCycleProvider'
 import {
     OpenFeature,
     Client,
@@ -8,149 +7,145 @@ import {
     DevCycleClient,
     DevCycleCloudClient,
     DevCycleUser,
+    DVCVariable,
+    DVCVariableValue,
 } from '../../src/index'
 
-jest.mock('@devcycle/nodejs-server-sdk')
+jest.mock('../../src/bucketing')
+jest.mock('@devcycle/config-manager')
 
 const variableMock = jest.spyOn(DevCycleClient.prototype, 'variable')
+const cloudVariableMock = jest.spyOn(DevCycleCloudClient.prototype, 'variable')
+
 const logger = {
     debug: jest.fn(),
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
 }
+type DevCycleClientTypes = 'DevCycleClient' | 'DevCycleCloudClient'
 
-function initOFClient(): {
-    ofClient: Client
-    dvcClient: DevCycleClient | DevCycleCloudClient
-} {
-    const options = { logger }
-    const dvcClient = new DevCycleClient('DEVCYCLE_SERVER_SDK_KEY', options)
-    OpenFeature.setProvider(new DevCycleProvider(dvcClient, options))
-    const ofClient = OpenFeature.getClient()
-    ofClient.setContext({ targetingKey: 'node_sdk_test' })
-    return { ofClient, dvcClient }
-}
+describe.each(['DevCycleClient', 'DevCycleCloudClient'])(
+    'DevCycleProvider Unit Tests',
+    (dvcClientType: DevCycleClientTypes) => {
+        async function initOFClient(): Promise<{
+            ofClient: Client
+            dvcClient: DevCycleClient | DevCycleCloudClient
+        }> {
+            const options = { logger }
+            const dvcClient =
+                dvcClientType === 'DevCycleClient'
+                    ? new DevCycleClient('DEVCYCLE_SERVER_SDK_KEY', options)
+                    : new DevCycleCloudClient(
+                          'DEVCYCLE_SERVER_SDK_KEY',
+                          options,
+                          {
+                              platform: 'NodeJS',
+                              sdkType: 'server',
+                          },
+                      )
+            await OpenFeature.setProviderAndWait(
+                dvcClient.getOpenFeatureProvider(),
+            )
+            const ofClient = OpenFeature.getClient()
+            ofClient.setContext({ targetingKey: 'node_sdk_test' })
+            return { ofClient, dvcClient }
+        }
 
-describe('DevCycleProvider Unit Tests', () => {
-    beforeEach(() => {
-        variableMock.mockClear()
-    })
+        function mockVariable(variable: DVCVariable<DVCVariableValue>) {
+            if (dvcClientType === 'DevCycleClient') {
+                variableMock.mockReturnValue(variable)
+            } else {
+                cloudVariableMock.mockResolvedValue(variable)
+            }
+        }
 
-    it('should setup an OpenFeature provider with a DVCUserClient', async () => {
-        const { ofClient, dvcClient } = initOFClient()
-        expect(ofClient).toBeDefined()
-        expect(dvcClient).toBeDefined()
-    })
-
-    describe('User Context', () => {
         beforeEach(() => {
-            variableMock.mockReturnValue({
-                key: 'boolean-flag',
-                value: true,
-                defaultValue: false,
-                isDefaulted: false,
-                type: 'Boolean',
+            variableMock.mockClear()
+        })
+
+        it(`${dvcClientType} - should setup an OpenFeature provider with a DVCUserClient`, async () => {
+            const { ofClient, dvcClient } = await initOFClient()
+
+            expect(ofClient).toBeDefined()
+            expect(dvcClient).toBeDefined()
+        })
+
+        describe(`${dvcClientType} - User Context`, () => {
+            beforeEach(() => {
+                mockVariable({
+                    key: 'boolean-flag',
+                    value: true,
+                    defaultValue: false,
+                    isDefaulted: false,
+                    type: 'Boolean',
+                })
             })
-        })
 
-        it('should throw error if targetingKey is missing', async () => {
-            const { ofClient } = initOFClient()
-            ofClient.setContext({})
-            expect(
-                ofClient.getBooleanDetails('boolean-flag', false),
-            ).resolves.toEqual({
-                flagKey: 'boolean-flag',
-                value: false,
-                errorCode: 'TARGETING_KEY_MISSING',
-                errorMessage: 'Missing targetingKey or user_id in context',
-                reason: 'ERROR',
-                flagMetadata: {},
+            it('should throw error if targetingKey is missing', async () => {
+                const { ofClient } = await initOFClient()
+
+                ofClient.setContext({})
+                expect(
+                    ofClient.getBooleanDetails('boolean-flag', false),
+                ).resolves.toEqual({
+                    flagKey: 'boolean-flag',
+                    value: false,
+                    errorCode: 'TARGETING_KEY_MISSING',
+                    errorMessage: 'Missing targetingKey or user_id in context',
+                    reason: 'ERROR',
+                    flagMetadata: {},
+                })
             })
-        })
 
-        it('should throw error if targetingKey is not a string', async () => {
-            const { ofClient } = initOFClient()
-            ofClient.setContext({ user_id: 123 })
-            expect(
-                ofClient.getBooleanDetails('boolean-flag', false),
-            ).resolves.toEqual({
-                flagKey: 'boolean-flag',
-                value: false,
-                errorCode: 'INVALID_CONTEXT',
-                errorMessage: 'targetingKey or user_id must be a string',
-                reason: 'ERROR',
-                flagMetadata: {},
+            it('should throw error if targetingKey is not a string', async () => {
+                const { ofClient } = await initOFClient()
+
+                ofClient.setContext({ user_id: 123 })
+                expect(
+                    ofClient.getBooleanDetails('boolean-flag', false),
+                ).resolves.toEqual({
+                    flagKey: 'boolean-flag',
+                    value: false,
+                    errorCode: 'INVALID_CONTEXT',
+                    errorMessage: 'targetingKey or user_id must be a string',
+                    reason: 'ERROR',
+                    flagMetadata: {},
+                })
             })
-        })
 
-        it('should convert Context properties to DevCycleUser properties', async () => {
-            const { ofClient, dvcClient } = initOFClient()
-            const dvcUser = {
-                user_id: 'user_id',
-                email: 'email',
-                name: 'name',
-                language: 'en',
-                country: 'CA',
-                appVersion: '1.0.11',
-                appBuild: 1000,
-                customData: { custom: 'data' },
-                privateCustomData: { private: 'data' },
-            }
-            ofClient.setContext(dvcUser)
-
-            await expect(
-                ofClient.getBooleanValue('boolean-flag', false),
-            ).resolves.toEqual(true)
-            expect(dvcClient.variable).toHaveBeenCalledWith(
-                new DevCycleUser(dvcUser),
-                'boolean-flag',
-                false,
-            )
-        })
-
-        it('should skip DevCycleUser properties that are not the correct type', async () => {
-            const { ofClient, dvcClient } = initOFClient()
-            const dvcUser = {
-                user_id: 'user_id',
-                appVersion: 1.0,
-                appBuild: 'string',
-                customData: 'data',
-            }
-            ofClient.setContext(dvcUser)
-
-            await expect(
-                ofClient.getBooleanValue('boolean-flag', false),
-            ).resolves.toEqual(true)
-
-            expect(dvcClient.variable).toHaveBeenCalledWith(
-                new DevCycleUser({ user_id: 'user_id' }),
-                'boolean-flag',
-                false,
-            )
-            expect(logger.warn).toHaveBeenCalledWith(
-                'Expected DevCycleUser property "appVersion" to be "string" but got "number" in EvaluationContext. ' +
-                    'Ignoring value.',
-            )
-            expect(logger.warn).toHaveBeenCalledWith(
-                'Expected DevCycleUser property "appBuild" to be "number" but got "string" in EvaluationContext. ' +
-                    'Ignoring value.',
-            )
-            expect(logger.warn).toHaveBeenCalledWith(
-                'Expected DevCycleUser property "customData" to be "object" but got "string" in EvaluationContext. ' +
-                    'Ignoring value.',
-            )
-        })
-
-        it(
-            'should skip Context properties that are sub-objects as ' +
-                'DevCycleUser only supports flat properties',
-            async () => {
-                const { ofClient, dvcClient } = initOFClient()
+            it('should convert Context properties to DevCycleUser properties', async () => {
+                const { ofClient, dvcClient } = await initOFClient()
                 const dvcUser = {
                     user_id: 'user_id',
-                    nullKey: null,
-                    obj: { key: 'value' },
+                    email: 'email',
+                    name: 'name',
+                    language: 'en',
+                    country: 'CA',
+                    appVersion: '1.0.11',
+                    appBuild: 1000,
+                    customData: { custom: 'data' },
+                    privateCustomData: { private: 'data' },
+                }
+                ofClient.setContext(dvcUser)
+
+                await expect(
+                    ofClient.getBooleanValue('boolean-flag', false),
+                ).resolves.toEqual(true)
+                expect(dvcClient.variable).toHaveBeenCalledWith(
+                    new DevCycleUser(dvcUser),
+                    'boolean-flag',
+                    false,
+                )
+            })
+
+            it('should skip DevCycleUser properties that are not the correct type', async () => {
+                const { ofClient, dvcClient } = await initOFClient()
+                const dvcUser = {
+                    user_id: 'user_id',
+                    appVersion: 1.0,
+                    appBuild: 'string',
+                    customData: 'data',
                 }
                 ofClient.setContext(dvcUser)
 
@@ -159,245 +154,294 @@ describe('DevCycleProvider Unit Tests', () => {
                 ).resolves.toEqual(true)
 
                 expect(dvcClient.variable).toHaveBeenCalledWith(
+                    new DevCycleUser({ user_id: 'user_id' }),
+                    'boolean-flag',
+                    false,
+                )
+                expect(logger.warn).toHaveBeenCalledWith(
+                    'Expected DevCycleUser property "appVersion" to be "string" but got "number" in ' +
+                        'EvaluationContext. Ignoring value.',
+                )
+                expect(logger.warn).toHaveBeenCalledWith(
+                    'Expected DevCycleUser property "appBuild" to be "number" but got "string" in ' +
+                        'EvaluationContext. Ignoring value.',
+                )
+                expect(logger.warn).toHaveBeenCalledWith(
+                    'Expected DevCycleUser property "customData" to be "object" but got "string" in ' +
+                        'EvaluationContext. Ignoring value.',
+                )
+            })
+
+            it(
+                'should skip Context properties that are sub-objects as ' +
+                    'DevCycleUser only supports flat properties',
+                async () => {
+                    const { ofClient, dvcClient } = await initOFClient()
+                    const dvcUser = {
+                        user_id: 'user_id',
+                        nullKey: null,
+                        obj: { key: 'value' },
+                    }
+                    ofClient.setContext(dvcUser)
+
+                    await expect(
+                        ofClient.getBooleanValue('boolean-flag', false),
+                    ).resolves.toEqual(true)
+
+                    expect(dvcClient.variable).toHaveBeenCalledWith(
+                        new DevCycleUser({
+                            user_id: 'user_id',
+                            customData: { nullKey: null },
+                        }),
+                        'boolean-flag',
+                        false,
+                    )
+                    expect(logger.warn).toHaveBeenCalledWith(
+                        'EvaluationContext property "obj" is an Object. ' +
+                            'DevCycleUser only supports flat customData properties of type ' +
+                            'string / number / boolean / null',
+                    )
+                },
+            )
+
+            it('should skip customData key that is not a flat json property', async () => {
+                const { ofClient, dvcClient } = await initOFClient()
+                const dvcUser = {
+                    user_id: 'user_id',
+                    customData: { obj: { key: 'value' }, num: 610 },
+                }
+                ofClient.setContext(dvcUser)
+                await expect(
+                    ofClient.getBooleanValue('boolean-flag', false),
+                ).resolves.toEqual(true)
+                expect(dvcClient.variable).toHaveBeenCalledWith(
                     new DevCycleUser({
                         user_id: 'user_id',
-                        customData: { nullKey: null },
+                        customData: { num: 610 },
                     }),
                     'boolean-flag',
                     false,
                 )
                 expect(logger.warn).toHaveBeenCalledWith(
-                    'EvaluationContext property "obj" is an Object. ' +
-                        'DevCycleUser only supports flat customData properties of type ' +
+                    'EvaluationContext property "customData" contains "obj" property of type ' +
+                        'object. DevCycleUser only supports flat customData properties of type ' +
                         'string / number / boolean / null',
                 )
-            },
-        )
-
-        it('should skip customData key that is not a flat json property', async () => {
-            const { ofClient, dvcClient } = initOFClient()
-            const dvcUser = {
-                user_id: 'user_id',
-                customData: { obj: { key: 'value' }, num: 610 },
-            }
-            ofClient.setContext(dvcUser)
-            await expect(
-                ofClient.getBooleanValue('boolean-flag', false),
-            ).resolves.toEqual(true)
-            expect(dvcClient.variable).toHaveBeenCalledWith(
-                new DevCycleUser({
-                    user_id: 'user_id',
-                    customData: { num: 610 },
-                }),
-                'boolean-flag',
-                false,
-            )
-            expect(logger.warn).toHaveBeenCalledWith(
-                'EvaluationContext property "customData" contains "obj" property of type object.' +
-                    'DevCycleUser only supports flat customData properties of type string / number / boolean / null',
-            )
-        })
-    })
-
-    describe('Boolean Flags', () => {
-        beforeEach(() => {
-            variableMock.mockReturnValue({
-                key: 'boolean-flag',
-                value: true,
-                defaultValue: false,
-                isDefaulted: false,
-                type: 'Boolean',
             })
         })
 
-        it('should resolve a boolean flag value', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getBooleanValue('boolean-flag', false),
-            ).resolves.toEqual(true)
-        })
-
-        it('should resolve a boolean flag details', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getBooleanDetails('boolean-flag', false),
-            ).resolves.toEqual({
-                flagKey: 'boolean-flag',
-                value: true,
-                reason: StandardResolutionReasons.TARGETING_MATCH,
-                flagMetadata: {},
+        describe(`${dvcClientType} - Boolean Flags`, () => {
+            beforeEach(() => {
+                mockVariable({
+                    key: 'boolean-flag',
+                    value: true,
+                    defaultValue: false,
+                    isDefaulted: false,
+                    type: 'Boolean',
+                })
             })
-        })
 
-        it('should return default value if flag is not found', async () => {
-            variableMock.mockReturnValue({
-                key: 'boolean-flag',
-                value: false,
-                defaultValue: false,
-                isDefaulted: true,
-                type: 'Boolean',
+            it('should resolve a boolean flag value', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getBooleanValue('boolean-flag', false),
+                ).resolves.toEqual(true)
             })
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getBooleanDetails('boolean-flag', false),
-            ).resolves.toEqual({
-                flagKey: 'boolean-flag',
-                value: false,
-                reason: StandardResolutionReasons.DEFAULT,
-                flagMetadata: {},
+
+            it('should resolve a boolean flag details', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getBooleanDetails('boolean-flag', false),
+                ).resolves.toEqual({
+                    flagKey: 'boolean-flag',
+                    value: true,
+                    reason: StandardResolutionReasons.TARGETING_MATCH,
+                    flagMetadata: {},
+                })
             })
-        })
-    })
 
-    describe('String Flags', () => {
-        beforeEach(() => {
-            variableMock.mockReturnValue({
-                key: 'string-flag',
-                value: 'string-value',
-                defaultValue: 'string-default',
-                isDefaulted: false,
-                type: 'String',
-            })
-        })
+            it('should return default value if flag is not found', async () => {
+                mockVariable({
+                    key: 'boolean-flag',
+                    value: false,
+                    defaultValue: false,
+                    isDefaulted: true,
+                    type: 'Boolean',
+                })
+                const { ofClient } = await initOFClient()
 
-        it('should resolve a string flag value', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getStringValue('string-flag', 'string-default'),
-            ).resolves.toEqual('string-value')
-        })
-
-        it('should resolve a string flag details', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getStringDetails('string-flag', 'string-default'),
-            ).resolves.toEqual({
-                flagKey: 'string-flag',
-                value: 'string-value',
-                reason: StandardResolutionReasons.TARGETING_MATCH,
-                flagMetadata: {},
-            })
-        })
-    })
-
-    describe('Number Flags', () => {
-        beforeEach(() => {
-            variableMock.mockReturnValue({
-                key: 'num-flag',
-                value: 610,
-                defaultValue: 2056,
-                isDefaulted: false,
-                type: 'Number',
+                expect(
+                    ofClient.getBooleanDetails('boolean-flag', false),
+                ).resolves.toEqual({
+                    flagKey: 'boolean-flag',
+                    value: false,
+                    reason: StandardResolutionReasons.DEFAULT,
+                    flagMetadata: {},
+                })
             })
         })
 
-        it('should resolve a number flag value', async () => {
-            const { ofClient } = initOFClient()
-            expect(ofClient.getNumberValue('num-flag', 2056)).resolves.toEqual(
-                610,
-            )
-        })
-
-        it('should resolve a number flag details', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getNumberDetails('num-flag', 2056),
-            ).resolves.toEqual({
-                flagKey: 'num-flag',
-                value: 610,
-                reason: StandardResolutionReasons.TARGETING_MATCH,
-                flagMetadata: {},
+        describe(`${dvcClientType} - String Flags`, () => {
+            beforeEach(() => {
+                mockVariable({
+                    key: 'string-flag',
+                    value: 'string-value',
+                    defaultValue: 'string-default',
+                    isDefaulted: false,
+                    type: 'String',
+                })
             })
-        })
-    })
 
-    describe('JSON Flags', () => {
-        beforeEach(() => {
-            variableMock.mockReturnValue({
-                key: 'json-flag',
-                value: { hello: 'world' },
-                defaultValue: { default: 'value' },
-                isDefaulted: false,
-                type: 'JSON',
+            it('should resolve a string flag value', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getStringValue('string-flag', 'string-default'),
+                ).resolves.toEqual('string-value')
             })
-        })
 
-        it('should resolve a string flag value', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getObjectValue('json-flag', { default: 'value' }),
-            ).resolves.toEqual({ hello: 'world' })
-        })
+            it('should resolve a string flag details', async () => {
+                const { ofClient } = await initOFClient()
 
-        it('should resolve a boolean flag details', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getObjectDetails('json-flag', { default: 'value' }),
-            ).resolves.toEqual({
-                flagKey: 'json-flag',
-                value: { hello: 'world' },
-                reason: StandardResolutionReasons.TARGETING_MATCH,
-                flagMetadata: {},
+                expect(
+                    ofClient.getStringDetails('string-flag', 'string-default'),
+                ).resolves.toEqual({
+                    flagKey: 'string-flag',
+                    value: 'string-value',
+                    reason: StandardResolutionReasons.TARGETING_MATCH,
+                    flagMetadata: {},
+                })
             })
         })
 
-        it('should return default value if json default is not an object', async () => {
-            const { ofClient } = initOFClient()
-            expect(
-                ofClient.getObjectDetails('json-flag', ['arry']),
-            ).resolves.toEqual({
-                flagKey: 'json-flag',
-                value: ['arry'],
-                reason: 'ERROR',
-                errorCode: 'PARSE_ERROR',
-                errorMessage:
-                    'DevCycle only supports object values for JSON flags',
-                flagMetadata: {},
+        describe(`${dvcClientType} - Number Flags`, () => {
+            beforeEach(() => {
+                mockVariable({
+                    key: 'num-flag',
+                    value: 610,
+                    defaultValue: 2056,
+                    isDefaulted: false,
+                    type: 'Number',
+                })
             })
-            expect(
-                ofClient.getObjectDetails('json-flag', 610),
-            ).resolves.toEqual({
-                flagKey: 'json-flag',
-                value: 610,
-                reason: 'ERROR',
-                errorCode: 'PARSE_ERROR',
-                errorMessage:
-                    'DevCycle only supports object values for JSON flags',
-                flagMetadata: {},
+
+            it('should resolve a number flag value', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getNumberValue('num-flag', 2056),
+                ).resolves.toEqual(610)
             })
-            expect(
-                ofClient.getObjectDetails('json-flag', 'string'),
-            ).resolves.toEqual({
-                flagKey: 'json-flag',
-                value: 'string',
-                reason: 'ERROR',
-                errorCode: 'PARSE_ERROR',
-                errorMessage:
-                    'DevCycle only supports object values for JSON flags',
-                flagMetadata: {},
-            })
-            expect(
-                ofClient.getObjectDetails('json-flag', false),
-            ).resolves.toEqual({
-                flagKey: 'json-flag',
-                value: false,
-                reason: 'ERROR',
-                errorCode: 'PARSE_ERROR',
-                errorMessage:
-                    'DevCycle only supports object values for JSON flags',
-                flagMetadata: {},
-            })
-            expect(
-                ofClient.getObjectDetails('json-flag', null),
-            ).resolves.toEqual({
-                flagKey: 'json-flag',
-                value: null,
-                reason: 'ERROR',
-                errorCode: 'PARSE_ERROR',
-                errorMessage:
-                    'DevCycle does not support null default values for JSON flags',
-                flagMetadata: {},
+
+            it('should resolve a number flag details', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getNumberDetails('num-flag', 2056),
+                ).resolves.toEqual({
+                    flagKey: 'num-flag',
+                    value: 610,
+                    reason: StandardResolutionReasons.TARGETING_MATCH,
+                    flagMetadata: {},
+                })
             })
         })
-    })
-})
+
+        describe(`${dvcClientType} - JSON Flags`, () => {
+            beforeEach(() => {
+                mockVariable({
+                    key: 'json-flag',
+                    value: { hello: 'world' },
+                    defaultValue: { default: 'value' },
+                    isDefaulted: false,
+                    type: 'JSON',
+                })
+            })
+
+            it('should resolve a string flag value', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getObjectValue('json-flag', { default: 'value' }),
+                ).resolves.toEqual({ hello: 'world' })
+            })
+
+            it('should resolve a boolean flag details', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getObjectDetails('json-flag', {
+                        default: 'value',
+                    }),
+                ).resolves.toEqual({
+                    flagKey: 'json-flag',
+                    value: { hello: 'world' },
+                    reason: StandardResolutionReasons.TARGETING_MATCH,
+                    flagMetadata: {},
+                })
+            })
+
+            it('should return default value if json default is not an object', async () => {
+                const { ofClient } = await initOFClient()
+
+                expect(
+                    ofClient.getObjectDetails('json-flag', ['arry']),
+                ).resolves.toEqual({
+                    flagKey: 'json-flag',
+                    value: ['arry'],
+                    reason: 'ERROR',
+                    errorCode: 'PARSE_ERROR',
+                    errorMessage:
+                        'DevCycle only supports object values for JSON flags',
+                    flagMetadata: {},
+                })
+                expect(
+                    ofClient.getObjectDetails('json-flag', 610),
+                ).resolves.toEqual({
+                    flagKey: 'json-flag',
+                    value: 610,
+                    reason: 'ERROR',
+                    errorCode: 'PARSE_ERROR',
+                    errorMessage:
+                        'DevCycle only supports object values for JSON flags',
+                    flagMetadata: {},
+                })
+                expect(
+                    ofClient.getObjectDetails('json-flag', 'string'),
+                ).resolves.toEqual({
+                    flagKey: 'json-flag',
+                    value: 'string',
+                    reason: 'ERROR',
+                    errorCode: 'PARSE_ERROR',
+                    errorMessage:
+                        'DevCycle only supports object values for JSON flags',
+                    flagMetadata: {},
+                })
+                expect(
+                    ofClient.getObjectDetails('json-flag', false),
+                ).resolves.toEqual({
+                    flagKey: 'json-flag',
+                    value: false,
+                    reason: 'ERROR',
+                    errorCode: 'PARSE_ERROR',
+                    errorMessage:
+                        'DevCycle only supports object values for JSON flags',
+                    flagMetadata: {},
+                })
+                expect(
+                    ofClient.getObjectDetails('json-flag', null),
+                ).resolves.toEqual({
+                    flagKey: 'json-flag',
+                    value: null,
+                    reason: 'ERROR',
+                    errorCode: 'PARSE_ERROR',
+                    errorMessage:
+                        'DevCycle does not support null default values for JSON flags',
+                    flagMetadata: {},
+                })
+            })
+        })
+    },
+)

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -128,7 +128,9 @@ export class DevCycleClient {
     getOpenFeatureProvider(): DevCycleProvider {
         if (this.openFeatureProvider) return this.openFeatureProvider
 
-        this.openFeatureProvider = new DevCycleProvider(this)
+        this.openFeatureProvider = new DevCycleProvider(this, {
+            logger: this.logger,
+        })
         return this.openFeatureProvider
     }
 

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -1,7 +1,7 @@
 import { DevCycleClient } from './client'
 import {
     DevCycleUser,
-    DevCycleCloudClient,
+    DevCycleCloudClient as DevCycleCloudServerClient,
     dvcDefaultLogger,
     isValidServerSDKKey,
     DevCycleEvent,
@@ -14,10 +14,32 @@ import {
     DVCVariableInterface,
     DVCFeature,
     DVCFeatureSet,
+    DevCyclePlatformDetails,
 } from '@devcycle/js-cloud-server-sdk'
 import { DevCycleServerSDKOptions } from '@devcycle/types'
 import { getNodeJSPlatformDetails } from './utils/platformDetails'
 import DevCycleProvider from './open-feature-provider/DevCycleProvider'
+
+class DevCycleCloudClient extends DevCycleCloudServerClient {
+    private openFeatureProvider: DevCycleProvider
+
+    constructor(
+        sdkKey: string,
+        options: DevCycleServerSDKOptions,
+        platformDetails: DevCyclePlatformDetails,
+    ) {
+        super(sdkKey, options, platformDetails)
+    }
+
+    getOpenFeatureProvider(): DevCycleProvider {
+        if (this.openFeatureProvider) return this.openFeatureProvider
+
+        this.openFeatureProvider = new DevCycleProvider(this, {
+            logger: this.logger,
+        })
+        return this.openFeatureProvider
+    }
+}
 
 export {
     DevCycleClient,

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -1,7 +1,7 @@
 import { DevCycleClient } from './client'
 import {
     DevCycleUser,
-    DevCycleCloudClient as DevCycleCloudServerClient,
+    DevCycleCloudClient as InternalDevCycleCloudClient,
     dvcDefaultLogger,
     isValidServerSDKKey,
     DevCycleEvent,
@@ -20,7 +20,7 @@ import { DevCycleServerSDKOptions } from '@devcycle/types'
 import { getNodeJSPlatformDetails } from './utils/platformDetails'
 import DevCycleProvider from './open-feature-provider/DevCycleProvider'
 
-class DevCycleCloudClient extends DevCycleCloudServerClient {
+class DevCycleCloudClient extends InternalDevCycleCloudClient {
     private openFeatureProvider: DevCycleProvider
 
     constructor(

--- a/sdk/nodejs/src/open-feature-provider/DevCycleProvider.ts
+++ b/sdk/nodejs/src/open-feature-provider/DevCycleProvider.ts
@@ -49,7 +49,7 @@ export default class DevCycleProvider implements Provider {
 
     constructor(
         private readonly devcycleClient: DevCycleClient | DevCycleCloudClient,
-        options: DevCycleOptions = {},
+        options: Pick<DevCycleOptions, 'logger' | 'logLevel'> = {},
     ) {
         this.logger =
             options.logger ?? dvcDefaultLogger({ level: options.logLevel })
@@ -323,7 +323,7 @@ export default class DevCycleProvider implements Provider {
                     break
                 default:
                     this.logger.warn(
-                        `EvaluationContext property "customData" contains "${key}" property of type ${typeof value}.` +
+                        `EvaluationContext property "customData" contains "${key}" property of type ${typeof value}. ` +
                             'DevCycleUser only supports flat customData properties of type ' +
                             'string / number / boolean / null',
                     )


### PR DESCRIPTION
We had to change approach from #714 as the OF libraries have NodeJS APIs. Now we just extend the `DevCycleCloudClient` with the `getOpenFeatureProvider()` method in the NodeJS SDK before exporting it for use.