### PR TITLE
chore: fixed passing in logger object when stringifying to prevent circular json error

### DIFF
--- a/sdk/nodejs/__tests__/eventQueue.test.ts
+++ b/sdk/nodejs/__tests__/eventQueue.test.ts
@@ -1071,5 +1071,18 @@ describe('EventQueue Unit Tests', () => {
                     'must be smaller than 20,000',
             )
         })
+
+        it('should not pass in logger to bucketing', () => {
+            const spy = jest.spyOn(bucketing, 'initEventQueue')
+            const options = {
+                logger: defaultLogger,
+                eventRequestChunkSize: 1000,
+                disableAutomaticEventLogging: true,
+                disableCustomEventLogging: false,
+            }
+            new EventQueue('test', 'uuid', bucketing, options)
+            const spyOptions = JSON.parse(spy.mock.calls[0][2])
+            expect(spyOptions.logger).toBeUndefined()
+        })
     })
 })

--- a/sdk/nodejs/src/eventQueue.ts
+++ b/sdk/nodejs/src/eventQueue.ts
@@ -106,10 +106,16 @@ export class EventQueue {
             this.eventFlushIntervalMS,
         )
 
+        const eventQueueOptions = {
+            eventRequestChunkSize: chunkSize,
+            disableAutomaticEventLogging: options.disableAutomaticEventLogging,
+            disableCustomEventLogging: options.disableCustomEventLogging,
+        }
+
         this.bucketing.initEventQueue(
             sdkKey,
             this.clientUUID,
-            JSON.stringify(options),
+            JSON.stringify(eventQueueOptions),
         )
     }
 


### PR DESCRIPTION
# Changes

- filtered out the `logger` option when initializing the event queue in the bucketing library to avoid JSON.stringifying a logger that could be passed in, e.g. `winston`. If the logger has a circular dependency, stringifying it will cause an error. Since the event queue options don't utilize the logger anyway, only pass in the options it expects

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
