### PR TITLE
fix: disable next events serverside in the ClientSide provider

### DIFF
--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -156,7 +156,6 @@ export class EventQueue<
             )
             return
         }
-        console.log('queueEvent', event)
         this.eventQueue.push(event)
     }
 
@@ -171,7 +170,6 @@ export class EventQueue<
             )
             return
         }
-        console.log('queueAggregateEvent', event)
 
         checkParamDefined('type', event.type)
         checkParamDefined('target', event.target)

--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -156,6 +156,7 @@ export class EventQueue<
             )
             return
         }
+        console.log('queueEvent', event)
         this.eventQueue.push(event)
     }
 
@@ -170,6 +171,7 @@ export class EventQueue<
             )
             return
         }
+        console.log('queueAggregateEvent', event)
 
         checkParamDefined('type', event.type)
         checkParamDefined('target', event.target)

--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -48,8 +48,8 @@ export const SuspendedProviderInitialization = ({
         // change user and config data to match latest server data
         // if the data has changed since the last invocation
         // assert this is a DevCycleClient, not a DevCycleNextClient, because it is. We expose a more limited type
-        // to the end user 
-        (context.client as DevCycleClient).synchronizeBootstrapData(
+        // to the end user
+        ;(context.client as DevCycleClient).synchronizeBootstrapData(
             serverData.config,
             serverData.user,
             userAgent,

--- a/sdk/nextjs/src/client/internal/context.ts
+++ b/sdk/nextjs/src/client/internal/context.ts
@@ -1,9 +1,24 @@
 'use client'
-import { DevCycleClient } from '@devcycle/js-client-sdk'
+import {
+    DevCycleClient,
+    DVCCustomDataJSON,
+    VariableDefinitions,
+} from '@devcycle/js-client-sdk'
 import React from 'react'
 
+export type DevCycleNextClient<
+    Variables extends VariableDefinitions = VariableDefinitions,
+    CustomData extends DVCCustomDataJSON = DVCCustomDataJSON,
+> = Omit<
+    DevCycleClient<Variables, CustomData>,
+    | 'onClientInitialized'
+    | 'identifyUser'
+    | 'resetUser'
+    | 'synchronizeBootstrapData'
+>
+
 type ClientProviderContext = {
-    client: DevCycleClient
+    client: DevCycleNextClient
     clientSDKKey: string
     enableStreaming: boolean
     serverDataPromise: Promise<unknown>

--- a/sdk/nextjs/src/client/internal/useDevCycleClient.ts
+++ b/sdk/nextjs/src/client/internal/useDevCycleClient.ts
@@ -1,7 +1,6 @@
 import { useContext } from 'react'
-import { DevCycleProviderContext } from './context'
-import { DevCycleClient } from '@devcycle/js-client-sdk'
+import { DevCycleNextClient, DevCycleProviderContext } from './context'
 
-export const useDevCycleClient = (): DevCycleClient => {
+export const useDevCycleClient = (): DevCycleNextClient => {
     return useContext(DevCycleProviderContext).client
 }

--- a/sdk/nextjs/src/client/useDevCycleClient.ts
+++ b/sdk/nextjs/src/client/useDevCycleClient.ts
@@ -1,6 +1,6 @@
+import { DevCycleNextClient } from './internal/context'
 import { useDevCycleClient as internalUseClient } from './internal/useDevCycleClient'
-import { DevCycleClient } from '@devcycle/js-client-sdk'
 
-export const useDevCycleClient = (): DevCycleClient => {
+export const useDevCycleClient = (): DevCycleNextClient => {
     return internalUseClient()
 }


### PR DESCRIPTION
- disable events in the JS client instantiated in the ClientsideProvider for Nextjs while running on the server
- don't create an event queue in the JS client when events are disabled