### PR TITLE
fix: changed type from DVCVariableValue to type VariableTypeAlias

### DIFF
--- a/sdk/js/src/Variable.ts
+++ b/sdk/js/src/Variable.ts
@@ -13,7 +13,7 @@ export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
     key: string
     // prevent more specific typing based on type of defaultValue
     value: VariableTypeAlias<T>
-    callback?: (value: T) => void
+    callback?: (value: VariableTypeAlias<T>) => void
     readonly defaultValue: T
     isDefaulted: boolean
     readonly evalReason: any
@@ -36,7 +36,7 @@ export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
         this.evalReason = variable.evalReason
     }
 
-    onUpdate(callback: (value: T) => void): DVCVariable<T> {
+    onUpdate(callback: (value: VariableTypeAlias<T>) => void): DVCVariable<T> {
         checkParamType('callback', callback, 'function')
         this.callback = callback
         return this

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -229,7 +229,7 @@ export interface DVCVariable<T extends DVCVariableValue> {
      *
      * @param callback
      */
-    onUpdate(callback: (value: DVCVariableValue) => void): DVCVariable<T>
+    onUpdate(callback: (value: VariableTypeAlias<T>) => void): DVCVariable<T>
 }
 
 export interface DevCycleEvent {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
