### PR TITLE
fix: remove leftover console.log from invalidateConfig

### DIFF
--- a/sdk/nextjs/src/common/invalidateConfig.ts
+++ b/sdk/nextjs/src/common/invalidateConfig.ts
@@ -12,7 +12,6 @@ export const invalidateConfig = async (
         )
         return
     }
-    console.log('Invalidating old DevCycle cached config')
     revalidateTag(sdkToken)
     if (userId) {
         revalidateTag(userId)


### PR DESCRIPTION
- fix: cleanup debugging `console.log` from NextJS `invalidateConfig` method
- addresses: https://github.com/DevCycleHQ/js-sdks/issues/993