### PR TITLE
fix: sdk not recovering from failure on first config fetch

### DIFF
--- a/lib/shared/config-manager/src/index.ts
+++ b/lib/shared/config-manager/src/index.ts
@@ -23,7 +23,7 @@ type TrackSDKConfigEventInterface = (
 ) => void
 
 export class EnvironmentConfigManager {
-    private hasConfig = false
+    hasConfig = false
     configEtag?: string
     configLastModified?: string
     private readonly pollingIntervalMS: number

--- a/lib/shared/config-manager/src/index.ts
+++ b/lib/shared/config-manager/src/index.ts
@@ -23,7 +23,7 @@ type TrackSDKConfigEventInterface = (
 ) => void
 
 export class EnvironmentConfigManager {
-    hasConfig = false
+    private _hasConfig = false
     configEtag?: string
     configLastModified?: string
     private readonly pollingIntervalMS: number
@@ -75,7 +75,9 @@ export class EnvironmentConfigManager {
                 }, this.pollingIntervalMS)
             })
     }
-
+    get hasConfig(): boolean {
+        return this._hasConfig
+    }
     stopPolling(): void {
         this.disablePolling = true
         this.clearInterval(this.intervalTimeout)
@@ -106,7 +108,7 @@ export class EnvironmentConfigManager {
             const errMsg =
                 `Request to get config failed for url: ${url}, ` +
                 `response message: ${error.message}, response data: ${projectConfig}`
-            if (this.hasConfig) {
+            if (this._hasConfig) {
                 this.logger.warn(errMsg)
             } else {
                 this.logger.error(errMsg)
@@ -165,7 +167,7 @@ export class EnvironmentConfigManager {
                     `${this.sdkKey}${this.clientMode ? '_client' : ''}`,
                     projectConfig,
                 )
-                this.hasConfig = true
+                this._hasConfig = true
                 this.configEtag = res?.headers.get('etag') || ''
                 this.configLastModified =
                     res?.headers.get('last-modified') || ''
@@ -179,7 +181,7 @@ export class EnvironmentConfigManager {
             }
         }
 
-        if (this.hasConfig) {
+        if (this._hasConfig) {
             this.logger.warn(
                 `Failed to download config, using cached version. url: ${url}.`,
             )

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -4,7 +4,30 @@ import { DevCycleClient } from '../src/client'
 import { DevCycleUser } from '@devcycle/js-cloud-server-sdk'
 
 jest.mock('../src/bucketing')
-jest.mock('@devcycle/config-manager')
+jest.mock('@devcycle/config-manager', () => {
+    return {
+        EnvironmentConfigManager: class {
+            hasConfig: boolean
+            config: unknown
+
+            constructor() {
+                this.hasConfig = true // Set hasConfig to true in the constructor
+            }
+
+            cleanup(): void {
+                return
+            }
+
+            getConfigURL(): string {
+                return 'url'
+            }
+
+            async _fetchConfig(): Promise<void> {
+                this.config = {}
+            }
+        },
+    }
+})
 jest.mock('../src/eventQueue')
 
 describe('DevCycleClient', () => {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -138,7 +138,6 @@ export class DevCycleClient {
         this.onInitialized = initializePromise
             .then(() => {
                 this.logger.info('DevCycle initialized')
-                this._isInitialized = true
                 return this
             })
             .catch((err) => {
@@ -146,8 +145,10 @@ export class DevCycleClient {
                 if (err instanceof UserError) {
                     throw err
                 }
-                this._isInitialized = true
                 return this
+            })
+            .finally(() => {
+                this._isInitialized = true
             })
 
         process.on('exit', () => {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -146,6 +146,7 @@ export class DevCycleClient {
                 if (err instanceof UserError) {
                     throw err
                 }
+                this._isInitialized = true
                 return this
             })
 
@@ -209,9 +210,9 @@ export class DevCycleClient {
         )
         const populatedUser = DVCPopulatedUserFromDevCycleUser(incomingUser)
 
-        if (!this._isInitialized) {
+        if (!this.configHelper.hasConfig) {
             this.logger.warn(
-                'variable called before DevCycleClient initialized, returning default value',
+                'variable called before DevCycleClient has config, returning default value',
             )
 
             this.eventQueue?.queueAggregateEvent(populatedUser, {
@@ -263,9 +264,9 @@ export class DevCycleClient {
     allVariables(user: DevCycleUser): DVCVariableSet {
         const incomingUser = castIncomingUser(user)
 
-        if (!this._isInitialized) {
+        if (!this.configHelper.hasConfig) {
             this.logger.warn(
-                'allVariables called before DevCycleClient initialized',
+                'allVariables called before DevCycleClient has config',
             )
             return {}
         }
@@ -278,9 +279,9 @@ export class DevCycleClient {
     allFeatures(user: DevCycleUser): DVCFeatureSet {
         const incomingUser = castIncomingUser(user)
 
-        if (!this._isInitialized) {
+        if (!this.configHelper.hasConfig) {
             this.logger.warn(
-                'allFeatures called before DevCycleClient initialized',
+                'allFeatures called before DevCycleClient has config',
             )
             return {}
         }


### PR DESCRIPTION
The first config request failing during initialization would result in the `_isInitalized` boolean never getting set. This would permanent break the variables/features/track calls since `_isInitialized` would only be set to true if the first config request succeeded.

The fix was to expose the `configHelper`'s `hasConfig` property to the client, and to use that property to determine whether the variable calls should log a warning and return the default. This allows the sdk to recover if/when a subsequent config request succeeds.

Additionally, the `_isInitialized` flag is now being set to true in the `catch` case of the initialized promise. This is so that the `track` call can continue to use that flag as a gate since it doesn't require a config, just the event queue being initialized.