### PR TITLE
chore: remove audience _id field from config and update bucketing code

### DIFF
--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
@@ -8,7 +8,8 @@ import {
     validSubTypes,
     CustomDataFilter,
     UserFilter,
-    NoIdAudience, AudienceMatchFilter
+    AudienceMatchFilter,
+    Audience
 } from '../types'
 import { JSON } from '@devcycle/assemblyscript-json/assembly'
 import { getF64FromJSONValue } from '../helpers/jsonHelpers'
@@ -24,7 +25,7 @@ import { getF64FromJSONValue } from '../helpers/jsonHelpers'
  */
 export function _evaluateOperator(
     operator: AudienceOperator,
-    audiences: Map<string, NoIdAudience>,
+    audiences: Map<string, Audience>,
     user: DVCPopulatedUser,
     clientCustomData: JSON.Obj
 ): bool {
@@ -61,7 +62,7 @@ export function _evaluateOperator(
 
 function doesUserPassFilter(
     filter: AudienceFilter,
-    audiences: Map<string, NoIdAudience>,
+    audiences: Map<string, Audience>,
     user: DVCPopulatedUser,
     clientCustomData: JSON.Obj
 ): bool {
@@ -96,7 +97,7 @@ function doesUserPassFilter(
 
 function filterForAudienceMatch(
     filter: AudienceMatchFilter,
-    configAudiences: Map<string, NoIdAudience>,
+    configAudiences: Map<string, Audience>,
     user: DVCPopulatedUser,
     clientCustomData: JSON.Obj
 ): bool {

--- a/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/testHelpers.ts
@@ -10,12 +10,12 @@ import {
     Rollout as PublicRollout,
     Target as PublicTarget,
     AudienceOperator, UserFilter,
-    NoIdAudience,
     decodeVariableForUserParams_PB,
     encodeVariableForUserParams_PB,
     decodeDVCUser_PB,
     decodeSDKVariable_PB,
-    encodeSDKVariable_PB
+    encodeSDKVariable_PB,
+    Audience
 } from './types'
 import {
     _checkCustomData,
@@ -87,7 +87,7 @@ export function evaluateOperatorFromJSON(
     if (!operatorJSON.isObj) {
         throw new Error('evaluateOperatorFromJSON operatorStr or userStr param not a JSON Object')
     }
-    const audiences = new Map<string, NoIdAudience>()
+    const audiences = new Map<string, Audience>()
     if (audiencesStr !== '' && audiencesStr !== '{}') {
         const audiencesJSON = JSON.parse(audiencesStr) as JSON.Obj
         if (!audiencesJSON.isObj) {
@@ -96,7 +96,7 @@ export function evaluateOperatorFromJSON(
         const keys = audiencesJSON.keys
         for (let i = 0; i < keys.length; i++) {
             const aud = audiencesJSON.get(keys[i]) as JSON.Obj
-            audiences.set(keys[i], new NoIdAudience(aud))
+            audiences.set(keys[i], new Audience(aud))
         }
     }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -9,7 +9,7 @@ import {
     getJSONObjFromJSONOptional,
 } from '../helpers/jsonHelpers'
 import { Feature } from './feature'
-import { NoIdAudience } from './target'
+import { Audience } from './target'
 
 export class PublicProject extends JSON.Value {
     readonly _id: string
@@ -79,7 +79,7 @@ export class Variable extends JSON.Value {
 
 export class ConfigBody {
     readonly project: PublicProject
-    readonly audiences: Map<string, NoIdAudience>
+    readonly audiences: Map<string, Audience>
     readonly environment: PublicEnvironment
     readonly features: Feature[]
     readonly variables: Variable[]
@@ -170,13 +170,13 @@ export class ConfigBody {
             configJSONObj,
             'audiences',
         )
-        const audiences = new Map<string, NoIdAudience>()
+        const audiences = new Map<string, Audience>()
         if (audiencesJSON) {
             const audienceKeys = audiencesJSON.keys
             for (let i = 0; i < audienceKeys.length; i++) {
                 const audience_id = audienceKeys[i]
                 const aud = audiencesJSON.get(audience_id)
-                audiences.set(audience_id, new NoIdAudience(aud as JSON.Obj))
+                audiences.set(audience_id, new Audience(aud as JSON.Obj))
             }
         }
         this.audiences = audiences

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -145,7 +145,7 @@ export class AudienceOperator extends JSON.Value {
     }
 }
 
-export class NoIdAudience extends JSON.Value {
+export class Audience extends JSON.Value {
     readonly filters: AudienceOperator
 
     constructor(audience: JSON.Obj) {
@@ -156,22 +156,6 @@ export class NoIdAudience extends JSON.Value {
 
     stringify(): string {
         const json = new JSON.Obj()
-        json.set('filters', this.filters)
-        return json.stringify()
-    }
-}
-
-export class Audience extends NoIdAudience {
-    readonly _id: string
-
-    constructor(audience: JSON.Obj) {
-        super(audience)
-        this._id = getStringFromJSON(audience, '_id')
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('_id', this._id)
         json.set('filters', this.filters)
         return json.stringify()
     }

--- a/lib/shared/bucketing-test-data/src/data/largeConfig.ts
+++ b/lib/shared/bucketing-test-data/src/data/largeConfig.ts
@@ -1,3 +1,5 @@
+import { ConfigBody } from '@devcycle/types'
+
 export const largeConfig = {
     project: {
         _id: '52979e6b353148fe8d54f1b7946578da',
@@ -51,7 +53,6 @@ export const largeConfig = {
                 targets: [
                     {
                         _audience: {
-                            _id: 'b8c6aca26fb540c78cea5560620d3fa5',
                             filters: {
                                 filters: [
                                     {
@@ -78,7 +79,6 @@ export const largeConfig = {
                     },
                     {
                         _audience: {
-                            _id: '59b2ecbd6d204f3ba8bd59ea17871844',
                             filters: {
                                 filters: [
                                     {
@@ -140,7 +140,6 @@ export const largeConfig = {
                 targets: [
                     {
                         _audience: {
-                            _id: '9a3c47be82ec469b836ef2aa63de3fdc',
                             filters: {
                                 filters: [
                                     {
@@ -275,7 +274,6 @@ export const largeConfig = {
                 targets: [
                     {
                         _audience: {
-                            _id: 'fa43ca76fc0943ba922051e144088065',
                             filters: {
                                 filters: [
                                     {
@@ -313,7 +311,6 @@ export const largeConfig = {
                     },
                     {
                         _audience: {
-                            _id: 'a0f11ee6388e4e7984667c779f423163',
                             filters: {
                                 filters: [
                                     {
@@ -371,7 +368,6 @@ export const largeConfig = {
                 targets: [
                     {
                         _audience: {
-                            _id: '19aec1d651d64ec7993df5c5a13ea33f',
                             filters: {
                                 filters: [
                                     {
@@ -403,7 +399,6 @@ export const largeConfig = {
                     },
                     {
                         _audience: {
-                            _id: '49b2698a5aa84622975f37d0582164e9',
                             filters: {
                                 filters: [
                                     {
@@ -461,7 +456,6 @@ export const largeConfig = {
                 targets: [
                     {
                         _audience: {
-                            _id: '09dce2cbd4594bf8bfc164769ec51415',
                             filters: {
                                 filters: [
                                     {
@@ -507,7 +501,6 @@ export const largeConfig = {
                     },
                     {
                         _audience: {
-                            _id: '86393f91545f4922a81b5567ac3ec901',
                             filters: {
                                 filters: [
                                     {

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -9,7 +9,8 @@ import {
     PublicEnvironment,
     PublicProject,
     PublicVariable,
-    PublicVariation, TargetAudience,
+    PublicVariation,
+    TargetAudience,
     UserSubType,
     VariableType,
 } from '@devcycle/types'
@@ -46,7 +47,7 @@ export const reusableAudiences: PublicAudience[] = [
             ],
             operator: AudienceOperator.and,
         },
-    }
+    },
 ]
 
 export const audiences: TargetAudience[] = [

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -9,7 +9,7 @@ import {
     PublicEnvironment,
     PublicProject,
     PublicVariable,
-    PublicVariation,
+    PublicVariation, TargetAudience,
     UserSubType,
     VariableType,
 } from '@devcycle/types'
@@ -32,7 +32,7 @@ export const environment: PublicEnvironment = {
     key: 'test-environment',
 }
 
-export const audiences: PublicAudience[] = [
+export const reusableAudiences: PublicAudience[] = [
     {
         _id: '614ef6ea475929459060721a',
         filters: {
@@ -46,9 +46,24 @@ export const audiences: PublicAudience[] = [
             ],
             operator: AudienceOperator.and,
         },
+    }
+]
+
+export const audiences: TargetAudience[] = [
+    {
+        filters: {
+            filters: [
+                {
+                    type: FilterType.user,
+                    subType: UserSubType.email,
+                    comparator: FilterComparator['='],
+                    values: ['test@email.com', 'test2@email.com'],
+                },
+            ],
+            operator: AudienceOperator.and,
+        },
     },
     {
-        _id: '6153557f1ed7bac7268ea0d9',
         filters: {
             filters: [
                 {
@@ -85,7 +100,6 @@ export const audiences: PublicAudience[] = [
         },
     },
     {
-        _id: '6153557f1ed7bac7268ea0d5',
         filters: {
             filters: [
                 {
@@ -115,7 +129,6 @@ export const audiences: PublicAudience[] = [
         },
     },
     {
-        _id: '6153557f1ed7bac7268ea0d6',
         filters: {
             filters: [
                 {
@@ -139,7 +152,6 @@ export const audiences: PublicAudience[] = [
         },
     },
     {
-        _id: '6153557f1ed7bac7268ea074',
         filters: {
             filters: [
                 {
@@ -152,7 +164,6 @@ export const audiences: PublicAudience[] = [
         },
     },
     {
-        _id: '6153557f1ed7bac7268ea0d7',
         filters: {
             filters: [
                 {
@@ -168,7 +179,6 @@ export const audiences: PublicAudience[] = [
         },
     },
     {
-        _id: '6153557f1ed7bac7268ea0d8',
         filters: {
             filters: [
                 {
@@ -404,10 +414,11 @@ function configBodyAudiences(audiences: PublicAudience[]): {
     })
     return auds
 }
+
 export const config: ConfigBody = {
     project,
     environment,
-    audiences: configBodyAudiences(audiences),
+    audiences: configBodyAudiences(reusableAudiences),
     features: [
         {
             _id: '614ef6aa473928459060721a',
@@ -634,7 +645,7 @@ export const barrenConfig: ConfigBody = {
 export const configWithNullCustomData: ConfigBody = {
     project,
     environment,
-    audiences: configBodyAudiences(audiences),
+    audiences: configBodyAudiences(reusableAudiences),
     features: [
         {
             _id: '614ef6aa475928459060721d',

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -4,15 +4,16 @@ import pick from 'lodash/pick'
 import last from 'lodash/last'
 import first from 'lodash/first'
 import {
-    ConfigBody,
-    PublicTarget,
-    PublicFeature,
+    AudienceOperator,
     BucketedUserConfig,
+    ConfigBody,
+    DVCBucketingUser,
+    Feature,
+    PublicFeature,
     PublicRollout,
     PublicRolloutStage,
-    DVCBucketingUser,
+    PublicTarget,
     Variation,
-    Feature,
 } from '@devcycle/types'
 
 import murmurhash from 'murmurhash'

--- a/lib/shared/types/src/types/config/models/audience.ts
+++ b/lib/shared/types/src/types/config/models/audience.ts
@@ -102,6 +102,43 @@ export enum AudienceOperator {
     or = 'or',
 }
 
+export class AudienceFilter<IdType = string> {
+    /**
+     * Filter type of this audience filter (user, audienceTemplate etc.)
+     */
+    type: FilterType
+
+    /**
+     * Sub type of this filter (appVersion, mixpanel etc.)
+     */
+    subType?: UserSubType
+
+    /**
+     * Comparator to use if this is a filter
+     */
+    comparator: FilterComparator
+
+    /**
+     * Data Key used for custom data and other filter sub-type that require a key-value mapping.
+     */
+    dataKey?: string
+
+    /**
+     * Data Key used for custom data and other filter sub-type that require a key-value mapping.
+     */
+    dataKeyType?: DataKeyType
+
+    /**
+     * Filter values to segment against, must be set for all filter types other than 'all'
+     */
+    values?: string[] | boolean[] | number[]
+
+    /**
+     * Array of audience id's for filters of type audienceMatch
+     */
+    _audiences?: IdType[]
+}
+
 /**
  * Audience filter used to describe a segmentation for a user audience.
  */

--- a/lib/shared/types/src/types/config/models/featureConfiguration.ts
+++ b/lib/shared/types/src/types/config/models/featureConfiguration.ts
@@ -1,4 +1,4 @@
-import { Audience, AudienceFilter } from './audience'
+import { Audience, AudienceFilter, TopLevelOperator } from './audience'
 import { Type } from 'class-transformer'
 
 export enum TargetingRuleTypes {
@@ -62,6 +62,10 @@ export class TargetDistribution<IdType = string> {
     percentage: number
 }
 
+export class TargetAudience<IdType = string> {
+    filters: TopLevelOperator<IdType>
+}
+
 /**
  * Defines an Audience Target including the Audience model, rollout, and variation distribution
  * _id needed as it will be used as the seed in the hashing function to determine a given users position
@@ -73,7 +77,7 @@ export class Target<IdType = string> {
     /**
      * Audience model describing target segmentation.
      */
-    _audience: Pick<Audience<IdType>, 'filters'>
+    _audience: TargetAudience<IdType>
 
     /**
      * Rollout sub-document describing how a Target's audience is rolled out

--- a/lib/shared/types/src/types/config/models/featureConfiguration.ts
+++ b/lib/shared/types/src/types/config/models/featureConfiguration.ts
@@ -1,4 +1,4 @@
-import { Audience } from './audience'
+import { Audience, AudienceFilter } from './audience'
 import { Type } from 'class-transformer'
 
 export enum TargetingRuleTypes {
@@ -73,7 +73,7 @@ export class Target<IdType = string> {
     /**
      * Audience model describing target segmentation.
      */
-    _audience: Audience<IdType>
+    _audience: Pick<Audience<IdType>, 'filters'>
 
     /**
      * Rollout sub-document describing how a Target's audience is rolled out


### PR DESCRIPTION
The `_audience._id` field inside the targeting rules of the config is not used, but also will no longer exist due to the audience merge migration.

Update the types to omit this field and update the assembly script bucketing to remove it as well