### PR TITLE
fix: Add clientSDKKey as a tag on the config request so it can be invalidated from the client side

### DIFF
--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -1,7 +1,6 @@
 'use client'
 import React, { Suspense, use, useContext, useRef, useState } from 'react'
 import { DevCycleClient, initializeDevCycle } from '@devcycle/js-client-sdk'
-import { useRouter } from 'next/navigation'
 import { invalidateConfig } from '../../common/invalidateConfig'
 import { DevCycleNextOptions, DevCycleServerData } from '../../common/types'
 import { DevCycleProviderContext } from './context'
@@ -59,20 +58,13 @@ export const InternalDevCycleClientsideProvider = ({
     children,
     promiseResolved,
 }: DevCycleClientsideProviderProps): React.ReactElement => {
-    const router = useRouter()
     const clientRef = useRef<DevCycleClient>()
 
     const { serverDataPromise, serverData, clientSDKKey, enableStreaming } =
         context
 
     const revalidateConfig = (lastModified?: number) => {
-        invalidateConfig(
-            clientSDKKey,
-            !!context.options.enableObfuscation,
-            lastModified,
-        ).finally(() => {
-            router.refresh()
-        })
+        void invalidateConfig(clientSDKKey)
     }
 
     let resolvedServerData = serverData

--- a/sdk/nextjs/src/client/internal/useRerenderOnVariableChange.ts
+++ b/sdk/nextjs/src/client/internal/useRerenderOnVariableChange.ts
@@ -7,7 +7,6 @@ export const useRerenderOnVariableChange = (key?: string): void => {
     const client = useDevCycleClient()
 
     const variableKey = key ?? '*'
-
     useEffect(() => {
         client.subscribe(
             `variableUpdated:${variableKey}`,

--- a/sdk/nextjs/src/common/invalidateConfig.ts
+++ b/sdk/nextjs/src/common/invalidateConfig.ts
@@ -1,12 +1,7 @@
 'use server'
-import { fetchCDNConfig } from '../server/requests'
 import { revalidateTag } from 'next/cache'
 
-export const invalidateConfig = async (
-    sdkToken: string,
-    obfuscated: boolean,
-    lastModified?: number,
-): Promise<void> => {
+export const invalidateConfig = async (sdkToken: string): Promise<void> => {
     if (typeof window != 'undefined') {
         console.error(
             'DevCycle realtime updates are only available in Next.js 14.0.5 and above. Please update your version ' +
@@ -14,29 +9,6 @@ export const invalidateConfig = async (
         )
         return
     }
-    await invalidateConfigCache(sdkToken, obfuscated, lastModified)
-}
-
-export const invalidateConfigCache = async (
-    sdkKey: string,
-    obfuscated: boolean,
-    lastModified?: number,
-): Promise<void> => {
-    const response = await fetchCDNConfig(sdkKey, {
-        enableObfuscation: obfuscated,
-    })
-
-    const lastModifiedHeader = response.headers.get('last-modified')
-
-    const lastModifiedCache = new Date(lastModifiedHeader ?? 0)
-    const lastModifiedClient = new Date(lastModified ?? 0)
-
-    if (
-        lastModifiedHeader &&
-        lastModified &&
-        lastModifiedClient > lastModifiedCache
-    ) {
-        console.log('Invalidating old DevCycle cached config')
-        revalidateTag(sdkKey)
-    }
+    console.log('Invalidating old DevCycle cached config')
+    revalidateTag(sdkToken)
 }

--- a/sdk/nextjs/src/pages/appWithDevCycle.tsx
+++ b/sdk/nextjs/src/pages/appWithDevCycle.tsx
@@ -30,7 +30,6 @@ export const appWithDevCycle = <Props extends NextJsAppProps>(
             ._devcycleSSR as SSRProps['_devcycleSSR']
 
         const onServerside = typeof window === 'undefined'
-
         if (!devcycleSSR) {
             return <WrappedComponent {...props} />
         }

--- a/sdk/nextjs/src/server/bucketing.ts
+++ b/sdk/nextjs/src/server/bucketing.ts
@@ -23,7 +23,6 @@ const generateBucketedConfigCached = cache(
             undefined,
             userAgent ?? undefined,
         )
-
         return {
             config: {
                 ...generateBucketedConfig({ user: populatedUser, config }),
@@ -44,12 +43,13 @@ const generateBucketedConfigCached = cache(
  */
 export const getBucketedConfig = async (
     sdkKey: string,
+    clientSDKKey: string,
     user: DevCycleUser,
     options: DevCycleNextOptions,
     userAgent?: string,
 ): Promise<BucketedConfigWithAdditionalFields> => {
     // this request will be cached by Next
-    const cdnConfig = await fetchCDNConfig(sdkKey, options)
+    const cdnConfig = await fetchCDNConfig(sdkKey, clientSDKKey, options)
     if (!cdnConfig.ok) {
         const responseText = await cdnConfig.text()
         throw new Error('Could not fetch config: ' + responseText)

--- a/sdk/nextjs/src/server/initialize.ts
+++ b/sdk/nextjs/src/server/initialize.ts
@@ -25,6 +25,7 @@ const cachedUserGetter = cache(
 
 export const initialize = async (
     sdkKey: string,
+    clientSDKKey: string,
     userGetter: () => DevCycleUser | Promise<DevCycleUser>,
     options: DevCycleNextOptions = {},
 ): Promise<DevCycleServerData> => {
@@ -51,7 +52,13 @@ export const initialize = async (
 
     let config = null
     try {
-        config = await getBucketedConfig(sdkKey, user, options, userAgent)
+        config = await getBucketedConfig(
+            sdkKey,
+            clientSDKKey,
+            user,
+            options,
+            userAgent,
+        )
     } catch (e) {
         console.error('Error fetching DevCycle config', e)
     }

--- a/sdk/nextjs/src/server/requests.ts
+++ b/sdk/nextjs/src/server/requests.ts
@@ -7,6 +7,7 @@ const getFetchUrl = (sdkKey: string, obfuscated: boolean) =>
 
 export const fetchCDNConfig = async (
     sdkKey: string,
+    clientSDKKey: string,
     options: DevCycleNextOptions,
 ): Promise<Response> => {
     return await fetch(
@@ -15,7 +16,7 @@ export const fetchCDNConfig = async (
         {
             next: {
                 revalidate: 60,
-                tags: [sdkKey],
+                tags: [sdkKey, clientSDKKey],
             },
         },
     )

--- a/sdk/nextjs/src/server/setupDevCycle.tsx
+++ b/sdk/nextjs/src/server/setupDevCycle.tsx
@@ -32,22 +32,27 @@ export const setupDevCycle = ({
         key,
         defaultValue,
     ) => {
-        await initialize(serverSDKKey, userGetter, options)
+        await initialize(serverSDKKey, clientSDKKey, userGetter, options)
         return getVariableValue(key, defaultValue)
     }
 
     const _getAllVariables: typeof getAllVariables = async () => {
-        await initialize(serverSDKKey, userGetter, options)
+        await initialize(serverSDKKey, clientSDKKey, userGetter, options)
         return getAllVariables()
     }
 
     const _getAllFeatures: typeof getAllFeatures = async () => {
-        await initialize(serverSDKKey, userGetter, options)
+        await initialize(serverSDKKey, clientSDKKey, userGetter, options)
         return getAllFeatures()
     }
 
     const _getClientContext = () => {
-        const serverDataPromise = initialize(serverSDKKey, userGetter, options)
+        const serverDataPromise = initialize(
+            serverSDKKey,
+            clientSDKKey,
+            userGetter,
+            options,
+        )
 
         const { enableStreaming, enableObfuscation, ...otherOptions } = options
 


### PR DESCRIPTION
- Remove the lastModified logic from the invalidation since the lastModified date wont actually be accessible on the client side due to the config using the server token
- add clientSDKKey as a parameter to the initialize call so it can be added as a tag on the server side
- Tested manually