### PR TITLE
fix: disable last modified check on vercel edge config and fix type definitions

### DIFF
--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -68,6 +68,7 @@ export const InternalDevCycleClientsideProvider = ({
 
     const revalidateConfig = async (lastModified?: number) => {
         if (context.realtimeDelay) {
+            // wait configured delay before checking for new config
             await new Promise((resolve) =>
                 setTimeout(resolve, context.realtimeDelay),
             )
@@ -75,9 +76,11 @@ export const InternalDevCycleClientsideProvider = ({
         try {
             await invalidateConfig(clientSDKKey)
         } catch {
-            // do nothing on failure
+            // do nothing on failure, this is best effort
         }
         if (context.realtimeDelay) {
+            // if delay is configured, assume that the server action invalidation won't update any content and just
+            // call for a full in-place refresh
             router.refresh()
         }
     }

--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -4,6 +4,7 @@ import { DevCycleClient, initializeDevCycle } from '@devcycle/js-client-sdk'
 import { invalidateConfig } from '../../common/invalidateConfig'
 import { DevCycleNextOptions, DevCycleServerData } from '../../common/types'
 import { DevCycleProviderContext } from './context'
+import { useRouter } from 'next/navigation'
 
 export type DevCycleClientContext = {
     serverDataPromise: Promise<DevCycleServerData>
@@ -11,6 +12,7 @@ export type DevCycleClientContext = {
     clientSDKKey: string
     options: DevCycleNextOptions
     enableStreaming: boolean
+    realtimeDelay?: number
     userAgent?: string
 }
 
@@ -59,12 +61,25 @@ export const InternalDevCycleClientsideProvider = ({
     promiseResolved,
 }: DevCycleClientsideProviderProps): React.ReactElement => {
     const clientRef = useRef<DevCycleClient>()
+    const router = useRouter()
 
     const { serverDataPromise, serverData, clientSDKKey, enableStreaming } =
         context
 
-    const revalidateConfig = (lastModified?: number) => {
-        void invalidateConfig(clientSDKKey)
+    const revalidateConfig = async (lastModified?: number) => {
+        if (context.realtimeDelay) {
+            await new Promise((resolve) =>
+                setTimeout(resolve, context.realtimeDelay),
+            )
+        }
+        try {
+            await invalidateConfig(clientSDKKey)
+        } catch {
+            // do nothing on failure
+        }
+        if (context.realtimeDelay) {
+            router.refresh()
+        }
     }
 
     let resolvedServerData = serverData

--- a/sdk/nextjs/src/common/ConfigSource.ts
+++ b/sdk/nextjs/src/common/ConfigSource.ts
@@ -8,11 +8,16 @@ export abstract class ConfigSource {
      * @param kind
      * @param obfuscated
      * @param lastModifiedThreshold
+     * @param skipLastModified
      */
-    abstract getConfig(
+    abstract getConfig<T extends boolean>(
         sdkKey: string,
         kind: 'server' | 'bootstrap',
         obfuscated: boolean,
         lastModifiedThreshold?: string,
-    ): Promise<{ config: ConfigBody; lastModified: string | null }>
+        skipLastModified?: T,
+    ): Promise<{
+        config: T extends true ? ConfigBody : ConfigBody | null
+        lastModified: string | null
+    }>
 }

--- a/sdk/nextjs/src/common/types.ts
+++ b/sdk/nextjs/src/common/types.ts
@@ -47,7 +47,6 @@ export type BucketedConfigWithAdditionalFields = BucketedUserConfig & {
 }
 
 export type DevCycleServerData = {
-    options: DevCycleNextOptions
     user: DevCycleUser
     // this is null if the config failed to be fetched
     config: BucketedConfigWithAdditionalFields | null

--- a/sdk/nextjs/src/pages/bucketing.ts
+++ b/sdk/nextjs/src/pages/bucketing.ts
@@ -20,7 +20,6 @@ class CDNConfigSource extends ConfigSource {
         sdkKey: string,
         kind: 'server' | 'bootstrap',
         obfuscated: boolean,
-        lastModifiedThreshold?: string,
     ): Promise<{
         config: ConfigBody
         lastModified: string | null
@@ -49,6 +48,8 @@ export const getBucketedConfig = async (
         sdkKey,
         'bootstrap',
         obfuscated,
+        '',
+        true,
     )
     const populatedUser = new DVCPopulatedUser(
         user,

--- a/sdk/nextjs/src/server/bucketing.ts
+++ b/sdk/nextjs/src/server/bucketing.ts
@@ -57,7 +57,7 @@ class CDNConfigSource extends ConfigSource {
             throw new Error('Could not fetch config: ' + responseText)
         }
         return {
-            config: await cdnConfig.json(),
+            config: (await cdnConfig.json()) as ConfigBody,
             lastModified: cdnConfig.headers.get('last-modified'),
         }
     }
@@ -82,6 +82,8 @@ export const getBucketedConfig = async (
         sdkKey,
         'bootstrap',
         !!options.enableObfuscation,
+        '',
+        true,
     )
 
     const { bucketedConfig } = await generateBucketedConfigCached(

--- a/sdk/nextjs/src/server/initialize.ts
+++ b/sdk/nextjs/src/server/initialize.ts
@@ -75,7 +75,7 @@ export const initialize = async (
         client.synchronizeBootstrapData(config, user, getUserAgent(options))
     }
 
-    return { config, user, options }
+    return { config, user }
 }
 
 export const validateSDKKey = (

--- a/sdk/nextjs/src/server/setupDevCycle.tsx
+++ b/sdk/nextjs/src/server/setupDevCycle.tsx
@@ -54,7 +54,12 @@ export const setupDevCycle = ({
             options,
         )
 
-        const { enableStreaming, enableObfuscation, ...otherOptions } = options
+        const {
+            enableStreaming,
+            enableObfuscation,
+            configSource,
+            ...otherOptions
+        } = options
 
         const {
             disableAutomaticEventLogging,
@@ -80,6 +85,10 @@ export const setupDevCycle = ({
             options: clientOptions,
             clientSDKKey: clientSDKKey,
             enableStreaming: options?.enableStreaming ?? false,
+            // if a custom config source is set, add an artificial delay for realtime updates as a clumsy way to
+            // allow for propagation time of the custom source, since we don't have a first-class way to ensure its
+            // up to date
+            realtimeDelay: options?.configSource ? 10000 : undefined,
             userAgent: getUserAgent(options),
         }
     }

--- a/sdk/nextjs/src/server/setupDevCycle.tsx
+++ b/sdk/nextjs/src/server/setupDevCycle.tsx
@@ -54,12 +54,7 @@ export const setupDevCycle = ({
             options,
         )
 
-        const {
-            enableStreaming,
-            enableObfuscation,
-            configSource,
-            ...otherOptions
-        } = options
+        const { enableStreaming, enableObfuscation, ...otherOptions } = options
 
         const {
             disableAutomaticEventLogging,


### PR DESCRIPTION
- make sure edge config always returns a config in Nextjs by disabling the last modified check in that SDK
- fix the type definitions so that the edge config client is compatible with Nextjs types