### PR TITLE
fix: trigger event if sse url contains dvc_user

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -700,8 +700,11 @@ export class DevCycleClient<
             config.variables,
             this.variableDefaultMap,
         )
-
-        if (!oldConfig || oldConfig.etag !== this.config.etag) {
+        // The URL including dvc_user means that this user is subscribed to a user specific ably channel
+        // This means that the user is a debug user and we should emit a config update event even if the etag
+        // is the same.
+        const isDebugUser = this.config?.sse?.url?.includes('dvc_user')
+        if (!oldConfig || isDebugUser || oldConfig.etag !== this.config.etag) {
             this.eventEmitter.emitConfigUpdate(config.variables)
         }
     }


### PR DESCRIPTION
ConfigUpdated events werent being triggered if there was a previous config, and a new config came in with a matching etag.  This is an issue for users who are subscribed to an sse channel containing "dvc_user", as the presence of that channel indicates that the user is listening for config changes triggered by self-targeting. Since self-targeting pulls in overrides separately from the CDN and then monkey-patches the config, the etag for the newly updated config will be unchanged.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a bug where ConfigUpdated events were not triggered for debug users if the new config had a matching etag with the previous config. It also adds tests to verify the correct behavior for both debug and non-debug users.

* **Bug Fixes**:
    - Fixed issue where ConfigUpdated events were not triggered if the new config had a matching etag with the previous config, specifically for users subscribed to an SSE channel containing 'dvc_user'.
* **Tests**:
    - Added test to ensure ConfigUpdated event is emitted for debug users even if the etag matches.
    - Added test to ensure ConfigUpdated event is not emitted for non-debug users if the etag matches.

<!-- Generated by sourcery-ai[bot]: end summary -->