### PR TITLE
fix: debounce iframe updates and limit size of stored events

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,9 +35,9 @@
             "@devcycle/js-cloud-server-sdk": [
                 "sdk/js-cloud-server/src/index.ts"
             ],
-            "@devcycle/nextjs-sdk": ["sdk/nextjs/src/index.ts"],
-            "@devcycle/nextjs-sdk/pages": ["sdk/nextjs/src/pages.ts"],
-            "@devcycle/nextjs-sdk/server": ["sdk/nextjs/src/server.ts"],
+            "@devcycle/nextjs-sdk": ["sdk/nextjs/index.ts"],
+            "@devcycle/nextjs-sdk/pages": ["sdk/nextjs/pages.ts"],
+            "@devcycle/nextjs-sdk/server": ["sdk/nextjs/server.ts"],
             "@devcycle/nodejs-server-sdk": ["sdk/nodejs/src/index.ts"],
             "@devcycle/nodejs-server-sdk/openfeature-strategy": [
                 "sdk/nodejs/openfeature-strategy.ts"


### PR DESCRIPTION
- limit number of live events stored by debugger
- debounce updateIframeData function so that it doesn't trigger once for each evaluation in a scenario where lots of variables are being evaluated.