### PR TITLE
chore: added property to know when instance of ConfigBody is created

### DIFF
--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -14,6 +14,7 @@ import {
     UserSubType,
     VariableType,
 } from '@devcycle/types'
+import { plainToInstance } from 'class-transformer'
 
 import moment from 'moment'
 
@@ -449,7 +450,7 @@ function configBodyAudiences(audiences: PublicAudience[]): {
     return auds
 }
 
-export const config: ConfigBody = {
+export const config = {
     project,
     environment,
     audiences: configBodyAudiences(reusableAudiences),
@@ -653,7 +654,7 @@ export const config: ConfigBody = {
     clientSDKKey: 'test',
 }
 
-export const barrenConfig: ConfigBody = {
+export const barrenConfig = {
     project,
     environment,
     audiences: {},
@@ -730,7 +731,7 @@ export const barrenConfig: ConfigBody = {
     variableHashes: {},
 }
 
-export const configWithNullCustomData: ConfigBody = {
+export const configWithNullCustomData = {
     project,
     environment,
     audiences: configBodyAudiences(reusableAudiences),
@@ -783,9 +784,10 @@ export const configWithNullCustomData: ConfigBody = {
     clientSDKKey: 'test',
 }
 
+const instancedConfig = plainToInstance(ConfigBody, config)
 export const configWithBucketingKey = (bucketingKey: string): ConfigBody => ({
-    ...config,
-    features: config.features.map((feature) => ({
+    ...instancedConfig,
+    features: instancedConfig.features.map((feature) => ({
         ...feature,
         configuration: {
             ...feature.configuration,

--- a/lib/shared/bucketing/__tests__/bucketing.test.ts
+++ b/lib/shared/bucketing/__tests__/bucketing.test.ts
@@ -1,5 +1,11 @@
 /* eslint-disable max-len */
-import { Audience, FeatureType, PublicRollout, Rollout } from '@devcycle/types'
+import {
+    Audience,
+    FeatureType,
+    PublicRollout,
+    Rollout,
+    ConfigBody,
+} from '@devcycle/types'
 import {
     generateBoundedHashes,
     decideTargetVariation,
@@ -7,9 +13,9 @@ import {
     doesUserPassRollout,
 } from '../src/bucketing'
 import {
-    config,
-    barrenConfig,
-    configWithNullCustomData,
+    config as plainConfig,
+    barrenConfig as plainBarrenConfig,
+    configWithNullCustomData as plainConfigWithNullCustomData,
     configWithBucketingKey,
 } from '@devcycle/bucketing-test-data'
 
@@ -17,6 +23,14 @@ import moment from 'moment'
 import times from 'lodash/times'
 import filter from 'lodash/filter'
 import * as uuid from 'uuid'
+import { plainToInstance } from 'class-transformer'
+
+const config = plainToInstance(ConfigBody, plainConfig)
+const barrenConfig = plainToInstance(ConfigBody, plainBarrenConfig)
+const configWithNullCustomData = plainToInstance(
+    ConfigBody,
+    plainConfigWithNullCustomData,
+)
 
 describe('User Hashing and Bucketing', () => {
     it('generates buckets approximately in the same distribution as the variation distributions', () => {
@@ -1595,6 +1609,35 @@ describe('Rollout Logic', () => {
         expect(doesUserPassRollout({ boundedHash: 0.4 })).toBeTruthy()
         expect(doesUserPassRollout({ boundedHash: 0.6 })).toBeTruthy()
         expect(doesUserPassRollout({ boundedHash: 0.9 })).toBeTruthy()
+    })
+
+    it('should not throw when given a ConfigBody config', () => {
+        expect(() =>
+            generateBucketedConfig({
+                config,
+                user: {
+                    user_id: 'asuh',
+                },
+            }),
+        ).not.toThrow()
+    })
+
+    it('should throw when given a non-ConfigBody config', () => {
+        const config = {} as ConfigBody
+
+        expect(() =>
+            generateBucketedConfig({
+                config,
+                user: {
+                    user_id: 'asuh',
+                },
+            }),
+        ).toThrow()
+    })
+
+    it('should have isConfigBody set to true', () => {
+        const config = plainToInstance(ConfigBody, plainConfig)
+        expect(config.isConfigBody).toBeTruthy()
     })
 
     describe('overrides', () => {

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -232,6 +232,11 @@ export const generateBucketedConfig = ({
     user: DVCBucketingUser
     overrides?: Record<string, string>
 }): BucketedUserConfig => {
+    if (!config.isConfigBody) {
+        throw new Error(
+            'Config is not a ConfigBody, transform config using plainToInstance',
+        )
+    }
     const variableMap: BucketedUserConfig['variables'] = {}
     const featureKeyMap: BucketedUserConfig['features'] = {}
     const featureVariationMap: BucketedUserConfig['featureVariationMap'] = {}

--- a/lib/shared/types/src/types/config/configBody.ts
+++ b/lib/shared/types/src/types/config/configBody.ts
@@ -40,6 +40,13 @@ export {
 
 export class ConfigBody<IdType = string> {
     /**
+     * This is to ensure usage of a proper ConfigBody instance by the bucketing library,
+     * using a regular JSON object will throw an error without this property, which is populated
+     * by using plainToInstance from class-transformer.
+     */
+    isConfigBody = true
+
+    /**
      * Basic project data used for building bucketing response
      */
     project: Project<IdType>

--- a/lib/shared/vercel-edge-config/src/edge-config.spec.ts
+++ b/lib/shared/vercel-edge-config/src/edge-config.spec.ts
@@ -24,7 +24,11 @@ describe('EdgeConfigSource', () => {
         expect(get).toHaveBeenCalledWith('devcycle-config-v2-server-sdk-key')
 
         expect(result).toEqual({
-            config: { key: 'value', lastModified: 'some date' },
+            config: {
+                key: 'value',
+                lastModified: 'some date',
+                isConfigBody: true,
+            },
             lastModified: 'some date',
             metaData: { resLastModified: 'some date' },
         })
@@ -64,6 +68,7 @@ describe('EdgeConfigSource', () => {
 
         expect(result).toEqual({
             config: {
+                isConfigBody: true,
                 key: 'value',
                 lastModified: 'some date',
                 features: [


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
