### PR TITLE
feat: Add mocks to nestjs sdk

### DIFF
--- a/sdk/nestjs/.eslintrc.json
+++ b/sdk/nestjs/.eslintrc.json
@@ -1,6 +1,11 @@
 {
     "extends": ["../../.eslintrc.json"],
-    "ignorePatterns": ["!**/*", "node_modules/*", "src/pb-types/compiled*"],
+    "ignorePatterns": [
+        "!**/*",
+        "node_modules/*",
+        "src/pb-types/compiled*",
+        "*/__mocks__/*"
+    ],
     "overrides": [
         {
             "files": ["*.json"],

--- a/sdk/nestjs/mocks.ts
+++ b/sdk/nestjs/mocks.ts
@@ -1,0 +1,1 @@
+export { MockDevCycleClient } from './src/__mocks__'

--- a/sdk/nestjs/src/__mocks__/DevCycleClient.ts
+++ b/sdk/nestjs/src/__mocks__/DevCycleClient.ts
@@ -1,0 +1,52 @@
+import { DVCVariable, DVCVariableValue } from '@devcycle/nodejs-server-sdk'
+import { VariableType } from '@devcycle/types'
+
+export class MockDevCycleClient {
+    public onClientInitialized = (callback: () => any) =>
+        callback?.() ?? Promise.resolve(this)
+    public variable = (user: any, key: string, defaultValue: any) =>
+        this.mockedVariables[key] ?? {
+            key,
+            value: defaultValue,
+            isDefaulted: true,
+            defaultValue,
+            type: getType(defaultValue),
+        }
+    public variableValue = (user: any, key: string, defaultValue: any) =>
+        this.mockedVariables[key]?.value ?? defaultValue
+    public allFeatures = () => ({})
+    public allVariables = () => ({})
+    public track = () => null
+    public flushEvents = (callback?: any) => Promise.resolve()
+    public close = () => Promise.resolve()
+
+    constructor(sdkKey: string, options?: any) {}
+
+    private mockedVariables: Record<string, any> = {}
+
+    public mockVariables(values: { [key: string]: DVCVariableValue }) {
+        this.mockedVariables = Object.entries(values).reduce(
+            (map, [key, value]) => {
+                map[key] = {
+                    key,
+                    value,
+                    isDefaulted: false,
+                    defaultValue: value,
+                    type: getType(value),
+                }
+                return map
+            },
+            {} as Record<string, DVCVariable<any>>,
+        )
+    }
+}
+
+const getType = (value: DVCVariableValue): VariableType => {
+    const types = {
+        string: 'String',
+        number: 'Number',
+        boolean: 'Boolean',
+        object: 'JSON',
+    }
+    return types[typeof value as keyof typeof types] as VariableType
+}

--- a/sdk/nestjs/src/__mocks__/DevCycleModule.ts
+++ b/sdk/nestjs/src/__mocks__/DevCycleModule.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common'
+import { APP_INTERCEPTOR } from '@nestjs/core'
+import { DevCycleClient } from '@devcycle/nodejs-server-sdk'
+import { MockDevCycleClient } from './DevCycleClient'
+import { RequestInterceptor } from '../DevCycleModule/RequestInterceptor'
+import {
+    ConfigurableModuleClass,
+    MODULE_OPTIONS_TOKEN,
+} from '../DevCycleModule/DevCycleModuleOptions'
+
+@Module({
+    exports: [DevCycleClient],
+    providers: [
+        {
+            provide: DevCycleClient,
+            useFactory: ({ key, options }) =>
+                new MockDevCycleClient(key, options),
+            inject: [MODULE_OPTIONS_TOKEN],
+        },
+        {
+            provide: APP_INTERCEPTOR,
+            useClass: RequestInterceptor,
+        },
+    ],
+})
+export class DevCycleModule extends ConfigurableModuleClass {}

--- a/sdk/nestjs/src/__mocks__/RequireVariableValue.ts
+++ b/sdk/nestjs/src/__mocks__/RequireVariableValue.ts
@@ -1,0 +1,1 @@
+export * from '../RequireVariableValue'

--- a/sdk/nestjs/src/__mocks__/VariableValue.ts
+++ b/sdk/nestjs/src/__mocks__/VariableValue.ts
@@ -1,0 +1,1 @@
+export * from '../VariableValue'

--- a/sdk/nestjs/src/__mocks__/index.ts
+++ b/sdk/nestjs/src/__mocks__/index.ts
@@ -1,0 +1,6 @@
+export * from './VariableValue'
+export * from './RequireVariableValue'
+export * from './DevCycleModule'
+export * from './DevCycleClient'
+
+export * from '@devcycle/nodejs-server-sdk'

--- a/sdk/nestjs/tsconfig.lib.json
+++ b/sdk/nestjs/tsconfig.lib.json
@@ -8,7 +8,6 @@
     "exclude": [
         "**/*.spec.ts",
         "**/*.test.ts",
-        "**/__mocks__/**/*.ts",
         "**/__tests__/**/*.ts",
         "jest.config.ts"
     ],


### PR DESCRIPTION
The SDK can be mocked using `jest.mock('@devcycle/nestjs-server-sdk')`

Variable values can be mocked using the `mockVariables` method
```
  const dvcClient = moduleRef.get<DevCycleClient>(
      DevCycleClient,
  ) as MockDevCycleClient
  dvcClient.mockVariables({ 'user-permissions': true })
```