### PR TITLE
fix: Forward Refs in React SDK HOC

### DIFF
--- a/.github/workflows/nx-affected-e2e.yml
+++ b/.github/workflows/nx-affected-e2e.yml
@@ -27,6 +27,7 @@ jobs:
               run: yarn affected:e2e
               env:
                 E2E_NEXTJS_SERVER_KEY: ${{ secrets.E2E_NEXTJS_SERVER_KEY }}
+                NEXT_PUBLIC_E2E_NEXTJS_KEY: ${{ secrets.NEXT_PUBLIC_E2E_NEXTJS_CLIENT_KEY }}
                 NEXT_PUBLIC_E2E_NEXTJS_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_E2E_NEXTJS_CLIENT_KEY }}
                 DVC_E2E_SERVER_SDK_KEY: ${{ secrets.DVC_E2E_SERVER_SDK_KEY }}
             - name: Upload Playwright Report

--- a/sdk/react/src/withDevCycleProvider.tsx
+++ b/sdk/react/src/withDevCycleProvider.tsx
@@ -1,25 +1,32 @@
 import { ProviderConfig } from './types'
-import React from 'react'
+import React, {
+    forwardRef,
+    ForwardRefExoticComponent,
+    PropsWithoutRef,
+    RefAttributes,
+} from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { DevCycleProvider } from './DevCycleProvider'
 
-export function withDevCycleProvider<T extends object>(
-    config: ProviderConfig,
-): (WrappedComponent: React.ComponentType<T>) => React.ComponentType<T> {
-    return (WrappedComponent) => {
-        const HoistedComponent = (props: T) => {
+export const withDevCycleProvider =
+    <T extends object>(config: ProviderConfig) =>
+    (
+        WrappedComponent: React.ComponentType<T>,
+    ): ForwardRefExoticComponent<
+        PropsWithoutRef<T> & RefAttributes<unknown>
+    > => {
+        const HoistedComponent = forwardRef((props: T, ref) => {
             return (
                 <DevCycleProvider config={config}>
-                    <WrappedComponent {...props} />
+                    <WrappedComponent {...props} ref={ref} />
                 </DevCycleProvider>
             )
-        }
+        })
 
         hoistNonReactStatics(HoistedComponent, WrappedComponent)
 
         return HoistedComponent
     }
-}
 
 /**
  * @deprecated Use withDevCycleProvider instead


### PR DESCRIPTION
Update the react SDK HOC to use forwardRef to assign any passed-in ref to the original wrapped component