### PR TITLE
fix: disable background refresh when realtime is disabled

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -122,7 +122,9 @@ export class DevCycleClient<
         this.eventQueue = new EventQueue(sdkKey, this, options)
 
         this.eventEmitter = new EventEmitter()
-        this.registerVisibilityChangeHandler()
+        if (!this.options.disableRefreshOnInactivity) {
+            this.registerVisibilityChangeHandler()
+        }
 
         this.onInitialized = new Promise((resolve, reject) => {
             this.settleOnInitialized = (value, error) => {

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -122,7 +122,7 @@ export class DevCycleClient<
         this.eventQueue = new EventQueue(sdkKey, this, options)
 
         this.eventEmitter = new EventEmitter()
-        if (!this.options.disableRefreshOnInactivity) {
+        if (!this.options.disableRealtimeUpdates) {
             this.registerVisibilityChangeHandler()
         }
 

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -82,6 +82,12 @@ export interface DevCycleOptions {
      * Disable Realtime Update and their SSE connection.
      */
     disableRealtimeUpdates?: boolean
+
+    /**
+     * Disable the behaviour of performing a configuration refresh when the current page is foregrounded after being
+     * inactive for a while. This may cause the SDk to miss configuration updates.
+     */
+    disableRefreshOnInactivity?: boolean
     /**
      * Defer fetching configuration from DevCycle until `client.identifyUser` is called. Useful when user data is not
      * available yet at time of client instantiation.

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -82,12 +82,6 @@ export interface DevCycleOptions {
      * Disable Realtime Update and their SSE connection.
      */
     disableRealtimeUpdates?: boolean
-
-    /**
-     * Disable the behaviour of performing a configuration refresh when the current page is foregrounded after being
-     * inactive for a while. This may cause the SDk to miss configuration updates.
-     */
-    disableRefreshOnInactivity?: boolean
     /**
      * Defer fetching configuration from DevCycle until `client.identifyUser` is called. Useful when user data is not
      * available yet at time of client instantiation.


### PR DESCRIPTION
When realtime updates are disabled, there should be no page background watcher that tries to refresh the config when foregrounded. The config should never be updated after initialization, unless identity is changed.