### PR TITLE
feat: update the error on getVariable to not log on default variable

### DIFF
--- a/sdk/js-cloud-server/src/cloudClient.ts
+++ b/sdk/js-cloud-server/src/cloudClient.ts
@@ -144,11 +144,13 @@ export class DevCycleCloudClient<
             })
         } catch (err) {
             throwIfUserError(err)
-            this.logger.error(
-                `Request to get variable: ${key} failed with response message: ${
-                    (err as any).message
-                }`,
-            )
+            if (err instanceof ResponseError && err.status !== 404) {
+                this.logger.error(
+                    `Request to get variable: ${key} failed with response message: ${
+                        (err as any).message
+                    }`,
+                )
+            }
             // Default Variable
             return new DVCVariable({ key, type, defaultValue })
         }


### PR DESCRIPTION
- there is logic in the cloud sdk for throwing if its not a 404 from bucketing api, we should not be loggin error here as well since we send a defaulted variable anyways