### PR TITLE
feat: added bucketing key logic to shared-bucketing-as

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
@@ -1629,3 +1629,205 @@ describe('Client Data', () => {
         setClientCustomDataJSON({})
     })
 })
+
+describe('bucketingKey tests', () => {
+    afterEach(() => cleanupSDK(sdkKey))
+
+    const configWithBucketingKey = (bucketingKey: string) => ({
+        ...config,
+        features: config.features.map((feature) => ({
+            ...feature,
+            configuration: {
+                ...feature.configuration,
+                targets: feature.configuration.targets.map((target) => ({
+                    ...target,
+                    bucketingKey,
+                })),
+            },
+        })),
+    })
+
+    it('buckets a user with user_id if no bucketingKey', () => {
+        const user = {
+            user_id: 'testwithfood@email.com',
+            customData: {
+                favouriteFood: 'pizza',
+            },
+            platformVersion: '1.1.2',
+        }
+        const cWithBucketingKey = configWithBucketingKey('user_id')
+        initSDK(sdkKey, cWithBucketingKey)
+
+        const c = generateBucketedConfig(user)
+
+        cleanupSDK(sdkKey)
+
+        initSDK(sdkKey, config)
+        const c2 = generateBucketedConfig(user)
+
+        expect(c.featureVariationMap.feature5).toEqual(
+            c2.featureVariationMap.feature5,
+        )
+    })
+
+    it('buckets a user with custom bucketingKey', () => {
+        const user = {
+            country: 'U S AND A',
+            user_id: 'pass_rollout',
+            customData: {
+                favouriteFood: 'pizza',
+            },
+            privateCustomData: {
+                favouriteDrink: 'coffee',
+            },
+            platformVersion: '1.1.2',
+            os: 'Android',
+            email: 'testwithfood@email.com',
+        }
+        const sameUserDifferentFood = {
+            ...user,
+            customData: {
+                favouriteFood: 'pasta',
+            },
+        }
+        const differentUserSameFood = {
+            ...sameUserDifferentFood,
+            user_id: 'a_different_person',
+        }
+        const cWithBucketingKey = configWithBucketingKey('favouriteFood')
+        initSDK(sdkKey, cWithBucketingKey)
+
+        const c = generateBucketedConfig(user)
+        const cSameUserDifferentFood = generateBucketedConfig(
+            sameUserDifferentFood,
+        )
+        const cDifferentUserSameFood = generateBucketedConfig(
+            differentUserSameFood,
+        )
+
+        expect(c.featureVariationMap.feature5).not.toEqual(
+            cSameUserDifferentFood.featureVariationMap.feature5,
+        )
+        expect(c.featureVariationMap.feature5).toEqual(
+            cDifferentUserSameFood.featureVariationMap.feature5,
+        )
+    })
+
+    it('buckets a user with custom bucketingKey from privateCustomData', () => {
+        const user = {
+            country: 'U S AND A',
+            user_id: 'pass_rollout',
+            privateCustomData: {
+                favouriteFood: 'pizza',
+            },
+            platformVersion: '1.1.2',
+            os: 'Android',
+            email: 'testwithfood@email.com',
+        }
+        const sameUserDifferentFood = {
+            ...user,
+            privateCustomData: {
+                favouriteFood: 'pasta',
+            },
+        }
+        const differentUserSameFood = {
+            ...sameUserDifferentFood,
+            user_id: 'a_different_person',
+        }
+        const cWithBucketingKey = configWithBucketingKey('favouriteFood')
+        initSDK(sdkKey, cWithBucketingKey)
+
+        const c = generateBucketedConfig(user)
+        const cSameUserDifferentFood = generateBucketedConfig(
+            sameUserDifferentFood,
+        )
+        const cDifferentUserSameFood = generateBucketedConfig(
+            differentUserSameFood,
+        )
+
+        expect(c.featureVariationMap.feature5).not.toEqual(
+            cSameUserDifferentFood.featureVariationMap.feature5,
+        )
+        expect(c.featureVariationMap.feature5).toEqual(
+            cDifferentUserSameFood.featureVariationMap.feature5,
+        )
+    })
+
+    it('buckets a user with custom number bucketingKey', () => {
+        const user = {
+            country: 'U S AND A',
+            user_id: 'pass_rollout',
+            privateCustomData: {
+                favouriteNumber: 610,
+            },
+            platformVersion: '1.1.2',
+            os: 'Android',
+            email: 'testwithfood@email.com',
+        }
+        const sameUserDifferentNum = {
+            ...user,
+            privateCustomData: {
+                favouriteNumber: 52900,
+            },
+        }
+        const differentUserSameNum = {
+            ...sameUserDifferentNum,
+            user_id: 'a_different_person',
+        }
+        const cWithBucketingKey = configWithBucketingKey('favouriteNumber')
+        initSDK(sdkKey, cWithBucketingKey)
+
+        const c = generateBucketedConfig(user)
+        const cSameUserDifferentNum =
+            generateBucketedConfig(sameUserDifferentNum)
+        const cDifferentUserSameNum =
+            generateBucketedConfig(differentUserSameNum)
+
+        expect(c.featureVariationMap.feature5).not.toEqual(
+            cSameUserDifferentNum.featureVariationMap.feature5,
+        )
+        expect(c.featureVariationMap.feature5).toEqual(
+            cDifferentUserSameNum.featureVariationMap.feature5,
+        )
+    })
+
+    it('buckets a user with custom boolean bucketingKey', () => {
+        const user = {
+            country: 'U S AND A',
+            user_id: 'pass_rollout',
+            privateCustomData: {
+                signed_up: true,
+            },
+            platformVersion: '1.1.2',
+            os: 'Android',
+            email: 'testwithfood@email.com',
+        }
+        const sameUserDifferentBool = {
+            ...user,
+            privateCustomData: {
+                signed_up: false,
+            },
+        }
+        const differentUserSameBool = {
+            ...sameUserDifferentBool,
+            user_id: 'a_different_person',
+        }
+        const cWithBucketingKey = configWithBucketingKey('signed_up')
+        initSDK(sdkKey, cWithBucketingKey)
+
+        const c = generateBucketedConfig(user)
+        const cSameUserDifferentBool = generateBucketedConfig(
+            sameUserDifferentBool,
+        )
+        const cDifferentUserSameBool = generateBucketedConfig(
+            differentUserSameBool,
+        )
+
+        expect(c.featureVariationMap.feature5).not.toEqual(
+            cSameUserDifferentBool.featureVariationMap.feature5,
+        )
+        expect(c.featureVariationMap.feature5).toEqual(
+            cDifferentUserSameBool.featureVariationMap.feature5,
+        )
+    })
+})

--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../bucketingImportHelper'
 import testData from '@devcycle/bucketing-test-data/json-data/testData.json'
 const { config, barrenConfig, configWithNullCustomData } = testData
+import { configWithBucketingKey } from '../helpers/configWithBucketingKey'
 
 import moment from 'moment'
 import * as uuid from 'uuid'
@@ -1633,27 +1634,14 @@ describe('Client Data', () => {
 describe('bucketingKey tests', () => {
     afterEach(() => cleanupSDK(sdkKey))
 
-    const configWithBucketingKey = (bucketingKey: string) => ({
-        ...config,
-        features: config.features.map((feature) => ({
-            ...feature,
-            configuration: {
-                ...feature.configuration,
-                targets: feature.configuration.targets.map((target) => ({
-                    ...target,
-                    bucketingKey,
-                })),
-            },
-        })),
-    })
-
     it('buckets a user with user_id if no bucketingKey', () => {
         const user = {
-            user_id: 'testwithfood@email.com',
+            user_id: 'test-id',
             customData: {
                 favouriteFood: 'pizza',
             },
             platformVersion: '1.1.2',
+            email: 'testwithfood@email.com',
         }
         const cWithBucketingKey = configWithBucketingKey('user_id')
         initSDK(sdkKey, cWithBucketingKey)
@@ -1665,8 +1653,9 @@ describe('bucketingKey tests', () => {
         initSDK(sdkKey, config)
         const c2 = generateBucketedConfig(user)
 
-        expect(c.featureVariationMap.feature5).toEqual(
-            c2.featureVariationMap.feature5,
+        expect(c.features.feature5).not.toBeFalsy()
+        expect(c.features.feature5.variationKey).toEqual(
+            c2.features.feature5.variationKey,
         )
     })
 
@@ -1705,11 +1694,11 @@ describe('bucketingKey tests', () => {
             differentUserSameFood,
         )
 
-        expect(c.featureVariationMap.feature5).not.toEqual(
-            cSameUserDifferentFood.featureVariationMap.feature5,
+        expect(c.features.feature5.variationKey).not.toEqual(
+            cSameUserDifferentFood.features.feature5.variationKey,
         )
-        expect(c.featureVariationMap.feature5).toEqual(
-            cDifferentUserSameFood.featureVariationMap.feature5,
+        expect(cSameUserDifferentFood.features.feature5.variationKey).toEqual(
+            cDifferentUserSameFood.features.feature5.variationKey,
         )
     })
 
@@ -1745,11 +1734,11 @@ describe('bucketingKey tests', () => {
             differentUserSameFood,
         )
 
-        expect(c.featureVariationMap.feature5).not.toEqual(
-            cSameUserDifferentFood.featureVariationMap.feature5,
+        expect(c.features.feature5.variationKey).not.toEqual(
+            cSameUserDifferentFood.features.feature5.variationKey,
         )
-        expect(c.featureVariationMap.feature5).toEqual(
-            cDifferentUserSameFood.featureVariationMap.feature5,
+        expect(cSameUserDifferentFood.features.feature5.variationKey).toEqual(
+            cDifferentUserSameFood.features.feature5.variationKey,
         )
     })
 
@@ -1783,11 +1772,11 @@ describe('bucketingKey tests', () => {
         const cDifferentUserSameNum =
             generateBucketedConfig(differentUserSameNum)
 
-        expect(c.featureVariationMap.feature5).not.toEqual(
-            cSameUserDifferentNum.featureVariationMap.feature5,
+        expect(c.features.feature5.variationKey).not.toEqual(
+            cSameUserDifferentNum.features.feature5.variationKey,
         )
-        expect(c.featureVariationMap.feature5).toEqual(
-            cDifferentUserSameNum.featureVariationMap.feature5,
+        expect(cSameUserDifferentNum.features.feature5.variationKey).toEqual(
+            cDifferentUserSameNum.features.feature5.variationKey,
         )
     })
 
@@ -1823,11 +1812,11 @@ describe('bucketingKey tests', () => {
             differentUserSameBool,
         )
 
-        expect(c.featureVariationMap.feature5).not.toEqual(
-            cSameUserDifferentBool.featureVariationMap.feature5,
+        expect(c.features.feature5.variationKey).not.toEqual(
+            cSameUserDifferentBool.features.feature5.variationKey,
         )
-        expect(c.featureVariationMap.feature5).toEqual(
-            cDifferentUserSameBool.featureVariationMap.feature5,
+        expect(cSameUserDifferentBool.features.feature5.variationKey).toEqual(
+            cDifferentUserSameBool.features.feature5.variationKey,
         )
     })
 })

--- a/lib/shared/bucketing-assembly-script/__tests__/helpers/configWithBucketingKey.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/helpers/configWithBucketingKey.ts
@@ -1,0 +1,17 @@
+import { config } from '@devcycle/bucketing-test-data/json-data/testData.json'
+
+export function configWithBucketingKey(bucketingKey: string): unknown {
+    return {
+        ...config,
+        features: config.features.map((feature) => ({
+            ...feature,
+            configuration: {
+                ...feature.configuration,
+                targets: feature.configuration.targets.map((target) => ({
+                    ...target,
+                    bucketingKey,
+                })),
+            },
+        })),
+    }
+}

--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/bucketing.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/bucketing.ts
@@ -1,31 +1,32 @@
 import { JSON } from '@devcycle/assemblyscript-json/assembly'
 import { first, last } from '../helpers/lodashHelpers'
 import {
-    ConfigBody,
-    Target as PublicTarget,
-    Feature as PublicFeature,
+    ConfigBodyV2 as ConfigBody,
+    TargetV2 as PublicTarget,
+    FeatureV2 as PublicFeature,
     BucketedUserConfig,
     Rollout as PublicRollout,
     DVCPopulatedUser,
     SDKVariable,
     SDKFeature,
     RolloutStage,
-    Target,
+    TargetV2 as Target,
     Variation,
     FeatureVariation,
-    Feature,
+    FeatureV2 as Feature,
 } from '../types'
 
 import { murmurhashV3 } from '../helpers/murmurhash'
 import { _evaluateOperator } from './segmentation'
 import {
-    getStringFromJSON,
     getStringFromJSONOptional,
+    getValueFromJSONOptional,
 } from '../helpers/jsonHelpers'
 
 // Max value of an unsigned 32-bit integer, which is what murmurhash returns
 const MAX_HASH_VALUE: f64 = 4294967295
 const baseSeed: i32 = 1
+const DEFAULT_BUCKETING_VALUE = 'null'
 
 export class BoundedHash {
     public rolloutHash: f64
@@ -144,7 +145,8 @@ function evaluateSegmentationForFeature(
         const passthroughRolloutEnabled = !config.project.settings.disablePassthroughRollouts
         let doesUserPassRollout = true
         if (target.rollout && passthroughRolloutEnabled) {
-            const boundedHashData = _generateBoundedHashes(user.user_id, target._id)
+            const bucketingValue = _getUserValueForBucketingKey(user, target)
+            const boundedHashData = _generateBoundedHashes(bucketingValue, target._id)
             const rolloutHash = boundedHashData.rolloutHash
             doesUserPassRollout = _doesUserPassRollout(target.rollout, rolloutHash)
         }
@@ -211,7 +213,8 @@ function doesUserQualifyForFeature(
     )
     if (!target) return null
 
-    const boundedHashData = _generateBoundedHashes(user.user_id, target._id)
+    const bucketingValue = _getUserValueForBucketingKey( user, target )
+    const boundedHashData = _generateBoundedHashes(bucketingValue, target._id)
     const rolloutHash = boundedHashData.rolloutHash
     const passthroughRolloutEnabled = !config.project.settings.disablePassthroughRollouts
     if (target.rollout && !passthroughRolloutEnabled && !_doesUserPassRollout(target.rollout, rolloutHash)) {
@@ -380,4 +383,30 @@ export function _generateBucketedVariableForUser(
         null,
     )
     return { variable: sdkVar, variation, feature: featureForVariable }
+}
+
+export function _getUserValueForBucketingKey(
+    user: DVCPopulatedUser,
+    target: PublicTarget
+): string {
+    if (target.bucketingKey && target.bucketingKey !== 'user_id') {
+        let bucketingValue: string = DEFAULT_BUCKETING_VALUE
+        const customData = user.getCombinedCustomData()
+        if (customData) {
+            const customDataValue = getValueFromJSONOptional(customData, target.bucketingKey)
+            bucketingValue = customDataValue
+                ? customDataValue.toString()
+                : DEFAULT_BUCKETING_VALUE
+        }
+        if (
+            typeof bucketingValue !== 'string' &&
+            typeof bucketingValue !== 'number' &&
+            typeof bucketingValue !== 'boolean'
+        ) {
+            return DEFAULT_BUCKETING_VALUE
+        } else {
+            return bucketingValue.toString()
+        }
+    }
+    return user.user_id
 }

--- a/lib/shared/bucketing-assembly-script/assembly/helpers/jsonHelpers.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/helpers/jsonHelpers.ts
@@ -29,6 +29,14 @@ export function getJSONArrayFromJSON(jsonObj: JSON.Obj, key: string): JSON.Arr {
     return obj
 }
 
+export function getValueFromJSONOptional(jsonObj: JSON.Obj, key: string): JSON.Value | null {
+    const value = jsonObj.get(key)
+    if (!value) {
+        return null
+    }
+    return value
+}
+
 export function getStringFromJSON(jsonObj: JSON.Obj, key: string): string {
     const str = jsonObj.getString(key)
     if (!str) {

--- a/lib/shared/bucketing-assembly-script/assembly/helpers/murmurhash.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/helpers/murmurhash.ts
@@ -14,7 +14,7 @@ const keyBuffer = new StaticArray<i32>(murmurhashBufferSize)
 export function murmurhashV3(key: string, seed: u32): u32 {
     let currentBuffer = keyBuffer
     if (key.length > keyBuffer.length) {
-        console.log("Warning: exceeded maximum size of murmurhash buffer.")
+        // console.log("Warning: exceeded maximum size of murmurhash buffer.")
         currentBuffer = new StaticArray<i32>(key.length)
     }
 

--- a/lib/shared/bucketing-assembly-script/assembly/index.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/index.ts
@@ -1,6 +1,6 @@
 import { JSON } from '@devcycle/assemblyscript-json/assembly'
 import {
-    ConfigBody,
+    ConfigBodyV2 as ConfigBody,
     DVCPopulatedUser,
     FeatureVariation,
     PlatformData,

--- a/lib/shared/bucketing-assembly-script/assembly/managers/configDataManager.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/managers/configDataManager.ts
@@ -1,4 +1,4 @@
-import { ConfigBody } from '../types'
+import { ConfigBodyV2 as ConfigBody } from '../types'
 
 const _configData: Map<string, ConfigBody> = new Map()
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/configBodyV2.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBodyV2.ts
@@ -8,8 +8,8 @@ import {
     getStringFromJSONOptional,
 } from '../helpers/jsonHelpers'
 import { FeatureV2 } from './featureV2'
-import { Audience } from './targetV2'
 import { PublicEnvironment, PublicProject, Variable} from './configBody'
+import { Audience } from './target'
 
 export class ConfigBodyV2 {
     readonly project: PublicProject

--- a/lib/shared/bucketing-assembly-script/assembly/types/featureV2.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/featureV2.ts
@@ -1,12 +1,13 @@
 import { JSON } from '@devcycle/assemblyscript-json/assembly'
 import {
     getJSONArrayFromJSON,
-    getJSONObjFromJSON, getJSONObjFromJSONOptional, getJSONValueFromJSON,
+    getJSONObjFromJSON, getJSONObjFromJSONOptional,
     getStringFromJSON,
     isValidString,
     jsonArrFromValueArray
 } from '../helpers/jsonHelpers'
 import { FeatureConfigurationV2 } from './featureConfigurationV2'
+import { Variation } from './feature'
 
 const validTypes = ['release', 'experiment', 'permission', 'ops']
 
@@ -59,66 +60,3 @@ export class FeatureV2 extends JSON.Value {
         return json.stringify()
     }
 }
-
-export class Variation extends JSON.Value {
-    readonly _id: string
-    readonly name: string
-    readonly key: string
-    readonly variables: Array<VariationVariable>
-
-    private readonly _variablesById: Map<string, VariationVariable>
-
-    constructor(variation: JSON.Obj) {
-        super()
-        this._id = getStringFromJSON(variation, '_id')
-
-        this.name = getStringFromJSON(variation, 'name')
-        this.key = getStringFromJSON(variation, 'key')
-
-        const variablesJSON = getJSONArrayFromJSON(variation, 'variables').valueOf()
-        const variables = new Array<VariationVariable>()
-        const variablesById = new Map<string, VariationVariable>()
-        for (let i = 0; i < variablesJSON.length; i++) {
-            const variable = new VariationVariable(variablesJSON[i] as JSON.Obj)
-            variables.push(variable)
-            variablesById.set(variable._var, variable)
-        }
-        this.variables = variables
-        this._variablesById = variablesById
-    }
-
-    getVariableById(variableId: string): VariationVariable | null {
-        return this._variablesById.has(variableId)
-            ? this._variablesById.get(variableId)
-            : null
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('_id', this._id)
-        json.set('name', this.name)
-        json.set('key', this.key)
-        json.set('variables', jsonArrFromValueArray(this.variables))
-
-        return json.stringify()
-    }
-}
-
-export class VariationVariable extends JSON.Value {
-    readonly _var: string
-    readonly value: JSON.Value
-
-    constructor(variable: JSON.Obj) {
-        super()
-        this._var = getStringFromJSON(variable, '_var')
-        this.value = getJSONValueFromJSON(variable, 'value')
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('_var', this._var)
-        json.set('value', this.value)
-        return json.stringify()
-    }
-}
-

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -43,6 +43,7 @@ export class Target extends JSON.Value {
                 value: distribution[i]._variation
             })
         }
+
         this._sortedDistribution = sortObjectsByString<TargetDistribution>(sortingArray, 'desc')
     }
 

--- a/lib/shared/bucketing-assembly-script/assembly/types/targetV2.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/targetV2.ts
@@ -1,24 +1,21 @@
 import { JSON } from '@devcycle/assemblyscript-json/assembly'
 import {
-    getDateFromJSON,
-    getF64FromJSONObj,
-    getF64FromJSONOptional,
     getJSONArrayFromJSON,
     getJSONObjFromJSON,
     getStringFromJSON,
     getStringFromJSONOptional,
     isValidString,
-    isValidStringOptional,
     jsonArrFromValueArray
 } from '../helpers/jsonHelpers'
 import { SortingArray, sortObjectsByString } from '../helpers/arrayHelpers'
+import { Audience, Rollout, TargetDistribution } from './target'
 
 export class TargetV2 extends JSON.Value {
     readonly _id: string
     readonly _audience: Audience
     readonly rollout: Rollout | null
     readonly distribution: TargetDistribution[]
-    readonly bucketingKey: string | null
+    readonly bucketingKey: string
     private readonly _sortedDistribution: TargetDistribution[]
 
     constructor(target: JSON.Obj) {
@@ -43,7 +40,12 @@ export class TargetV2 extends JSON.Value {
                 value: distribution[i]._variation
             })
         }
-        this.bucketingKey = getStringFromJSONOptional(target, 'bucketingKey')
+        const bucketingKey = getStringFromJSONOptional(target, 'bucketingKey')
+        if (bucketingKey) {
+            this.bucketingKey = bucketingKey
+        } else {
+            this.bucketingKey = 'user_id'
+        }
         this._sortedDistribution = sortObjectsByString<TargetDistribution>(sortingArray, 'desc')
     }
 
@@ -94,78 +96,6 @@ export class AudienceFilter extends JSON.Value {
         return json.stringify()
     }
 }
-// This is a virtual container class that's used by the code to determine whether a filter is a nested operator
-// or a base level filter. This is used to support the recursive nature of nested filters.
-// The config is returned to its original form when stringified.
-export class AudienceFilterOrOperator extends JSON.Value {
-    readonly operatorClass: AudienceOperator | null
-    readonly filterClass: AudienceFilter | null
-
-    constructor(filter: JSON.Obj) {
-        super()
-        const operator = isValidStringOptional(filter, 'operator', validAudienceOperators, false)
-        this.operatorClass = operator ? new AudienceOperator(filter) : null
-        this.filterClass = operator ? null : initializeFilterClass(filter)
-    }
-
-    stringify(): string {
-        if (this.operatorClass !== null) {
-            return (this.operatorClass as AudienceOperator).stringify()
-        }
-        if (this.filterClass !== null) {
-            return (this.filterClass as AudienceFilter).stringify()
-        }
-        return ''
-    }
-}
-
-export class AudienceOperator extends JSON.Value {
-    readonly operator: string
-    readonly filters: AudienceFilterOrOperator[]
-
-    constructor(filter: JSON.Obj) {
-        super()
-
-        this.operator = isValidString(filter, 'operator', validAudienceOperators, false)
-
-        const filters = getJSONArrayFromJSON(filter, 'filters')
-        // Initialize AudienceFilterOrOperator
-        this.filters = []
-        for (let i = 0; i < filters.valueOf().length; i ++) {
-            this.filters.push(new AudienceFilterOrOperator(filters.valueOf()[i] as JSON.Obj))
-        }
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        if (this.operator) {
-            json.set('operator', this.operator)
-        }
-        if (this.filters) {
-            json.set('filters', jsonArrFromValueArray(this.filters as AudienceFilterOrOperator[]))
-        }
-
-        return json.stringify()
-    }
-}
-
-export class Audience extends JSON.Value {
-    readonly filters: AudienceOperator
-
-    constructor(audience: JSON.Obj) {
-        super()
-
-        this.filters = new AudienceOperator(getJSONObjFromJSON(audience, 'filters'))
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('filters', this.filters)
-        return json.stringify()
-    }
-}
-
-const validAudienceOperators = ['and', 'or']
 
 const validTypes = ['all', 'user', 'optIn', 'audienceMatch']
 
@@ -355,95 +285,6 @@ export class CustomDataFilter extends UserFilter {
         if (this.values) {
             json.set('values', this.values)
         }
-        return json.stringify()
-    }
-}
-
-function initializeFilterClass(filter: JSON.Obj): AudienceFilter {
-    if (getStringFromJSONOptional(filter, 'type') === 'user') {
-        if (getStringFromJSONOptional(filter, 'subType') === 'customData') {
-            return new CustomDataFilter(filter)
-        }
-        return new UserFilter(filter)
-    } else if (getStringFromJSONOptional(filter, 'type') === 'audienceMatch'){
-        return new AudienceMatchFilter(filter)
-    } else {
-        return new AudienceFilter(filter)
-    }
-}
-
-const validRolloutTypes = ['schedule', 'gradual', 'stepped']
-
-export class Rollout extends JSON.Value {
-    readonly type: string
-    readonly startPercentage: f64
-    readonly startDate: Date
-    readonly stages: RolloutStage[] | null
-
-    constructor(rollout: JSON.Obj) {
-        super()
-        this.type = isValidString(rollout, 'type', validRolloutTypes)
-
-        this.startPercentage = getF64FromJSONOptional(rollout, 'startPercentage', f64(1))
-
-        this.startDate = getDateFromJSON(rollout, 'startDate')
-
-        const stages = rollout.getArr('stages')
-        this.stages = stages ?
-            stages.valueOf().map<RolloutStage>((stage) => {
-                return new RolloutStage(stage as JSON.Obj)
-            }) : null
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('type', this.type)
-        json.set('startPercentage', this.startPercentage)
-        json.set('startDate', this.startDate.toISOString())
-        if (this.stages) {
-            json.set('stages', jsonArrFromValueArray(this.stages as RolloutStage[]))
-        }
-        return json.stringify()
-    }
-}
-
-const validRolloutStages = ['linear', 'discrete']
-
-export class RolloutStage extends JSON.Value {
-    readonly type: string
-    readonly date: Date
-    readonly percentage: f64
-
-    constructor(stage: JSON.Obj) {
-        super()
-        this.type = isValidString(stage, 'type', validRolloutStages)
-        this.date = getDateFromJSON(stage, 'date')
-        this.percentage = getF64FromJSONObj(stage, 'percentage')
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('type', this.type)
-        json.set('date', this.date.toISOString())
-        json.set('percentage', this.percentage)
-        return json.stringify()
-    }
-}
-
-export class TargetDistribution extends JSON.Value {
-    readonly _variation: string
-    readonly percentage: f64
-
-    constructor(distribution: JSON.Obj) {
-        super()
-        this._variation = getStringFromJSON(distribution, '_variation')
-        this.percentage = getF64FromJSONObj(distribution, 'percentage')
-    }
-
-    stringify(): string {
-        const json = new JSON.Obj()
-        json.set('_variation', this._variation)
-        json.set('percentage', this.percentage)
         return json.stringify()
     }
 }


### PR DESCRIPTION
# Changes

- added tests for bucketing key 
- used bucketing key if it exists instead of user_id

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
