### PR TITLE
chore: typescript 5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "scripts": {
         "lint": "nx run-many --parallel --target lint --all",
         "test": "nx run-many --parallel --target test --all",
+        "check-types": "nx run-many --parallel --target check-types --all",
         "affected:lint": "nx affected --base=origin/main --head=HEAD --target=lint",
         "affected:test": "nx affected --base=origin/main --head=HEAD --target=test",
         "affected:e2e": "nx affected --base=origin/main --head=HEAD --target=e2e",
@@ -206,7 +207,7 @@
         "ts-jest": "29.1.0",
         "ts-node": "^10.9.2",
         "tslib": "^2.3.0",
-        "typescript": "^5.3.3",
+        "typescript": "^5.7.2",
         "url-loader": "^4.1.1",
         "validate-npm-package-name": "^5.0.0",
         "verdaccio": "^5.27.0",

--- a/sdk/nestjs/src/VariableValue.test.ts
+++ b/sdk/nestjs/src/VariableValue.test.ts
@@ -15,7 +15,6 @@ function getParamDecoratorFactory(decorator: () => ParameterDecorator) {
 }
 
 describe('VariableValue', () => {
-    let ctx: ExecutionContext
     let dvcClient: DevCycleClient
     let dvcUser: DevCycleUser
 
@@ -40,7 +39,7 @@ describe('VariableValue', () => {
         const defaultValue = 'default value'
 
         const factory = getParamDecoratorFactory(VariableValue)
-        const value = factory({ key, default: defaultValue }, ctx)
+        const value = factory({ key, default: defaultValue })
 
         expect(dvcClient.variableValue).toBeCalledWith(
             dvcUser,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15437,7 +15437,7 @@ __metadata:
     ts-jest: 29.1.0
     ts-node: ^10.9.2
     tslib: ^2.3.0
-    typescript: ^5.3.3
+    typescript: ^5.7.2
     ua-parser-js: ^1.0.36
     url-loader: ^4.1.1
     uuid: ^8.3.2
@@ -31111,13 +31111,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2, typescript@npm:^5.3.3":
+"typescript@npm:^5.2.2":
   version: 5.3.3
   resolution: "typescript@npm:5.3.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.7.2":
+  version: 5.7.2
+  resolution: "typescript@npm:5.7.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b55300c4cefee8ee380d14fa9359ccb41ff8b54c719f6bc49b424899d662a5ce62ece390ce769568c7f4d14af844085255e63788740084444eb12ef423b13433
   languageName: node
   linkType: hard
 
@@ -31151,13 +31161,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.3.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=5da071"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.7.2#~builtin<compat/typescript>":
+  version: 5.7.2
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#~builtin<compat/typescript>::version=5.7.2&hash=5da071"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 803430c6da2ba73c25a21880d8d4f08a56d9d2444e6db2ea949ac4abceeece8e4a442b7b9b585db7d8a0b47ebda2060e45fe8ee8b8aca23e27ec1d4844987ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- update Typescript to fix compiler's handling of empty interface `keyof` declarations