### PR TITLE
fix: the clientSDKKey field currently errors when you try and test th…

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/types/configBody.test.ts
@@ -34,6 +34,27 @@ describe.each([true, false])('Config Body', (utf8) => {
         )
     })
 
+    it('should parse if missing optional top level field', () => {
+        const config = cloneDeep(testData.config)
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        delete config.clientSDKKey
+        expect(testConfigBody(JSON.stringify(config), utf8)).toEqual(
+            JSON.parse(
+                JSON.stringify({
+                    ...testData.config,
+                    project: {
+                        ...testData.config.project,
+                        settings: {
+                            disablePassthroughRollouts: false
+                        }
+                    },
+                    variableHashes: undefined,
+                    clientSDKKey: undefined,
+                }),
+            ),
+        )
+    })
     it('should throw if target.rollout is missing type', () => {
         const config = cloneDeep(testData.config)
         const target: any = config.features[0].configuration.targets[0]

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -24,7 +24,6 @@ export class Settings extends JSON.Value {
             this.disablePassthroughRollouts = false
         }
     }
-    
     stringify(): string {
         const json = new JSON.Obj()
         json.set('disablePassthroughRollouts', this.disablePassthroughRollouts)
@@ -143,9 +142,8 @@ export class ConfigBody {
         this.etag = etag
         this.clientSDKKey = getStringFromJSONOptional(
             configJSONObj,
-            'clientSDKKey',
+            'clientSDKKey'
         )
-
         this.project = new PublicProject(
             getJSONObjFromJSON(configJSONObj, 'project'),
         )
@@ -232,7 +230,9 @@ export class ConfigBody {
         json.set('audiences', jsonObjFromMap(this.audiences))
         json.set('features', jsonArrFromValueArray(this.features))
         json.set('variables', jsonArrFromValueArray(this.variables))
-        json.set('clientSDKKey', this.clientSDKKey)
+        if (this.clientSDKKey) {
+            json.set('clientSDKKey', this.clientSDKKey)
+        }
         return json.stringify()
     }
 

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -663,7 +663,6 @@ export const barrenConfig: ConfigBody = {
     ],
     variables: [],
     variableHashes: {},
-    clientSDKKey: 'test',
 }
 
 export const configWithNullCustomData: ConfigBody = {


### PR DESCRIPTION
…e config body because it was always getting set to null, and then throwing on stringify