### PR TITLE
fix: caching of user and bucketed config

### DIFF
--- a/sdk/nextjs/src/server/bucketing.ts
+++ b/sdk/nextjs/src/server/bucketing.ts
@@ -8,6 +8,16 @@ import {
 } from '../common/types'
 import { BucketedUserConfig, ConfigBody, ConfigSource } from '@devcycle/types'
 
+const getPopulatedUser = cache((user: DevCycleUser, userAgent?: string) => {
+    return new DVCPopulatedUser(
+        user,
+        {},
+        undefined,
+        undefined,
+        userAgent ?? undefined,
+    )
+})
+
 // wrap this function in react cache to avoid redoing work for the same user and config
 const generateBucketedConfigCached = cache(
     async (
@@ -16,13 +26,7 @@ const generateBucketedConfigCached = cache(
         config: ConfigBody,
         userAgent?: string,
     ) => {
-        const populatedUser = new DVCPopulatedUser(
-            user,
-            {},
-            undefined,
-            undefined,
-            userAgent ?? undefined,
-        )
+        const populatedUser = getPopulatedUser(user, userAgent)
 
         // clientSDKKey is always defined for bootstrap config
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -33,12 +37,10 @@ const generateBucketedConfigCached = cache(
                 obfuscated,
                 populatedUser,
             )
-            const response =
-                (await bucketedConfigResponse.json()) as BucketedUserConfig
 
             return {
                 bucketedConfig: {
-                    ...response,
+                    ...bucketedConfigResponse,
                     clientSDKKey,
                 },
             }


### PR DESCRIPTION
- wrap the construction of the DVCPopulatedUser in a per-request cache so that it doesn't recreate from scratch on each call to `useVariableValue`
- this also makes sure we're using the same timestamps for the user across the request
- caching this means that caching the bucketed config result now works as intended
- wrap the call to the SDK API in a cache as well, because the fetch call is being treated as "not cacheable" by Next for some reason
