### PR TITLE
feat: add comparators to ConfigBody

### DIFF
--- a/lib/shared/types/src/types/config/models/audience.ts
+++ b/lib/shared/types/src/types/config/models/audience.ts
@@ -12,6 +12,10 @@ export enum FilterComparator {
     '!exist' = '!exist',
     'contain' = 'contain',
     '!contain' = '!contain',
+    'startWith' = 'startWith',
+    '!startWith' = '!startWith',
+    'endWith' = 'endWith',
+    '!endWith' = '!endWith',
 }
 
 export enum BooleanFilterComparator {
@@ -27,6 +31,10 @@ export enum StringFilterComparator {
     '!exist' = '!exist',
     'contain' = 'contain',
     '!contain' = '!contain',
+    'startWith' = 'startWith',
+    '!startWith' = '!startWith',
+    'endWith' = 'endWith',
+    '!endWith' = '!endWith',
 }
 
 export enum NumberFilterComparator {

--- a/lib/shared/types/src/types/config/models/featureConfiguration.ts
+++ b/lib/shared/types/src/types/config/models/featureConfiguration.ts
@@ -1,4 +1,4 @@
-import { Audience, AudienceFilter, TopLevelOperator } from './audience'
+import { TopLevelOperator } from './audience'
 import { Type } from 'class-transformer'
 
 export enum TargetingRuleTypes {


### PR DESCRIPTION
- add comparator types to the shared types


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
