### PR TITLE
fix: reset current promise after every config request

### DIFF
--- a/sdk/js/src/ConfigRequestConsolidator.ts
+++ b/sdk/js/src/ConfigRequestConsolidator.ts
@@ -75,6 +75,9 @@ export class ConfigRequestConsolidator {
             .catch((err) => {
                 resolvers.forEach(({ reject }) => reject(err))
             })
+            .finally(() => {
+                this.currentPromise = null
+            })
 
         if (this.resolvers.length) {
             this.processQueue()
@@ -90,7 +93,6 @@ export class ConfigRequestConsolidator {
         )
         this.requestParams = null
         const bucketedConfig = await this.currentPromise
-        this.currentPromise = null
         return bucketedConfig
     }
 }

--- a/sdk/js/src/ConfigRequestConsolidator.ts
+++ b/sdk/js/src/ConfigRequestConsolidator.ts
@@ -73,10 +73,8 @@ export class ConfigRequestConsolidator {
                 }
             })
             .catch((err) => {
-                resolvers.forEach(({ reject }) => reject(err))
-            })
-            .finally(() => {
                 this.currentPromise = null
+                resolvers.forEach(({ reject }) => reject(err))
             })
 
         if (this.resolvers.length) {
@@ -93,6 +91,7 @@ export class ConfigRequestConsolidator {
         )
         this.requestParams = null
         const bucketedConfig = await this.currentPromise
+        this.currentPromise = null
         return bucketedConfig
     }
 }

--- a/sdk/js/src/ConfigRequestConsolidator.ts
+++ b/sdk/js/src/ConfigRequestConsolidator.ts
@@ -73,7 +73,6 @@ export class ConfigRequestConsolidator {
                 }
             })
             .catch((err) => {
-                this.currentPromise = null
                 resolvers.forEach(({ reject }) => reject(err))
             })
 
@@ -90,8 +89,12 @@ export class ConfigRequestConsolidator {
             this.requestParams ? this.requestParams : undefined,
         )
         this.requestParams = null
-        const bucketedConfig = await this.currentPromise
-        this.currentPromise = null
+        const bucketedConfig = await this.currentPromise.finally(() => {
+            // clear the current promise so we can make another request
+            // this should happen regardless of whether the request was successful or not
+            this.currentPromise = null
+        })
+
         return bucketedConfig
     }
 }


### PR DESCRIPTION
- fix: reset `currentPromise` in the config request consolidation queue, including if there is an error while fetching