### PR TITLE
fix: OpenFeature peer dependancy

### DIFF
--- a/dev-apps/openfeature-nodejs/src/main.ts
+++ b/dev-apps/openfeature-nodejs/src/main.ts
@@ -53,6 +53,14 @@ async function startDevCycle() {
         true,
     )
     console.log(`Value of the variable is ${defaultVariable} \n`)
+
+    openFeatureClient.track('of-test-event', context, {
+        value: 610,
+        metaDataField: 1,
+        metaDataFieldString: 'test',
+        metaDataFieldBoolean: true,
+        metaDataFieldDouble: 1.23,
+    })
 }
 
 startDevCycle()

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -29,7 +29,7 @@
     },
     "peerDependencies": {
         "@openfeature/multi-provider": "^0.1.1",
-        "@openfeature/server-sdk": "^1.13.5"
+        "@openfeature/server-sdk": "^1.16.2"
     },
     "peerDependenciesMeta": {
         "@openfeature/multi-provider": {

--- a/sdk/openfeature-web-provider/package.json
+++ b/sdk/openfeature-web-provider/package.json
@@ -23,7 +23,7 @@
     },
     "peerDependencies": {
         "@openfeature/multi-provider-web": "^0.0.2",
-        "@openfeature/web-sdk": "^1.0.3"
+        "@openfeature/web-sdk": "^1.3.2"
     },
     "peerDependenciesMeta": {
         "@openfeature/multi-provider-web": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,7 +4737,7 @@ __metadata:
     fetch-retry: ^5.0.6
   peerDependencies:
     "@openfeature/multi-provider": ^0.1.1
-    "@openfeature/server-sdk": ^1.13.5
+    "@openfeature/server-sdk": ^1.16.2
   peerDependenciesMeta:
     "@openfeature/multi-provider":
       optional: true
@@ -4747,6 +4747,8 @@ __metadata:
 "@devcycle/openfeature-nodejs-example@workspace:dev-apps/openfeature-nodejs":
   version: 0.0.0-use.local
   resolution: "@devcycle/openfeature-nodejs-example@workspace:dev-apps/openfeature-nodejs"
+  dependencies:
+    "@openfeature/server-sdk": ^1.16.2
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4747,8 +4747,6 @@ __metadata:
 "@devcycle/openfeature-nodejs-example@workspace:dev-apps/openfeature-nodejs":
   version: 0.0.0-use.local
   resolution: "@devcycle/openfeature-nodejs-example@workspace:dev-apps/openfeature-nodejs"
-  dependencies:
-    "@openfeature/server-sdk": ^1.16.2
   languageName: unknown
   linkType: soft
 
@@ -4765,7 +4763,7 @@ __metadata:
     "@devcycle/js-client-sdk": ^1.31.2
   peerDependencies:
     "@openfeature/multi-provider-web": ^0.0.2
-    "@openfeature/web-sdk": ^1.0.3
+    "@openfeature/web-sdk": ^1.3.2
   peerDependenciesMeta:
     "@openfeature/multi-provider-web":
       optional: true


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
