### PR TITLE
fix: Node.js SSE reconnecting after error on 304 CDN response

### DIFF
--- a/lib/shared/config-manager/src/index.ts
+++ b/lib/shared/config-manager/src/index.ts
@@ -273,6 +273,7 @@ export class EnvironmentConfigManager {
                 `Config not modified, using cache, etag: ${this.configEtag}` +
                     `, last-modified: ${this.configLastModified}`,
             )
+            this.handleSSEConfig()
             return
         } else if (res?.status === 200 && projectConfig) {
             const lastModifiedHeader = res?.headers.get('last-modified')
@@ -329,11 +330,15 @@ export class EnvironmentConfigManager {
         )
     }
 
-    private handleSSEConfig(projectConfig: string) {
+    private handleSSEConfig(projectConfig?: string) {
         if (this.enableRealtimeUpdates) {
-            const configBody = JSON.parse(projectConfig) as ConfigBody<string>
             const originalConfigSSE = this.configSSE
-            this.configSSE = configBody.sse
+            if (projectConfig) {
+                const configBody = JSON.parse(
+                    projectConfig,
+                ) as ConfigBody<string>
+                this.configSSE = configBody.sse
+            }
 
             // Reconnect SSE if not first config fetch, and the SSE config has changed
             if (


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
