### PR TITLE
chore: update react-native and react-native-expo build system to remove polyfills

### DIFF
--- a/sdk/react-native-expo/package.json
+++ b/sdk/react-native-expo/package.json
@@ -34,7 +34,7 @@
         "react-native-get-random-values": "^1.7.2"
     },
     "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-native": ">=0.69.5"
+        "react": ">=17.0.2",
+        "react-native": ">=0.68.0"
     }
 }

--- a/sdk/react-native-expo/package.json
+++ b/sdk/react-native-expo/package.json
@@ -34,7 +34,7 @@
         "react-native-get-random-values": "^1.7.2"
     },
     "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-native": ">=0.64.0"
+        "react": ">=18.0.0",
+        "react-native": ">=0.69.5"
     }
 }

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -15,6 +15,12 @@
         "build": {
             "executor": "@nrwl/rollup:rollup",
             "outputs": ["{options.outputPath}"],
+            "dependsOn": [
+                "shared-types:build",
+                "js:build",
+                "react:build",
+                "react-native:build"
+            ],
             "options": {
                 "outputPath": "dist/sdk/react-native-expo",
                 "tsConfig": "sdk/react-native-expo/tsconfig.lib.json",

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -28,7 +28,6 @@
                 "entryFile": "sdk/react-native-expo/src/index.ts",
                 "format": ["esm", "cjs"],
                 "external": "all",
-                "generateExportsField": true,
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "tsc",
                 "assets": [

--- a/sdk/react-native-expo/project.json
+++ b/sdk/react-native-expo/project.json
@@ -13,25 +13,6 @@
             }
         },
         "build": {
-            "command": "echo Building Expo Target",
-            "dependsOn": ["build:expo"]
-        },
-        "build:expo": {
-            "executor": "@altack/nx-bundlefy:run",
-            "configurations": {},
-            "dependsOn": ["build:es5"],
-            "outputs": ["{options.outputFile}"]
-        },
-        "build:es5": {
-            "dependsOn": [
-                "shared-types:build:es5",
-                "shared-types:build",
-                "js:build:es5",
-                "js:build",
-                "react:build:es5",
-                "react:build",
-                "react:build:es5"
-            ],
             "executor": "@nrwl/rollup:rollup",
             "outputs": ["{options.outputPath}"],
             "options": {
@@ -41,8 +22,9 @@
                 "entryFile": "sdk/react-native-expo/src/index.ts",
                 "format": ["esm", "cjs"],
                 "external": "all",
+                "generateExportsField": true,
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
-                "compiler": "babel",
+                "compiler": "tsc",
                 "assets": [
                     {
                         "glob": "sdk/react-native-expo/README.md",

--- a/sdk/react-native-expo/tsconfig.lib.json
+++ b/sdk/react-native-expo/tsconfig.lib.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
-        "types": ["node"],
+        "types": ["node"]
     },
     "exclude": [
         "jest.config.ts",

--- a/sdk/react-native-expo/tsconfig.lib.json
+++ b/sdk/react-native-expo/tsconfig.lib.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
         "types": ["node"],
-        "jsx": "react-native"
     },
     "exclude": [
         "jest.config.ts",

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -33,7 +33,7 @@
         "react-native-get-random-values": "^1.7.2"
     },
     "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-native": ">=0.69.5"
+        "react": ">=17.0.2",
+        "react-native": ">=0.68.0"
     }
 }

--- a/sdk/react-native/package.json
+++ b/sdk/react-native/package.json
@@ -33,7 +33,7 @@
         "react-native-get-random-values": "^1.7.2"
     },
     "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-native": ">=0.64.0"
+        "react": ">=18.0.0",
+        "react-native": ">=0.69.5"
     }
 }

--- a/sdk/react-native/project.json
+++ b/sdk/react-native/project.json
@@ -15,6 +15,11 @@
         "build": {
             "executor": "@nrwl/rollup:rollup",
             "outputs": ["{options.outputPath}"],
+            "dependsOn": [
+                "shared-types:build",
+                "js:build",
+                "react:build"
+            ],
             "options": {
                 "outputPath": "dist/sdk/react-native",
                 "tsConfig": "sdk/react-native/tsconfig.lib.json",
@@ -22,8 +27,9 @@
                 "entryFile": "sdk/react-native/src/index.ts",
                 "format": ["esm", "cjs"],
                 "external": "all",
+                "generateExportsField": true,
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
-                "compiler": "babel",
+                "compiler": "tsc",
                 "assets": [
                     {
                         "glob": "sdk/react-native/README.md",

--- a/sdk/react-native/project.json
+++ b/sdk/react-native/project.json
@@ -27,7 +27,6 @@
                 "entryFile": "sdk/react-native/src/index.ts",
                 "format": ["esm", "cjs"],
                 "external": "all",
-                "generateExportsField": true,
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "tsc",
                 "assets": [

--- a/sdk/react-native/project.json
+++ b/sdk/react-native/project.json
@@ -15,11 +15,7 @@
         "build": {
             "executor": "@nrwl/rollup:rollup",
             "outputs": ["{options.outputPath}"],
-            "dependsOn": [
-                "shared-types:build",
-                "js:build",
-                "react:build"
-            ],
+            "dependsOn": ["shared-types:build", "js:build", "react:build"],
             "options": {
                 "outputPath": "dist/sdk/react-native",
                 "tsConfig": "sdk/react-native/tsconfig.lib.json",

--- a/sdk/react-native/tsconfig.lib.json
+++ b/sdk/react-native/tsconfig.lib.json
@@ -2,8 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
-        "types": ["node"],
-        "jsx": "react-native"
+        "types": ["node"]
     },
     "exclude": [
         "jest.config.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,8 +4800,8 @@ __metadata:
     react-native-device-info: ^8.7.0
     react-native-get-random-values: ^1.7.2
   peerDependencies:
-    react: ">=16.8.0"
-    react-native: ">=0.64.0"
+    react: ">=18.0.0"
+    react-native: ">=0.69.5"
   languageName: unknown
   linkType: soft
 
@@ -4815,8 +4815,8 @@ __metadata:
     react-native-device-info: ^8.7.0
     react-native-get-random-values: ^1.7.2
   peerDependencies:
-    react: ">=16.8.0"
-    react-native: ">=0.64.0"
+    react: ">=18.0.0"
+    react-native: ">=0.69.5"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,8 +4800,8 @@ __metadata:
     react-native-device-info: ^8.7.0
     react-native-get-random-values: ^1.7.2
   peerDependencies:
-    react: ">=18.0.0"
-    react-native: ">=0.69.5"
+    react: ">=17.0.2"
+    react-native: ">=0.68.0"
   languageName: unknown
   linkType: soft
 
@@ -4815,8 +4815,8 @@ __metadata:
     react-native-device-info: ^8.7.0
     react-native-get-random-values: ^1.7.2
   peerDependencies:
-    react: ">=18.0.0"
-    react-native: ">=0.69.5"
+    react: ">=17.0.2"
+    react-native: ">=0.68.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The `build:es5` builds for `react-native` and `react-native-expo` were adding polyfills for Promises and other functions, these polyfills are not required anymore. But do require increasing our minimum support levels to:
- react-native: `0.69.0`
- react: `18.0.0`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
