### PR TITLE
fix: OpenFeature Web Provider exporting events emitter

### DIFF
--- a/sdk/openfeature-web-provider/src/DevCycleProvider.ts
+++ b/sdk/openfeature-web-provider/src/DevCycleProvider.ts
@@ -50,7 +50,8 @@ export default class DevCycleProvider implements Provider {
 
     private readonly options: DevCycleOptions
     private readonly sdkKey: string
-    private _events = new OpenFeatureEventEmitter()
+
+    readonly events = new OpenFeatureEventEmitter()
 
     private _devcycleClient: DevCycleClient | null = null
     get devcycleClient(): DevCycleClient | null {
@@ -72,7 +73,7 @@ export default class DevCycleProvider implements Provider {
         this._devcycleClient.eventEmitter.subscribe(
             'configUpdated',
             (allVariables) => {
-                this._events.emit(
+                this.events.emit(
                     ProviderEvents.ConfigurationChanged,
                     allVariables,
                 )
@@ -80,7 +81,7 @@ export default class DevCycleProvider implements Provider {
         )
 
         this._devcycleClient.eventEmitter.subscribe('error', (error) => {
-            this._events.emit(ProviderEvents.Error, error)
+            this.events.emit(ProviderEvents.Error, error)
         })
 
         if (!context) {


### PR DESCRIPTION
Fix setting the OpenFeature Web Provider to actually export the EventsEmitter to make live-updates work in React. 

For context here is the Provider interface: 
<img width="759" alt="image" src="https://github.com/DevCycleHQ/js-sdks/assets/1219069/24fe417d-a3a0-49b0-9a67-dc241b5efc5e">
