### PR TITLE
fix: vercel edge config adapter to calls class-transform

### DIFF
--- a/lib/shared/vercel-edge-config/package.json
+++ b/lib/shared/vercel-edge-config/package.json
@@ -5,6 +5,9 @@
         "@devcycle/types": "*",
         "@vercel/edge-config": "^1.2.0"
     },
+    "dependencies": {
+        "class-transformer": "^0.5.1"
+    },
     "type": "commonjs",
     "main": "./src/index.js",
     "typings": "./src/index.d.ts"

--- a/lib/shared/vercel-edge-config/src/edge-config.spec.ts
+++ b/lib/shared/vercel-edge-config/src/edge-config.spec.ts
@@ -30,6 +30,63 @@ describe('EdgeConfigSource', () => {
         })
     })
 
+    it('transforms raw data into a valid ConfigBody', async () => {
+        const get = jest.fn()
+        const edgeConfigSource = new EdgeConfigSource(
+            fromPartial({
+                get,
+            }),
+        )
+
+        get.mockResolvedValue({
+            key: 'value',
+            features: [
+                {
+                    configuration: {
+                        targets: [
+                            {
+                                rollout: {
+                                    startDate: '2024-12-05T20:36:26.086Z',
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+            lastModified: 'some date',
+        })
+
+        const result = await edgeConfigSource.getConfig(
+            'sdk-key',
+            'server',
+            false,
+        )
+
+        expect(result).toEqual({
+            config: {
+                key: 'value',
+                lastModified: 'some date',
+                features: [
+                    {
+                        configuration: {
+                            targets: [
+                                {
+                                    rollout: {
+                                        startDate: new Date(
+                                            '2024-12-05T20:36:26.086Z',
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+            lastModified: 'some date',
+            metaData: { resLastModified: 'some date' },
+        })
+    })
+
     it('returns null when the existing config date is newer', async () => {
         const get = jest.fn()
         const edgeConfigSource = new EdgeConfigSource(

--- a/lib/shared/vercel-edge-config/src/edge-config.ts
+++ b/lib/shared/vercel-edge-config/src/edge-config.ts
@@ -1,5 +1,6 @@
 import { EdgeConfigClient, EdgeConfigValue } from '@vercel/edge-config'
 import { ConfigBody, ConfigSource, UserError } from '@devcycle/types'
+import { plainToInstance } from 'class-transformer'
 
 export class EdgeConfigSource extends ConfigSource {
     constructor(private edgeConfigClient: EdgeConfigClient) {
@@ -44,7 +45,7 @@ export class EdgeConfigSource extends ConfigSource {
         this.configLastModified = config['lastModified'] as string
 
         return {
-            config: config as unknown as ConfigBody,
+            config: plainToInstance(ConfigBody, config),
             metaData: { resLastModified: this.configLastModified },
             lastModified: this.configLastModified,
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,6 +4829,8 @@ __metadata:
 "@devcycle/vercel-edge-config@workspace:lib/shared/vercel-edge-config":
   version: 0.0.0-use.local
   resolution: "@devcycle/vercel-edge-config@workspace:lib/shared/vercel-edge-config"
+  dependencies:
+    class-transformer: ^0.5.1
   peerDependencies:
     "@devcycle/types": "*"
     "@vercel/edge-config": ^1.2.0


### PR DESCRIPTION
- fix vercel edge config adapter so that it calls class transformer on the config data after retrieval

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
