### PR TITLE
fix: remove warning about window being undefined

### DIFF
--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -100,12 +100,7 @@ export function initializeDevCycle<
     const userAndOptions = determineUserAndOptions(userOrOptions, optionsArg)
     const { options } = userAndOptions
     const isServiceWorker = checkIsServiceWorker()
-    // TODO: implement logger
-    if (typeof window === 'undefined' && !options.next && !isServiceWorker) {
-        console.warn(
-            'Window is not defined, try initializing in a browser context',
-        )
-    }
+
     if (
         typeof window !== 'undefined' &&
         !window.addEventListener &&


### PR DESCRIPTION
- remove the warning about window not being defined
- this appears any time the js sdk is executed on the server (which can happen in any SSR usecase) so it isn't really a useful warning. The SDK works without the window being defined