### PR TITLE
chore: test number conversion to string in as

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
@@ -8,6 +8,7 @@ import {
     setClientCustomData,
     variableForUser as variableForUser_AS,
     VariableType,
+    convertNumberToString,
 } from '../bucketingImportHelper'
 import testData from '@devcycle/bucketing-test-data/json-data/testData.json'
 const { config, barrenConfig, configWithNullCustomData } = testData
@@ -214,6 +215,22 @@ describe('User Hashing and Bucketing', () => {
             'fake',
         )
         expect(bucketingHash).not.toBe(rolloutHash)
+    })
+})
+
+describe('AS Number conversion', () => {
+    it('converts numbers to strings', () => {
+        const number = 610
+        const convertedNumber = convertNumberToString(number)
+        expect(typeof convertedNumber).toBe('string')
+        expect(convertedNumber).toBe('610')
+    })
+
+    it('converts floats to strings', () => {
+        const number = 610.61
+        const convertedNumber = convertNumberToString(number)
+        expect(typeof convertedNumber).toBe('string')
+        expect(convertedNumber).toBe('610.61')
     })
 })
 

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -63,6 +63,10 @@ export function generateBucketedConfigForUser(
     return bucketedConfig.stringify()
 }
 
+export function convertNumberToString(num: number): string {
+    return num.toString()
+}
+
 export function generateBucketedConfigForUserUTF8(
     sdkKey: string,
     userJSONStr: Uint8Array,

--- a/lib/shared/bucketing/__tests__/bucketing.test.ts
+++ b/lib/shared/bucketing/__tests__/bucketing.test.ts
@@ -5,6 +5,7 @@ import {
     decideTargetVariation,
     generateBucketedConfig,
     doesUserPassRollout,
+    convertNumberToString,
 } from '../src/bucketing'
 import {
     config,
@@ -96,6 +97,22 @@ describe('User Hashing and Bucketing', () => {
             'fake',
         )
         expect(bucketingHash).not.toBe(rolloutHash)
+    })
+})
+
+describe('TypeScript Number conversion', () => {
+    it('converts numbers to strings', () => {
+        const number = 610
+        const convertedNumber = convertNumberToString(number)
+        expect(typeof convertedNumber).toBe('string')
+        expect(convertedNumber).toBe('610.0')
+    })
+
+    it('converts floats to strings', () => {
+        const number = 610.61
+        const convertedNumber = convertNumberToString(number)
+        expect(typeof convertedNumber).toBe('string')
+        expect(convertedNumber).toBe('610.61')
     })
 })
 

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -175,6 +175,10 @@ const checkRolloutAndEvaluate = ({
     }
 }
 
+export const convertNumberToString = (num: number): string => {
+    return num.toString()
+}
+
 export const getSegmentedFeatureDataFromConfig = ({
     config,
     user,


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
