### PR TITLE
fix: update react-native and react-native-expo TYPE path in package.json to the right file

### DIFF
--- a/sdk/react-native-expo/package.json
+++ b/sdk/react-native-expo/package.json
@@ -24,7 +24,7 @@
         "url": "git://github.com/DevCycleHQ/js-sdks.git"
     },
     "homepage": "https://devcycle.com",
-    "types": "dist/index.d.ts",
+    "types": "./index.cjs.d.ts",
     "license": "MIT",
     "dependencies": {
         "@devcycle/js-client-sdk": "^1.24.3",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -23,7 +23,7 @@
         "tsc": "tsc",
         "build": "yarn clean && yarn tsc"
     },
-    "types": "dist/index.d.ts",
+    "types": "./index.cjs.d.ts",
     "license": "MIT",
     "dependencies": {
         "@devcycle/js-client-sdk": "^1.24.3",


### PR DESCRIPTION
- fix: update `react-native` package.json `types` to `./index.cjs.d.ts` 
- fix: update `react-native-expo` package.json `types` to `./index.cjs.d.ts` 
  - these changes are required as NX does not support remapping of the `types` field the same way it supports the `main` field in the package.json files