### PR TITLE
feat: support strong typing of variable keys

### DIFF
--- a/sdk/js-cloud-server/src/request.ts
+++ b/sdk/js-cloud-server/src/request.ts
@@ -2,6 +2,7 @@ import { DVCPopulatedUser } from './models/populatedUser'
 import { DevCycleEvent } from './types'
 import { DevCycleServerSDKOptions } from '@devcycle/types'
 import { post } from '@devcycle/server-request'
+import { VariableKey } from '@devcycle/js-client-sdk'
 
 export const HOST = '.devcycle.com'
 
@@ -58,7 +59,7 @@ export async function getAllVariables(
 export async function getVariable(
     user: DVCPopulatedUser,
     sdkKey: string,
-    variableKey: string,
+    variableKey: VariableKey,
     options: DevCycleServerSDKOptions,
 ): Promise<Response> {
     const baseUrl = `${

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -193,15 +193,42 @@ export interface DevCycleUser<T extends DVCCustomDataJSON = DVCCustomDataJSON> {
     privateCustomData?: T
 }
 
-export interface VariableDefinitions {
-    [key: string]: VariableValue
-}
+/**
+ * Used to support strong typing of flag strings in the SDK.
+ * Usage;
+ * ```ts
+ * import '@devcycle/js-client-sdk';
+ * declare module '@devcycle/js-client-sdk' {
+ *   interface CustomVariableDefinitions {
+ *     'flag-one': boolean;
+ *   }
+ * }
+ * ```
+ * Or when using the cli generated types;
+ * ```ts
+ * import '@devcycle/js-client-sdk';
+ * declare module '@devcycle/js-client-sdk' {
+ *   interface CustomVariableDefinitions extends DVCVariableTypes {}
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CustomVariableDefinitions {}
+type DynamicBaseVariableDefinitions =
+    keyof CustomVariableDefinitions extends never
+        ? {
+              [key: string]: VariableValue
+          }
+        : CustomVariableDefinitions
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface VariableDefinitions extends DynamicBaseVariableDefinitions {}
+export type VariableKey = string & keyof VariableDefinitions
 
 export interface DVCVariable<T extends DVCVariableValue> {
     /**
      * Unique "key" by Project to use for this Dynamic Variable.
      */
-    readonly key: string
+    readonly key: VariableKey
 
     /**
      * The value for this Dynamic Variable which will be set to the `defaultValue`

--- a/sdk/react/src/RenderIfEnabled.tsx
+++ b/sdk/react/src/RenderIfEnabled.tsx
@@ -1,11 +1,11 @@
 import useVariableValue from './useVariableValue'
-import { DVCVariableValue } from '@devcycle/js-client-sdk'
+import { DVCVariableValue, VariableKey } from '@devcycle/js-client-sdk'
 import { useContext } from 'react'
 import { debugContext } from './context'
 
 type CommonProps = {
     children: React.ReactNode
-    variableKey: string
+    variableKey: VariableKey
 }
 
 type RenderIfEnabledProps<T extends DVCVariableValue> =

--- a/sdk/react/src/SwapComponents.tsx
+++ b/sdk/react/src/SwapComponents.tsx
@@ -1,11 +1,12 @@
 import { ComponentProps, ComponentType } from 'react'
+import type { VariableKey } from '@devcycle/js-client-sdk'
 import useVariableValue from './useVariableValue'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const SwapComponents = <T extends ComponentType<any>>(
     OldComponent: T,
     NewComponent: T,
-    variableKey: string,
+    variableKey: VariableKey,
 ) => {
     const DevCycleConditionalComponent = (
         props: ComponentProps<T>,

--- a/sdk/react/src/useVariable.ts
+++ b/sdk/react/src/useVariable.ts
@@ -1,10 +1,14 @@
 'use client'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import context from './context'
-import type { DVCVariable, DVCVariableValue } from '@devcycle/js-client-sdk'
+import type {
+    DVCVariable,
+    DVCVariableValue,
+    VariableKey,
+} from '@devcycle/js-client-sdk'
 
 export const useVariable = <T extends DVCVariableValue>(
-    key: string,
+    key: VariableKey,
     defaultValue: T,
 ): DVCVariable<T> => {
     const dvcContext = useContext(context)

--- a/sdk/react/src/useVariableValue.ts
+++ b/sdk/react/src/useVariableValue.ts
@@ -1,9 +1,9 @@
 import { useVariable } from './useVariable'
-import type { DVCVariableValue } from '@devcycle/js-client-sdk'
+import type { DVCVariableValue, VariableKey } from '@devcycle/js-client-sdk'
 import type { VariableTypeAlias } from '@devcycle/types'
 
 export const useVariableValue = <T extends DVCVariableValue>(
-    key: string,
+    key: VariableKey,
     defaultValue: T,
 ): VariableTypeAlias<T> => {
     return useVariable(key, defaultValue).value


### PR DESCRIPTION
This allows better strong typing of the string values in the react hooks.
There are no changes to the js SDK but due to the usage of generics all the other libraries should get advantages from this too.

![CleanShot 2024-11-27 at 16 41 57](https://github.com/user-attachments/assets/e0a2b7ef-f549-41b9-a1c7-6a3648b54330)


Please do let me know if I've missed something as this was mostly tested out by playing around with the types in node_modules. I think that if this lands we could also update the cli to include the definition output as an option?