### PR TITLE
fix: use a useEffect for suspended data synchronization

### DIFF
--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -1,5 +1,12 @@
 'use client'
-import React, { Suspense, use, useContext, useRef, useState } from 'react'
+import React, {
+    Suspense,
+    use,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from 'react'
 import { DevCycleClient, initializeDevCycle } from '@devcycle/js-client-sdk'
 import { invalidateConfig } from '../../common/invalidateConfig'
 import { DevCycleNextOptions, DevCycleServerData } from '../../common/types'
@@ -38,18 +45,20 @@ export const SuspendedProviderInitialization = ({
         DevCycleServerData | undefined
     >()
     const context = useContext(DevCycleProviderContext)
-    if (previousContext !== serverData) {
-        // change user and config data to match latest server data
-        // if the data has changed since the last invocation
-        // assert this is a DevCycleClient, not a DevCycleNextClient, because it is. We expose a more limited type
-        // to the end user
-        ;(context.client as DevCycleClient).synchronizeBootstrapData(
-            serverData.config,
-            serverData.user,
-            serverData.userAgent,
-        )
-        setPreviousContext(serverData)
-    }
+    useEffect(() => {
+        if (previousContext !== serverData) {
+            // change user and config data to match latest server data
+            // if the data has changed since the last invocation
+            // assert this is a DevCycleClient, not a DevCycleNextClient, because it is. We expose a more limited type
+            // to the end user
+            ;(context.client as DevCycleClient).synchronizeBootstrapData(
+                serverData.config,
+                serverData.user,
+                serverData.userAgent,
+            )
+            setPreviousContext(serverData)
+        }
+    }, [serverData, context, previousContext])
     return null
 }
 

--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -2,6 +2,7 @@
 import React, {
     Suspense,
     use,
+    useCallback,
     useContext,
     useEffect,
     useRef,
@@ -45,20 +46,31 @@ export const SuspendedProviderInitialization = ({
         DevCycleServerData | undefined
     >()
     const context = useContext(DevCycleProviderContext)
+
+    const synchronizeData = useCallback(() => {
+        ;(context.client as DevCycleClient).synchronizeBootstrapData(
+            serverData.config,
+            serverData.user,
+            serverData.userAgent,
+        )
+    }, [context.client, serverData])
+
+    if (!previousContext) {
+        synchronizeData()
+    }
+
     useEffect(() => {
         if (previousContext !== serverData) {
             // change user and config data to match latest server data
             // if the data has changed since the last invocation
             // assert this is a DevCycleClient, not a DevCycleNextClient, because it is. We expose a more limited type
             // to the end user
-            ;(context.client as DevCycleClient).synchronizeBootstrapData(
-                serverData.config,
-                serverData.user,
-                serverData.userAgent,
-            )
+            if (previousContext) {
+                synchronizeData()
+            }
             setPreviousContext(serverData)
         }
-    }, [serverData, context.client, previousContext])
+    }, [synchronizeData, serverData, previousContext])
     return null
 }
 

--- a/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
+++ b/sdk/nextjs/src/client/internal/InternalDevCycleClientsideProvider.tsx
@@ -58,7 +58,7 @@ export const SuspendedProviderInitialization = ({
             )
             setPreviousContext(serverData)
         }
-    }, [serverData, context, previousContext])
+    }, [serverData, context.client, previousContext])
     return null
 }
 


### PR DESCRIPTION
- switch to using a useEffect for suspended data synchronization in the Next SDK
- calling any kind of setState during a render will always lead to errors in React, it should only be done in effects or event handlers