### PR TITLE
feat: add custom property generic to SDKs

### DIFF
--- a/sdk/js/__tests__/Client.test.ts
+++ b/sdk/js/__tests__/Client.test.ts
@@ -1,13 +1,16 @@
-global.fetch = jest.fn()
+global.fetch = jest.fn().mockResolvedValue({
+    json: jest.fn().mockResolvedValue({ features: {}, variables: {} }),
+})
+
 type Variables = {
     enum_var: 'value1' | 'value2'
     bool: boolean
     string: string
     number: number
 }
-jest.mock('fetch-retry')
 import { DevCycleClient } from '../src/Client'
 jest.mock('../src/StreamingConnection')
+
 describe('DevCycleClient', () => {
     it('should prevent invalid variables', () => {
         const client = new DevCycleClient<Variables>('test', {

--- a/sdk/js/__tests__/Client.test.ts
+++ b/sdk/js/__tests__/Client.test.ts
@@ -32,4 +32,65 @@ describe('DevCycleClient', () => {
         client.variable('string', 'test')
         client.variable('number', 1)
     })
+    it('should enforce CustomData type checking', () => {
+        type MyCustomData = {
+            favoriteColor: string
+            age: number
+        }
+
+        // Correct initialization
+        const client = new DevCycleClient<Variables, MyCustomData>('test', {
+            user_id: 'test',
+            customData: {
+                favoriteColor: 'blue',
+                age: 30,
+            },
+        })
+
+        new DevCycleClient<Variables, MyCustomData>('test', {
+            user_id: 'test',
+            customData: {
+                favoriteColor: 'blue',
+                // @ts-expect-error - should not allow invalid custom data types
+                age: '30', // Should be a number
+            },
+        })
+
+        new DevCycleClient<Variables, MyCustomData>('test', {
+            user_id: 'test',
+            // @ts-expect-error - should not allow missing custom data fields
+            customData: {
+                favoriteColor: 'blue',
+                // Missing 'age' field
+            },
+        })
+
+        // Test identify method
+        client.identifyUser({
+            user_id: 'newUser',
+            customData: {
+                favoriteColor: 'red',
+                age: 25,
+            },
+        })
+
+        client.identifyUser({
+            user_id: 'newUser',
+            customData: {
+                favoriteColor: 'red',
+                // @ts-expect-error - should not allow invalid custom data in identify
+                age: '25', // Should be a number
+            },
+        })
+
+        client.identifyUser({
+            user_id: 'newUser',
+            customData: {
+                favoriteColor: 'red',
+                age: 25,
+                // @ts-expect-error - should not allow extra fields in custom data
+                extraField: true, // Extra field not in MyCustomData
+            },
+        })
+    })
 })

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -54,7 +54,7 @@ export const isDeferredOptions = (
 
 export class DevCycleClient<
     Variables extends VariableDefinitions = VariableDefinitions,
-    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
 > {
     logger: DVCLogger
     config?: BucketedUserConfig
@@ -97,7 +97,11 @@ export class DevCycleClient<
         user: undefined,
         options: DevCycleOptionsWithDeferredInitialization,
     )
-    constructor(sdkKey: string, user: DevCycleUser<CustomData>, options?: DevCycleOptions)
+    constructor(
+        sdkKey: string,
+        user: DevCycleUser<CustomData>,
+        options?: DevCycleOptions,
+    )
     constructor(
         sdkKey: string,
         user: DevCycleUser<CustomData> | undefined,
@@ -173,7 +177,9 @@ export class DevCycleClient<
      * first identified (in deferred mode)
      * @param initialUser
      */
-    private clientInitialization = async (initialUser: DevCycleUser<CustomData>) => {
+    private clientInitialization = async (
+        initialUser: DevCycleUser<CustomData>,
+    ) => {
         if (this.initializeTriggered || this._closing) {
             return this
         }
@@ -423,7 +429,9 @@ export class DevCycleClient<
         return promise
     }
 
-    private async _identifyUser(user: DevCycleUser<CustomData>): Promise<DVCVariableSet> {
+    private async _identifyUser(
+        user: DevCycleUser<CustomData>,
+    ): Promise<DVCVariableSet> {
         let updatedUser: DVCPopulatedUser
 
         if (this.options.deferInitialization && !this.initializeTriggered) {

--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -1,5 +1,10 @@
 import { DevCycleClient } from './Client'
-import { DevCycleEvent, DevCycleOptions, VariableDefinitions, DVCCustomDataJSON } from './types'
+import {
+    DevCycleEvent,
+    DevCycleOptions,
+    VariableDefinitions,
+    DVCCustomDataJSON,
+} from './types'
 import { publishEvents } from './Request'
 import { checkParamDefined } from './utils'
 import chunk from 'lodash/chunk'
@@ -15,7 +20,7 @@ type AggregateEvent = DevCycleEvent & {
 
 export class EventQueue<
     Variables extends VariableDefinitions = VariableDefinitions,
-    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
 > {
     private readonly sdkKey: string
     private readonly options: DevCycleOptions

--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -1,5 +1,5 @@
 import { DevCycleClient } from './Client'
-import { DevCycleEvent, DevCycleOptions } from './types'
+import { DevCycleEvent, DevCycleOptions, VariableDefinitions, DVCCustomDataJSON } from './types'
 import { publishEvents } from './Request'
 import { checkParamDefined } from './utils'
 import chunk from 'lodash/chunk'
@@ -13,10 +13,13 @@ type AggregateEvent = DevCycleEvent & {
     target: string
 }
 
-export class EventQueue {
+export class EventQueue<
+    Variables extends VariableDefinitions = VariableDefinitions,
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON
+> {
     private readonly sdkKey: string
     private readonly options: DevCycleOptions
-    private readonly client: DevCycleClient
+    private readonly client: DevCycleClient<Variables, CustomData>
     private eventQueue: DevCycleEvent[]
     private aggregateEventMap: Record<string, Record<string, AggregateEvent>>
     private flushInterval: ReturnType<typeof setInterval>
@@ -26,7 +29,7 @@ export class EventQueue {
 
     constructor(
         sdkKey: string,
-        dvcClient: DevCycleClient,
+        dvcClient: DevCycleClient<Variables, CustomData>,
         options: DevCycleOptions,
     ) {
         this.sdkKey = sdkKey

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -135,7 +135,7 @@ export interface DevCycleOptions {
     sdkPlatform?: string
 }
 
-export interface DevCycleUser {
+export interface DevCycleUser<T extends DVCCustomDataJSON = DVCCustomDataJSON> {
     /**
      * If a user is anonymous a unique anonymous user id will be generated and stored in the cache.
      * If no user_id is provided, the user is assumed to be anonymous.
@@ -183,14 +183,14 @@ export interface DevCycleUser {
      * Custom JSON data used for audience segmentation, must be limited to __kb in size.
      * Values will be logged to DevCycle's servers and available in the dashboard to view.
      */
-    customData?: DVCCustomDataJSON
+    customData?: T
 
     /**
      * Private Custom JSON data used for audience segmentation, must be limited to __kb in size.
      * Values will not be logged to DevCycle's servers and
      * will not be available in the dashboard.
      */
-    privateCustomData?: DVCCustomDataJSON
+    privateCustomData?: T
 }
 
 export interface VariableDefinitions {

--- a/sdk/nextjs/index.ts
+++ b/sdk/nextjs/index.ts
@@ -15,6 +15,7 @@ export {
     DVCVariable,
     DVCVariableValue,
     DevCycleJSON,
+    DVCCustomDataJSON,
 } from '@devcycle/react-client-sdk'
 
 type DevCycleClient = Omit<JSClient, 'identifyUser' | 'resetUser'>

--- a/sdk/nextjs/src/server/setupDevCycle.tsx
+++ b/sdk/nextjs/src/server/setupDevCycle.tsx
@@ -8,16 +8,16 @@ import { getAllFeatures } from './allFeatures'
 import { DevCycleNextOptions } from '../common/types'
 
 // server-side users must always be "identified" with a user id
-type ServerUser<CustomData extends DVCCustomDataJSON = DVCCustomDataJSON> = Omit<
-    DevCycleUser<CustomData>,
-    'user_id' | 'isAnonymous'
-> & {
-    user_id: string
-}
+type ServerUser<CustomData extends DVCCustomDataJSON = DVCCustomDataJSON> =
+    Omit<DevCycleUser<CustomData>, 'user_id' | 'isAnonymous'> & {
+        user_id: string
+    }
 
 // allow return type inference
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const setupDevCycle = <CustomData extends DVCCustomDataJSON = DVCCustomDataJSON>({
+export const setupDevCycle = <
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
+>({
     serverSDKKey,
     clientSDKKey,
     userGetter,

--- a/sdk/nextjs/src/server/setupDevCycle.tsx
+++ b/sdk/nextjs/src/server/setupDevCycle.tsx
@@ -1,20 +1,23 @@
 import 'server-only'
 import { getVariableValue } from './getVariableValue'
 import { initialize, validateSDKKey } from './initialize'
-import { DevCycleUser } from '@devcycle/js-client-sdk'
+import { DevCycleUser, DVCCustomDataJSON } from '@devcycle/js-client-sdk'
 import { getUserAgent } from './userAgent'
 import { getAllVariables } from './getAllVariables'
 import { getAllFeatures } from './allFeatures'
 import { DevCycleNextOptions } from '../common/types'
 
 // server-side users must always be "identified" with a user id
-type ServerUser = Omit<DevCycleUser, 'user_id' | 'isAnonymous'> & {
+type ServerUser<CustomData extends DVCCustomDataJSON = DVCCustomDataJSON> = Omit<
+    DevCycleUser<CustomData>,
+    'user_id' | 'isAnonymous'
+> & {
     user_id: string
 }
 
 // allow return type inference
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const setupDevCycle = ({
+export const setupDevCycle = <CustomData extends DVCCustomDataJSON = DVCCustomDataJSON>({
     serverSDKKey,
     clientSDKKey,
     userGetter,
@@ -22,7 +25,7 @@ export const setupDevCycle = ({
 }: {
     serverSDKKey: string
     clientSDKKey: string
-    userGetter: () => Promise<ServerUser> | ServerUser
+    userGetter: () => Promise<ServerUser<CustomData>> | ServerUser<CustomData>
     options?: DevCycleNextOptions
 }) => {
     validateSDKKey(serverSDKKey, 'server')

--- a/sdk/react/src/index.ts
+++ b/sdk/react/src/index.ts
@@ -16,6 +16,7 @@ export type {
     DVCUser,
     DVCVariableValue,
     DVCVariable,
+    DVCCustomDataJSON,
     DevCycleJSON,
     DevCycleEvent,
     DevCycleOptions,

--- a/sdk/react/src/types.ts
+++ b/sdk/react/src/types.ts
@@ -1,4 +1,8 @@
-import type { DevCycleOptions, DevCycleUser } from '@devcycle/js-client-sdk'
+import type {
+    DevCycleOptions,
+    DevCycleUser,
+    DVCCustomDataJSON,
+} from '@devcycle/js-client-sdk'
 
 type WithSDKKey = {
     sdkKey: string
@@ -22,7 +26,9 @@ type OptionsWithDebug = DevCycleOptions & {
     }
 }
 
-export type ProviderConfig = (WithSDKKey | WithEnvironmentKey) & {
-    user?: DevCycleUser
+export type ProviderConfig<
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
+> = (WithSDKKey | WithEnvironmentKey) & {
+    user?: DevCycleUser<CustomData>
     options?: OptionsWithDebug
 }

--- a/sdk/react/src/useDevCycleClient.ts
+++ b/sdk/react/src/useDevCycleClient.ts
@@ -1,10 +1,15 @@
 import { useContext } from 'react'
 import context from './context'
-import { DevCycleClient, VariableDefinitions } from '@devcycle/js-client-sdk'
+import {
+    DevCycleClient,
+    VariableDefinitions,
+    DVCCustomDataJSON,
+} from '@devcycle/js-client-sdk'
 
 export const useDevCycleClient = <
     Variables extends VariableDefinitions = VariableDefinitions,
->(): DevCycleClient<Variables> => {
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
+>(): DevCycleClient<Variables, CustomData> => {
     const dvcContext = useContext(context)
 
     if (dvcContext === undefined)
@@ -12,7 +17,8 @@ export const useDevCycleClient = <
             'useDevCycleClient must be used within DevCycleProvider',
         )
 
-    return dvcContext.client
+    // enforce the variable and custom data types provided by the user. These are for type-checking only.
+    return dvcContext.client as unknown as DevCycleClient<Variables, CustomData>
 }
 
 /**

--- a/sdk/react/src/withDevCycleProvider.tsx
+++ b/sdk/react/src/withDevCycleProvider.tsx
@@ -9,7 +9,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { DevCycleProvider } from './DevCycleProvider'
 import { DVCCustomDataJSON } from '@devcycle/js-client-sdk'
 
-export function withDevCycleProvider<CustomData extends DVCCustomDataJSON>(
+export function withDevCycleProvider<CustomData extends DVCCustomDataJSON = DVCCustomDataJSON>(
     config: ProviderConfig<CustomData>,
 ) {
     return function <T extends object>(

--- a/sdk/react/src/withDevCycleProvider.tsx
+++ b/sdk/react/src/withDevCycleProvider.tsx
@@ -9,15 +9,12 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { DevCycleProvider } from './DevCycleProvider'
 import { DVCCustomDataJSON } from '@devcycle/js-client-sdk'
 
-export const withDevCycleProvider =
-    <T extends object, CustomData extends DVCCustomDataJSON = DVCCustomDataJSON>(
-        config: ProviderConfig<CustomData>,
-    ) =>
-    (
+export function withDevCycleProvider<CustomData extends DVCCustomDataJSON>(
+    config: ProviderConfig<CustomData>,
+) {
+    return function <T extends object>(
         WrappedComponent: React.ComponentType<T>,
-    ): ForwardRefExoticComponent<
-        PropsWithoutRef<T> & RefAttributes<unknown>
-    > => {
+    ): ForwardRefExoticComponent<PropsWithoutRef<T> & RefAttributes<unknown>> {
         const HoistedComponent = forwardRef((props: T, ref) => {
             return (
                 <DevCycleProvider config={config}>
@@ -30,6 +27,7 @@ export const withDevCycleProvider =
 
         return HoistedComponent
     }
+}
 
 /**
  * @deprecated Use withDevCycleProvider instead

--- a/sdk/react/src/withDevCycleProvider.tsx
+++ b/sdk/react/src/withDevCycleProvider.tsx
@@ -7,9 +7,12 @@ import React, {
 } from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { DevCycleProvider } from './DevCycleProvider'
+import { DVCCustomDataJSON } from '@devcycle/js-client-sdk'
 
 export const withDevCycleProvider =
-    <T extends object>(config: ProviderConfig) =>
+    <T extends object, CustomData extends DVCCustomDataJSON = DVCCustomDataJSON>(
+        config: ProviderConfig<CustomData>,
+    ) =>
     (
         WrappedComponent: React.ComponentType<T>,
     ): ForwardRefExoticComponent<

--- a/sdk/react/src/withDevCycleProvider.tsx
+++ b/sdk/react/src/withDevCycleProvider.tsx
@@ -9,9 +9,9 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { DevCycleProvider } from './DevCycleProvider'
 import { DVCCustomDataJSON } from '@devcycle/js-client-sdk'
 
-export function withDevCycleProvider<CustomData extends DVCCustomDataJSON = DVCCustomDataJSON>(
-    config: ProviderConfig<CustomData>,
-) {
+export function withDevCycleProvider<
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
+>(config: ProviderConfig<CustomData>) {
     return function <T extends object>(
         WrappedComponent: React.ComponentType<T>,
     ): ForwardRefExoticComponent<PropsWithoutRef<T> & RefAttributes<unknown>> {


### PR DESCRIPTION
- add a generic type arg for specifying the type of the user's custom data
- enforce via types that the custom data is set correctly in the user interfaces of the JS, React and Next SDKs