### PR TITLE
fix: react strictmode closing wrong client again

### DIFF
--- a/sdk/react/src/DevCycleProvider.tsx
+++ b/sdk/react/src/DevCycleProvider.tsx
@@ -26,6 +26,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
     }
 
     const clientRef = useRef<DevCycleClient>()
+    const [_, forceRerender] = useState({})
 
     if (clientRef.current === undefined) {
         clientRef.current = initializeDevCycleClient(sdkKey, user, {
@@ -38,6 +39,8 @@ export function DevCycleProvider(props: Props): React.ReactElement {
             clientRef.current = initializeDevCycleClient(sdkKey, user, {
                 ...options,
             })
+            // react doesn't know the effect changed the ref, make sure it re-renders
+            forceRerender({})
         }
 
         clientRef.current


### PR DESCRIPTION
Based on the answer here:
https://github.com/facebook/react/issues/27735#issuecomment-1885624506

due to some misunderstanding in what strict mode actually does, we were still causing the client to get erroneously closed in development when strict mode was enabled. 

Basically this fix makes it so that a client exists on initial render, and continues to exist and not get recreated when in production or without strict mode

With strict mode, the useEffect gets double-executed, which causes a cleanup of the client. But now it sets the ref to null in that case, and the second run of the useEffect re-creates the client when it sees that it is now null