### PR TITLE
feat: add startswith endswith

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
@@ -158,186 +158,6 @@ describe('SegmentationManager Unit Test', () => {
     beforeEach(() => {
         setPlatformDataJSON(defaultPlatformData)
     })
-    // TODO update and uncomment these tests when we incorporate list audiences
-    // describe('listAudience filters', () => {
-    //     it('passes segmentation for single list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '2'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(true)
-    //     })
-    //
-    //     it('passes segmentation for multiple value list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '2'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(true)
-    //     })
-    //
-    //     it('passes segmentation for not in list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '!=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '14'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(true)
-    //     })
-    //
-    //     it('fails segmentation for not in list audience while IN list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '!=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '2'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(false)
-    //     })
-    //
-    //     it('fails segmentation for in list audience while NOT IN list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '14'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(false)
-    //     })
-    //
-    //     it('throws error when filters not prepared', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '!=',
-    //             values: ['test1']
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //         try {
-    //             segmentation.evaluateFilters({ filters, data: appUser })
-    //         } catch (e) {
-    //             expect(e.message)
-    //              .toBe('ListAudience filter must be an object, has not been prepared for segmentation')
-    //             return
-    //         }
-    //
-    //         throw new Error()
-    //     })
-    // })
 
     describe('evaluateOperator', () => {
         it('should fail for empty filters', () => {
@@ -1260,6 +1080,38 @@ describe('SegmentationManager Unit Test', () => {
                 values: ['Chrome', 0],
             }
             assert.strictEqual(true, checkStringsFilter('Chrome', filter))
+        })
+        it('should return true if string startsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'startsWith',
+                values: ['something'],
+            }
+            assert.strictEqual(true, checkStringsFilter('something_else', filter))
+        })
+        it('should return false if string does not startsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'startsWith',
+                values: ['something'],
+            }
+            assert.strictEqual(false, checkStringsFilter('aaaa', filter))
+        })
+        it('should return true if string endsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'endsWith',
+                values: ['something'],
+            }
+            assert.strictEqual(true, checkStringsFilter('ends_something', filter))
+        })
+        it('should return false if string does not endsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'endsWith',
+                values: ['something'],
+            }
+            assert.strictEqual(false, checkStringsFilter('aaaa', filter))
         })
         it('should return true if browser device type filter works', () => {
             const filter = {

--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/segmentation.test.ts
@@ -1087,7 +1087,10 @@ describe('SegmentationManager Unit Test', () => {
                 comparator: 'startsWith',
                 values: ['something'],
             }
-            assert.strictEqual(true, checkStringsFilter('something_else', filter))
+            assert.strictEqual(
+                true,
+                checkStringsFilter('something_else', filter),
+            )
         })
         it('should return false if string does not startsWith value', () => {
             const filter = {
@@ -1103,7 +1106,10 @@ describe('SegmentationManager Unit Test', () => {
                 comparator: 'endsWith',
                 values: ['something'],
             }
-            assert.strictEqual(true, checkStringsFilter('ends_something', filter))
+            assert.strictEqual(
+                true,
+                checkStringsFilter('ends_something', filter),
+            )
         })
         it('should return false if string does not endsWith value', () => {
             const filter = {

--- a/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
@@ -853,6 +853,7 @@ describe('EventQueueManager Tests', () => {
     describe('memory usage test', () => {
         it('should save a large number of events to AS Event Queue', () => {
             const sdkKey = 'sdk_key_memory_test'
+            const user_id = 'user_id_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test'
             const event = {
                 type: 'testType_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test_long_name',
                 target: 'testTarget_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test',
@@ -861,8 +862,7 @@ describe('EventQueueManager Tests', () => {
                 metaData: random_JSON,
             }
             const dvcUser = {
-                user_id:
-                    'user_id_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test',
+                user_id,
                 email: '_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test',
                 language: 'en',
                 country: 'CA',
@@ -877,7 +877,7 @@ describe('EventQueueManager Tests', () => {
             initSDK(sdkKey)
             for (let i = 0; i < 2000; i++) {
                 event.target += i
-                dvcUser.user_id += i
+                dvcUser.user_id = user_id + i
                 queueEvent(sdkKey, dvcUser, event)
             }
 

--- a/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/eventQueue/eventQueueManager.test.ts
@@ -853,7 +853,8 @@ describe('EventQueueManager Tests', () => {
     describe('memory usage test', () => {
         it('should save a large number of events to AS Event Queue', () => {
             const sdkKey = 'sdk_key_memory_test'
-            const user_id = 'user_id_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test'
+            const user_id =
+                'user_id_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test'
             const event = {
                 type: 'testType_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test_long_name',
                 target: 'testTarget_long_name_test_long_name_test_long_name_test_long_name_test_long_name_test',

--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
@@ -232,11 +232,11 @@ export function checkVersionFilter(
     return !not ? passed : !passed
 }
 
-export function _checkNumberFilter(num: f64, filterNums: f64[], operator: string | null): bool {
-    if (operator && isString(operator)) {
-        if (operator === 'exist') {
+export function _checkNumberFilter(num: f64, filterNums: f64[], comparator: string | null): bool {
+    if (comparator && isString(comparator)) {
+        if (comparator === 'exist') {
             return !isNaN(num)
-        } else if (operator === '!exist') {
+        } else if (comparator === '!exist') {
             return isNaN(num)
         }
     }
@@ -245,7 +245,7 @@ export function _checkNumberFilter(num: f64, filterNums: f64[], operator: string
         return false
     }
 
-    if (operator === '!=') {
+    if (comparator === '!=') {
         let passesFilter = true
         for (let i = 0; i < filterNums.length; i++) {
             const filterNum = filterNums[i]
@@ -264,15 +264,15 @@ export function _checkNumberFilter(num: f64, filterNums: f64[], operator: string
             continue
         }
 
-        if (operator === '=') {
+        if (comparator === '=') {
             someValue = num === filterNum
-        } else if (operator === '>') {
+        } else if (comparator === '>') {
             someValue = num > filterNum
-        } else if (operator === '>=') {
+        } else if (comparator === '>=') {
             someValue = num >= filterNum
-        } else if (operator === '<') {
+        } else if (comparator === '<') {
             someValue = num < filterNum
-        } else if (operator === '<=') {
+        } else if (comparator === '<=') {
             someValue = num <= filterNum
         } else {
             continue
@@ -311,6 +311,26 @@ export function _checkStringsFilter(string: string | null, filter: UserFilter): 
         return string !== null && !!findString(values, string)
     } else if (operator === '!contain') {
         return string === null || !findString(values, string)
+    } else if (operator === 'startsWith') {
+        if (string == null) {
+            return false
+        }
+        for (let i = 0; i < values.length; i++) {
+            if (string.startsWith(values[i])) {
+                return true
+            }
+        }
+        return false
+    } else if (operator === 'endsWith') {
+        if (string == null) {
+            return false
+        }
+        for (let i = 0; i < values.length; i++) {
+            if (string.endsWith(values[i])) {
+                return true
+            }
+        }
+        return false
     } else {
         return isString(string)
     }

--- a/lib/shared/bucketing-assembly-script/assembly/helpers/murmurhash.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/helpers/murmurhash.ts
@@ -15,7 +15,6 @@ export function murmurhashV3(key: string, seed: u32): u32 {
     let currentBuffer = keyBuffer
     if (key.length > keyBuffer.length) {
         console.log("Warning: exceeded maximum size of murmurhash buffer.")
-        console.log(key)
         currentBuffer = new StaticArray<i32>(key.length)
     }
 

--- a/lib/shared/bucketing-assembly-script/assembly/helpers/murmurhash.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/helpers/murmurhash.ts
@@ -15,6 +15,7 @@ export function murmurhashV3(key: string, seed: u32): u32 {
     let currentBuffer = keyBuffer
     if (key.length > keyBuffer.length) {
         console.log("Warning: exceeded maximum size of murmurhash buffer.")
+        console.log(key)
         currentBuffer = new StaticArray<i32>(key.length)
     }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -171,7 +171,7 @@ export const validSubTypes = [
 ]
 
 const validComparators = [
-    '=', '!=', '>', '>=', '<', '<=', 'exist', '!exist', 'contain', '!contain'
+    '=', '!=', '>', '>=', '<', '<=', 'exist', '!exist', 'contain', '!contain', 'startsWith', 'endsWith'
 ]
 
 const validAudienceMatchComparators = ['=', '!=']

--- a/lib/shared/bucketing/__tests__/segmentation.test.ts
+++ b/lib/shared/bucketing/__tests__/segmentation.test.ts
@@ -939,7 +939,10 @@ describe('SegmentationManager Unit Test', () => {
                 comparator: 'startsWith',
                 values: ['something'],
             } as AudienceFilterOrOperator
-            assert.strictEqual(true, segmentation.checkStringsFilter('something_else', filter))
+            assert.strictEqual(
+                true,
+                segmentation.checkStringsFilter('something_else', filter),
+            )
         })
         it('should return false if string does not startsWith value', () => {
             const filter = {
@@ -947,7 +950,10 @@ describe('SegmentationManager Unit Test', () => {
                 comparator: 'startsWith',
                 values: ['something'],
             } as AudienceFilterOrOperator
-            assert.strictEqual(false, segmentation.checkStringsFilter('aaaa', filter))
+            assert.strictEqual(
+                false,
+                segmentation.checkStringsFilter('aaaa', filter),
+            )
         })
         it('should return true if string endsWith value', () => {
             const filter = {
@@ -955,7 +961,10 @@ describe('SegmentationManager Unit Test', () => {
                 comparator: 'endsWith',
                 values: ['something'],
             } as AudienceFilterOrOperator
-            assert.strictEqual(true, segmentation.checkStringsFilter('ends_something', filter))
+            assert.strictEqual(
+                true,
+                segmentation.checkStringsFilter('ends_something', filter),
+            )
         })
         it('should return false if string does not endsWith value', () => {
             const filter = {
@@ -963,7 +972,10 @@ describe('SegmentationManager Unit Test', () => {
                 comparator: 'endsWith',
                 values: ['something'],
             } as AudienceFilterOrOperator
-            assert.strictEqual(false, segmentation.checkStringsFilter('aaaa', filter))
+            assert.strictEqual(
+                false,
+                segmentation.checkStringsFilter('aaaa', filter),
+            )
         })
         it('should return true if not contains filter and value', () => {
             const filter = {

--- a/lib/shared/bucketing/__tests__/segmentation.test.ts
+++ b/lib/shared/bucketing/__tests__/segmentation.test.ts
@@ -13,186 +13,6 @@ import {
 } from '@devcycle/types'
 
 describe('SegmentationManager Unit Test', () => {
-    // TODO update and uncomment these tests when we incorporate list audiences
-    // describe('listAudience filters', () => {
-    //     it('passes segmentation for single list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '2'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(true)
-    //     })
-    //
-    //     it('passes segmentation for multiple value list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '2'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(true)
-    //     })
-    //
-    //     it('passes segmentation for not in list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '!=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '14'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(true)
-    //     })
-    //
-    //     it('fails segmentation for not in list audience while IN list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '!=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '2'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(false)
-    //     })
-    //
-    //     it('fails segmentation for in list audience while NOT IN list audience', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '=',
-    //             values: [{
-    //                 _listAudience: 'test1',
-    //                 version: '14'
-    //             }, {
-    //                 _listAudience: 'test1',
-    //                 version: '17'
-    //             }]
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //
-    //         expect(segmentation.evaluateFilters({ filters, data: appUser })).toBe(false)
-    //     })
-    //
-    //     it('throws error when filters not prepared', () => {
-    //         const filters = [{
-    //             _id: 'some_id',
-    //             type: 'listAudience',
-    //             comparator: '!=',
-    //             values: ['test1']
-    //         }]
-    //         const appUser = {
-    //             listAudienceSegmentation: [
-    //                 {
-    //                     _listAudience: 'test1',
-    //                     version: '1'
-    //                 }, {
-    //                     _listAudience: 'test1',
-    //                     version: '2'
-    //                 }, {
-    //                     _listAudience: 'test2',
-    //                     version: '1'
-    //                 }]
-    //         }
-    //         try {
-    //             segmentation.evaluateFilters({ filters, data: appUser })
-    //         } catch (e) {
-    //             expect(e.message).toBe('ListAudience filter must be an object, has not been prepared for segmentation')
-    //             return
-    //         }
-    //
-    //         throw new Error()
-    //     })
-    // })
-
     const featureId = 'testID'
     const isOptInEnabled = false
 
@@ -1112,6 +932,38 @@ describe('SegmentationManager Unit Test', () => {
                 true,
                 segmentation.checkStringsFilter(null, filter),
             )
+        })
+        it('should return true if string startsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'startsWith',
+                values: ['something'],
+            } as AudienceFilterOrOperator
+            assert.strictEqual(true, segmentation.checkStringsFilter('something_else', filter))
+        })
+        it('should return false if string does not startsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'startsWith',
+                values: ['something'],
+            } as AudienceFilterOrOperator
+            assert.strictEqual(false, segmentation.checkStringsFilter('aaaa', filter))
+        })
+        it('should return true if string endsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'endsWith',
+                values: ['something'],
+            } as AudienceFilterOrOperator
+            assert.strictEqual(true, segmentation.checkStringsFilter('ends_something', filter))
+        })
+        it('should return false if string does not endsWith value', () => {
+            const filter = {
+                type: 'user',
+                comparator: 'endsWith',
+                values: ['something'],
+            } as AudienceFilterOrOperator
+            assert.strictEqual(false, segmentation.checkStringsFilter('aaaa', filter))
         })
         it('should return true if not contains filter and value', () => {
             const filter = {

--- a/lib/shared/bucketing/src/segmentation.ts
+++ b/lib/shared/bucketing/src/segmentation.ts
@@ -324,6 +324,10 @@ export const checkStringsFilter = (
                 (!isString(string) ||
                     !find(values, (value) => includes(string, value)))
             )
+        case 'startsWith':
+            return !!values && isString(string) && values.some(value => isString(value) && string.startsWith(value))
+        case 'endsWith' :
+            return !!values && isString(string) && values.some(value => isString(value) && string.endsWith(value))
     }
     return isString(string)
 }
@@ -395,30 +399,6 @@ export const checkCustomData = (
     }
     return true
 }
-
-// const checkListAudienceFilterOrOperator = ({ values = [], data, comparator }) => {
-//     const isInListAudience = values.some((value) => {
-//         if (!isObject(value)) {
-//             throw new Error('ListAudience filter must be an object, has not been prepared for segmentation')
-//         }
-//         return data.some((datum) => isEqual(datum, value))
-//     })
-//
-//     return comparator === '=' ? !!isInListAudience : !isInListAudience
-// }
-// exports.checkListAudienceFilter = checkListAudienceFilter
-
-//
-// const checkListAudienceFields = (data, filters) => {
-//     if (!filters || !filters.length) return true
-//
-//     return filters.every((filter) => {
-//         const values = getFilterValues(filter)
-//         const comparator = filter.comparator
-//         return checkListAudienceFilter({ data, values, comparator })
-//     })
-// }
-// exports.checkListAudienceFields = checkListAudienceFields
 
 export const getFilterValues = (
     filter: AudienceFilterOrOperator,

--- a/lib/shared/bucketing/src/segmentation.ts
+++ b/lib/shared/bucketing/src/segmentation.ts
@@ -325,9 +325,21 @@ export const checkStringsFilter = (
                     !find(values, (value) => includes(string, value)))
             )
         case 'startsWith':
-            return !!values && isString(string) && values.some(value => isString(value) && string.startsWith(value))
-        case 'endsWith' :
-            return !!values && isString(string) && values.some(value => isString(value) && string.endsWith(value))
+            return (
+                !!values &&
+                isString(string) &&
+                values.some(
+                    (value) => isString(value) && string.startsWith(value),
+                )
+            )
+        case 'endsWith':
+            return (
+                !!values &&
+                isString(string) &&
+                values.some(
+                    (value) => isString(value) && string.endsWith(value),
+                )
+            )
     }
     return isString(string)
 }

--- a/lib/shared/types/src/types/config/models/audience.ts
+++ b/lib/shared/types/src/types/config/models/audience.ts
@@ -12,6 +12,8 @@ export enum FilterComparator {
     '!exist' = '!exist',
     'contain' = 'contain',
     '!contain' = '!contain',
+    'startsWith' = 'startsWith',
+    'endsWith' = 'endsWith'
 }
 
 export enum BooleanFilterComparator {
@@ -27,6 +29,8 @@ export enum StringFilterComparator {
     '!exist' = '!exist',
     'contain' = 'contain',
     '!contain' = '!contain',
+    'startsWith' = 'startsWith',
+    'endsWith' = 'endsWith'
 }
 
 export enum NumberFilterComparator {

--- a/lib/shared/types/src/types/config/models/audience.ts
+++ b/lib/shared/types/src/types/config/models/audience.ts
@@ -13,7 +13,7 @@ export enum FilterComparator {
     'contain' = 'contain',
     '!contain' = '!contain',
     'startsWith' = 'startsWith',
-    'endsWith' = 'endsWith'
+    'endsWith' = 'endsWith',
 }
 
 export enum BooleanFilterComparator {
@@ -30,7 +30,7 @@ export enum StringFilterComparator {
     'contain' = 'contain',
     '!contain' = '!contain',
     'startsWith' = 'startsWith',
-    'endsWith' = 'endsWith'
+    'endsWith' = 'endsWith',
 }
 
 export enum NumberFilterComparator {


### PR DESCRIPTION
Add support for "startsWith" and "endsWith" comparators to bucketing logic. This prepares the logic for future addition of these operators once we figure out a deployment plan that doesn't break old SDK versions.