### PR TITLE
chore: Fix example apps resolution

### DIFF
--- a/examples/react/project.json
+++ b/examples/react/project.json
@@ -26,7 +26,7 @@
                 "tsConfig": "examples/react/tsconfig.app.json",
                 "assets": ["examples/react/src/public"],
                 "scripts": [],
-                "webpackConfig": "@nx/react/plugins/webpack"
+                "webpackConfig": "examples/react/webpack.config.js"
             },
             "defaultConfiguration": "production"
         },

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -2,6 +2,8 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "jsx": "react-jsx",
+        "module": "esnext",
+        "moduleResolution": "bundler",
         "allowJs": true,
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,

--- a/examples/react/webpack.config.js
+++ b/examples/react/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = composePlugins(
     withNx(),
     withReact(),
     (config, { options, context }) => {
+        // support resolving .js import extensions with their respective .ts extensions
         config.resolve.extensionAlias = {
             '.js': ['.ts', '.js'],
             '.mjs': ['.mts', '.mjs'],

--- a/examples/react/webpack.config.js
+++ b/examples/react/webpack.config.js
@@ -1,0 +1,16 @@
+const { composePlugins, withNx } = require('@nx/webpack')
+const { withReact } = require('@nx/react')
+
+// Nx composable plugins for webpack.
+module.exports = composePlugins(
+    withNx(),
+    withReact(),
+    (config, { options, context }) => {
+        config.resolve.extensionAlias = {
+            '.js': ['.ts', '.js'],
+            '.mjs': ['.mts', '.mjs'],
+            '.cjs': ['.cts', '.cjs'],
+        }
+        return config
+    },
+)

--- a/lib/web-debugger/package.json
+++ b/lib/web-debugger/package.json
@@ -2,8 +2,8 @@
     "name": "@devcycle/web-debugger",
     "version": "0.0.5",
     "type": "module",
-    "main": "./src/index.js",
-    "types": "./src/index.d.ts",
+    "main": "./index.js",
+    "types": "./index.d.ts",
     "description": "The DevCycle Web Debugger used for debugging feature flags from your own website",
     "license": "MIT",
     "author": "DevCycle <support@devcycle.com>",
@@ -23,12 +23,10 @@
     "exports": {
         ".": {
             "import": "./index.js",
-            "require": "./index.js",
             "types": "./index.d.ts"
         },
         "./react": {
             "import": "./react.js",
-            "require": "./react.js",
             "types": "./react.d.ts"
         }
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,8 +31,8 @@
             "@devcycle/config-manager": [
                 "lib/shared/config-manager/src/index.ts"
             ],
-            "@devcycle/web-debugger": ["lib/web-debugger/src/index.ts"],
-            "@devcycle/web-debugger/react": ["lib/web-debugger/src/react.tsx"],
+            "@devcycle/web-debugger": ["lib/web-debugger/index.ts"],
+            "@devcycle/web-debugger/react": ["lib/web-debugger/react.tsx"],
             "@devcycle/js-client-sdk": ["sdk/js/src/index.ts"],
             "@devcycle/js-cloud-server-sdk": [
                 "sdk/js-cloud-server/src/index.ts"


### PR DESCRIPTION
Allow the React example app to properly resolve ".js" file imports from our libraries that need to specify imports that way.