### PR TITLE
chore: use v2 configs in nodejs

### DIFF
--- a/lib/shared/config-manager/__tests__/environmentConfigManager.spec.ts
+++ b/lib/shared/config-manager/__tests__/environmentConfigManager.spec.ts
@@ -170,7 +170,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
             }),
         )
         expect(trackSDKConfigEvent_mock).toBeCalledWith(
-            'https://config-cdn.devcycle.com/config/v1/server/sdkKey.json',
+            'https://config-cdn.devcycle.com/config/v2/server/sdkKey.json',
             expect.any(Number),
             expect.objectContaining({ resStatus: 200 }),
             undefined,
@@ -192,7 +192,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
             'Failed to download DevCycle config.',
         )
         expect(trackSDKConfigEvent_mock).toBeCalledWith(
-            'https://config-cdn.devcycle.com/config/v1/server/sdkKey.json',
+            'https://config-cdn.devcycle.com/config/v2/server/sdkKey.json',
             expect.any(Number),
             undefined,
             expect.objectContaining({

--- a/lib/shared/config-manager/src/CDNConfigSource.ts
+++ b/lib/shared/config-manager/src/CDNConfigSource.ts
@@ -90,8 +90,8 @@ export class CDNConfigSource extends ConfigSource {
 
     getConfigURL(sdkKey: string, kind: 'server' | 'bootstrap'): string {
         if (kind === 'bootstrap') {
-            return `${this.cdnURI}/config/v1/server/bootstrap/${sdkKey}.json`
+            return `${this.cdnURI}/config/v2/server/bootstrap/${sdkKey}.json`
         }
-        return `${this.cdnURI}/config/v1/server/${sdkKey}.json`
+        return `${this.cdnURI}/config/v2/server/${sdkKey}.json`
     }
 }


### PR DESCRIPTION
# Changes

- use v2 configs in nodejs

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
