### PR TITLE
fix: update imports to use js extensions for es modules

### DIFF
--- a/lib/web-debugger/index.ts
+++ b/lib/web-debugger/index.ts
@@ -1,1 +1,1 @@
-export * from './src/initializeDevCycleDebugger'
+export * from './src/initializeDevCycleDebugger.js'

--- a/lib/web-debugger/package.json
+++ b/lib/web-debugger/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@devcycle/web-debugger",
     "version": "0.0.3",
-    "type": "commonjs",
+    "type": "module",
     "main": "./src/index.js",
     "types": "./src/index.d.ts",
     "description": "The DevCycle Web Debugger used for debugging feature flags from your own website",

--- a/lib/web-debugger/react.tsx
+++ b/lib/web-debugger/react.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import {
     initializeDevCycleDebugger,
     DebuggerIframeOptions,
-} from './src/initializeDevCycleDebugger'
+} from './src/initializeDevCycleDebugger.js'
 import { useDevCycleClient } from '@devcycle/react-client-sdk'
 
 export const DevCycleDebugger = (options: DebuggerIframeOptions): null => {


### PR DESCRIPTION
- add js extensions to imports so it works in esmodules
- change package.json type to "module" since Nx is messing with it anyway and setting it to module