### PR TITLE
feat: default sse enabled for NodeJS SDK

### DIFF
--- a/.github/workflows/nx-affected-e2e.yml
+++ b/.github/workflows/nx-affected-e2e.yml
@@ -30,9 +30,9 @@ jobs:
             - name: Install system dependencies
               run: |
                 sudo apt-get update
-                sudo apt-get install -y libasound2 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 \
+                sudo apt-get install -y libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 \
                 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 \
-                libcairo2 libasound2 libatspi2.0-0 libgtk-3-0 libnspr4 libnss3
+                libcairo2 libatspi2.0-0 libgtk-3-0 libnspr4 libnss3
             - run: git fetch origin main
             - run: yarn --immutable
             - name: Install Playwright Browsers

--- a/.github/workflows/nx-affected-e2e.yml
+++ b/.github/workflows/nx-affected-e2e.yml
@@ -27,6 +27,12 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
+            - name: Install system dependencies
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y libasound2 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 \
+                libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 \
+                libcairo2 libasound2 libatspi2.0-0 libgtk-3-0 libnspr4 libnss3
             - run: git fetch origin main
             - run: yarn --immutable
             - name: Install Playwright Browsers

--- a/.github/workflows/nx-affected-e2e.yml
+++ b/.github/workflows/nx-affected-e2e.yml
@@ -27,12 +27,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
-            - name: Install system dependencies
-              run: |
-                sudo apt-get update
-                sudo apt-get install -y libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libdbus-1-3 \
-                libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 \
-                libcairo2 libatspi2.0-0 libgtk-3-0 libnspr4 libnss3
             - run: git fetch origin main
             - run: yarn --immutable
             - name: Install Playwright Browsers

--- a/e2e/js/js-cloud-server/yarn.lock
+++ b/e2e/js/js-cloud-server/yarn.lock
@@ -1497,27 +1497,27 @@ __metadata:
   linkType: hard
 
 "@devcycle/js-cloud-server-sdk@file:../../../dist/sdk/js-cloud-server::locator=e2e-js-cloud-server%40workspace%3A.":
-  version: 1.17.2
-  resolution: "@devcycle/js-cloud-server-sdk@file:../../../dist/sdk/js-cloud-server#../../../dist/sdk/js-cloud-server::hash=2335fe&locator=e2e-js-cloud-server%40workspace%3A."
+  version: 1.19.0
+  resolution: "@devcycle/js-cloud-server-sdk@file:../../../dist/sdk/js-cloud-server#../../../dist/sdk/js-cloud-server::hash=4e03da&locator=e2e-js-cloud-server%40workspace%3A."
   dependencies:
-    "@devcycle/types": ^1.18.1
+    "@devcycle/types": ^1.20.0
     cross-fetch: ^4.0.0
     fetch-retry: ^5.0.6
     lodash: ^4.17.21
-  checksum: a62182d688d10924c0c347a0fe5a7ed73cd07a0c6e82105b9d215969f1e302609c325f0b2db2f744aaa0f61049280fd455cc9f8a4b6ccc5d9445ace0c6bd24f3
+  checksum: 144f12c3bd75898831578fd766b8964a5db55cc73288672c0f0e17a29c82297e166f8ff1820bfa9d8dac6dfec042889d1e673e7d3b5549e11b2cd7a6c3dce8ab
   languageName: node
   linkType: hard
 
 "@devcycle/types@file:../../../dist/lib/shared/types::locator=e2e-js-cloud-server%40workspace%3A.":
-  version: 1.18.1
-  resolution: "@devcycle/types@file:../../../dist/lib/shared/types#../../../dist/lib/shared/types::hash=d094ae&locator=e2e-js-cloud-server%40workspace%3A."
+  version: 1.20.0
+  resolution: "@devcycle/types@file:../../../dist/lib/shared/types#../../../dist/lib/shared/types::hash=164d40&locator=e2e-js-cloud-server%40workspace%3A."
   dependencies:
     class-transformer: 0.5.1
     class-validator: 0.14.1
     iso-639-1: ^2.1.13
     lodash: ^4.17.21
     reflect-metadata: ^0.1.13
-  checksum: 8c37c512e1d183bf96bbbcde0c9c146a9154b48542646336aae80ac5e3b31115b88b26780e63aa5ef53ae9277a8e0d94f82bb8248e09ab4c6365020c575d0867
+  checksum: cfc298d75d8b5c11f1e3bfc6210ae06a61e351eb79bb274f5c212ebbbddf5406b431192472bf891d9b4282736b57a492747d27c8388611e978a3b5575e1ef35e
   languageName: node
   linkType: hard
 

--- a/e2e/nextjs/app-router/app/yarn.lock
+++ b/e2e/nextjs/app-router/app/yarn.lock
@@ -31,8 +31,8 @@ __metadata:
   linkType: hard
 
 "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs::locator=app%40workspace%3A.":
-  version: 2.8.0
-  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=7ea780&locator=app%40workspace%3A."
+  version: 2.9.0
+  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=9eef4c&locator=app%40workspace%3A."
   dependencies:
     "@devcycle/bucketing": "npm:^1.25.0"
     "@devcycle/js-client-sdk": "npm:^1.33.0"
@@ -41,7 +41,7 @@ __metadata:
     class-transformer: "npm:^0.5.1"
     hoist-non-react-statics: "npm:^3.3.2"
     server-only: "npm:^0.0.1"
-  checksum: a97ec2cd27c27cdef68d9b87bd99e32a4babe7a8bdbdb33941463a7651402b95864202c1a028870a471925a3aa5644d7fdfacdd730072a76cf2a429df8e89329
+  checksum: 36d12f4d2f293c581cc215abfd0bb9ede4cd1b3bd35339c8ae48c55505e0c4b1c4b6c152e261e52dd69fc6e6311573e02fd6c3c46697db5f105203ee4806f58f
   languageName: node
   linkType: hard
 
@@ -60,14 +60,14 @@ __metadata:
 
 "@devcycle/types@file:../../../../dist/lib/shared/types::locator=app%40workspace%3A.":
   version: 1.20.0
-  resolution: "@devcycle/types@file:../../../../dist/lib/shared/types#../../../../dist/lib/shared/types::hash=49328d&locator=app%40workspace%3A."
+  resolution: "@devcycle/types@file:../../../../dist/lib/shared/types#../../../../dist/lib/shared/types::hash=ad05f7&locator=app%40workspace%3A."
   dependencies:
     class-transformer: "npm:0.5.1"
     class-validator: "npm:0.14.1"
     iso-639-1: "npm:^2.1.13"
     lodash: "npm:^4.17.21"
     reflect-metadata: "npm:^0.1.13"
-  checksum: 37a261b629edf04b9225ac3a29001c4c7694269d78221533b401ceb351ebfcf16602e18049797fe0af3baab17e84ffe1d7834227eeb4850f67d00925bc001437
+  checksum: e4cfd22054696115942f5252e083d733da347d3c49a83bc1ae68bcbaf808625d392887efccfbc0c5e67f6871889400d575c44d7e82ffd07ada439424a8ff673e
   languageName: node
   linkType: hard
 

--- a/e2e/nextjs/pages-router/app/yarn.lock
+++ b/e2e/nextjs/pages-router/app/yarn.lock
@@ -6,67 +6,68 @@ __metadata:
   cacheKey: 10
 
 "@devcycle/bucketing@file:../../../../dist/lib/shared/bucketing::locator=app%40workspace%3A.":
-  version: 1.23.0
-  resolution: "@devcycle/bucketing@file:../../../../dist/lib/shared/bucketing#../../../../dist/lib/shared/bucketing::hash=3760ab&locator=app%40workspace%3A."
+  version: 1.25.0
+  resolution: "@devcycle/bucketing@file:../../../../dist/lib/shared/bucketing#../../../../dist/lib/shared/bucketing::hash=f620ff&locator=app%40workspace%3A."
   dependencies:
-    "@devcycle/types": "npm:^1.18.0"
+    "@devcycle/types": "npm:^1.20.0"
     lodash: "npm:^4.17.21"
     murmurhash: "npm:^2.0.0"
     ua-parser-js: "npm:^1.0.36"
-  checksum: 44395904d0770308ce33a41e7bf5aa82523b98ddf6a2e44d0a66e62a01ffbe76b0e931ad28def059afd260f296ca0f93c36e3960cc5f0a7f3d85b7a91b5fccd0
+  checksum: 26b227546ed21ed61ccbf917eb5f6d60e7c5a31fd0b61d015f92dd95b4c51b1f79182ef0cf9bf54ddbd423f4eda496a79af77d75460126ef59b543a8dbeab358
   languageName: node
   linkType: hard
 
 "@devcycle/js-client-sdk@file:../../../../dist/sdk/js::locator=app%40workspace%3A.":
-  version: 1.31.0
-  resolution: "@devcycle/js-client-sdk@file:../../../../dist/sdk/js#../../../../dist/sdk/js::hash=40e7b0&locator=app%40workspace%3A."
+  version: 1.33.0
+  resolution: "@devcycle/js-client-sdk@file:../../../../dist/sdk/js#../../../../dist/sdk/js::hash=5d8b0d&locator=app%40workspace%3A."
   dependencies:
-    "@devcycle/types": "npm:^1.18.0"
+    "@devcycle/types": "npm:^1.20.0"
     fetch-retry: "npm:^5.0.6"
     lodash: "npm:^4.17.21"
     ua-parser-js: "npm:^1.0.36"
     uuid: "npm:^8.3.2"
-  checksum: 3acdcbf8b351c08cf6b482e7a3e56aa9560a7e3589cfaf9fcd330624e101c3001479b68c457fa3a54384d1248b572f3ddb71364e6bf5ffbb385cd2f02dabb915
+  checksum: d27d6f6952f363ea71a3eb6865021d1af175d696a81284f36dd6e7dd134c00996f8506cf5c8c35cc7b9c5044dc30edbf9308d580c330ed6bad7623c98dc91e7a
   languageName: node
   linkType: hard
 
 "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs::locator=app%40workspace%3A.":
-  version: 2.6.0
-  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=f2c38c&locator=app%40workspace%3A."
+  version: 2.9.0
+  resolution: "@devcycle/nextjs-sdk@file:../../../../dist/sdk/nextjs#../../../../dist/sdk/nextjs::hash=9eef4c&locator=app%40workspace%3A."
   dependencies:
-    "@devcycle/bucketing": "npm:^1.23.0"
-    "@devcycle/js-client-sdk": "npm:^1.31.0"
-    "@devcycle/react-client-sdk": "npm:^1.29.0"
-    "@devcycle/types": "npm:^1.18.0"
+    "@devcycle/bucketing": "npm:^1.25.0"
+    "@devcycle/js-client-sdk": "npm:^1.33.0"
+    "@devcycle/react-client-sdk": "npm:^1.31.0"
+    "@devcycle/types": "npm:^1.20.0"
+    class-transformer: "npm:^0.5.1"
     hoist-non-react-statics: "npm:^3.3.2"
     server-only: "npm:^0.0.1"
-  checksum: 9d905c89316e3e87fa1ec663ef29298abca0d40d7603bb156f4942568a322cf45e581d84481d7f0c2957f73f5fb72fbb5818307042ebd1a6d4ba796317f5ce2a
+  checksum: 36d12f4d2f293c581cc215abfd0bb9ede4cd1b3bd35339c8ae48c55505e0c4b1c4b6c152e261e52dd69fc6e6311573e02fd6c3c46697db5f105203ee4806f58f
   languageName: node
   linkType: hard
 
 "@devcycle/react-client-sdk@file:../../../../dist/sdk/react::locator=app%40workspace%3A.":
-  version: 1.29.0
-  resolution: "@devcycle/react-client-sdk@file:../../../../dist/sdk/react#../../../../dist/sdk/react::hash=53291e&locator=app%40workspace%3A."
+  version: 1.31.0
+  resolution: "@devcycle/react-client-sdk@file:../../../../dist/sdk/react#../../../../dist/sdk/react::hash=3e2fc6&locator=app%40workspace%3A."
   dependencies:
-    "@devcycle/js-client-sdk": "npm:^1.31.0"
-    "@devcycle/types": "npm:^1.18.0"
+    "@devcycle/js-client-sdk": "npm:^1.33.0"
+    "@devcycle/types": "npm:^1.20.0"
     hoist-non-react-statics: "npm:^3.3.2"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: bc8140acca4d07fd4c5adba4e3b750b52314eaf2f2b8794b073d5878dc99a6904594ef1c10702420a29e3712ea3d0238b72a511e3d731adc1fe7fc0c053cba67
+  checksum: f022ea564ad4ef722b33afc295ccdd61eb44c03dec21f47a368d418297da3ba7ad398b175016d3ad9bc32f051159fc8c5d6a1875c4bca7bca01176cf133d3a2f
   languageName: node
   linkType: hard
 
 "@devcycle/types@file:../../../../dist/lib/shared/types::locator=app%40workspace%3A.":
-  version: 1.18.0
-  resolution: "@devcycle/types@file:../../../../dist/lib/shared/types#../../../../dist/lib/shared/types::hash=4eb545&locator=app%40workspace%3A."
+  version: 1.20.0
+  resolution: "@devcycle/types@file:../../../../dist/lib/shared/types#../../../../dist/lib/shared/types::hash=ad05f7&locator=app%40workspace%3A."
   dependencies:
     class-transformer: "npm:0.5.1"
     class-validator: "npm:0.14.1"
     iso-639-1: "npm:^2.1.13"
     lodash: "npm:^4.17.21"
     reflect-metadata: "npm:^0.1.13"
-  checksum: 9422caa1a8dd9cdd356ac213b968faca1e656381a195efdc12118bf65a672f84930d0866716c0717507ea9b54b031c779d3d1427fd608a4f511b5ee4a93ceb0c
+  checksum: e4cfd22054696115942f5252e083d733da347d3c49a83bc1ae68bcbaf808625d392887efccfbc0c5e67f6871889400d575c44d7e82ffd07ada439424a8ff673e
   languageName: node
   linkType: hard
 
@@ -378,7 +379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"class-transformer@npm:0.5.1":
+"class-transformer@npm:0.5.1, class-transformer@npm:^0.5.1":
   version: 0.5.1
   resolution: "class-transformer@npm:0.5.1"
   checksum: 750327e3e9a5cf233c5234252f4caf6b06c437bf68a24acbdcfb06c8e0bfff7aa97c30428184813e38e08111b42871f20c5cf669ea4490f8ae837c09f08b31e7

--- a/lib/shared/config-manager/__tests__/environmentConfigManager.spec.ts
+++ b/lib/shared/config-manager/__tests__/environmentConfigManager.spec.ts
@@ -373,7 +373,6 @@ describe('EnvironmentConfigManager Unit Tests', () => {
             const envConfig = getConfigManager(logger, 'sdkKey', {
                 configPollingIntervalMS: 1000,
                 configPollingTimeoutMS: 1000,
-                enableBetaRealTimeUpdates: true,
             })
             await envConfig.fetchConfigPromise
             return envConfig

--- a/lib/shared/config-manager/__tests__/environmentConfigManager.spec.ts
+++ b/lib/shared/config-manager/__tests__/environmentConfigManager.spec.ts
@@ -350,7 +350,10 @@ describe('EnvironmentConfigManager Unit Tests', () => {
 
     describe('SSE Connection', () => {
         const lastModifiedDate = new Date()
-        const connectToSSE = async (config?: string) => {
+        const connectToSSE = async (
+            config?: string,
+            disableRealTimeUpdates = false,
+        ) => {
             getEnvironmentConfig_mock.mockImplementation(async () =>
                 mockFetchResponse(
                     {
@@ -373,6 +376,7 @@ describe('EnvironmentConfigManager Unit Tests', () => {
             const envConfig = getConfigManager(logger, 'sdkKey', {
                 configPollingIntervalMS: 1000,
                 configPollingTimeoutMS: 1000,
+                disableRealTimeUpdates,
             })
             await envConfig.fetchConfigPromise
             return envConfig
@@ -388,6 +392,16 @@ describe('EnvironmentConfigManager Unit Tests', () => {
 
             jest.advanceTimersByTime(10 * 60 * 1000)
             expect(getEnvironmentConfig_mock).toBeCalledTimes(2)
+
+            envConfig.cleanup()
+        })
+
+        it('shuld not conenct to SSE if disableRealTimeUpdates is true', async () => {
+            const envConfig = await connectToSSE(undefined, true)
+
+            expect(setInterval_mock).toHaveBeenCalledTimes(1)
+            expect(getEnvironmentConfig_mock).toBeCalledTimes(1)
+            expect(MockEventSource).not.toHaveBeenCalled()
 
             envConfig.cleanup()
         })

--- a/lib/shared/config-manager/src/index.ts
+++ b/lib/shared/config-manager/src/index.ts
@@ -10,7 +10,7 @@ type ConfigPollingOptions = {
     configPollingTimeoutMS?: number
     configCDNURI?: string
     clientMode?: boolean
-    enableBetaRealTimeUpdates?: boolean
+    disableRealTimeUpdates?: boolean
 }
 
 type SetIntervalInterface = (handler: () => void, timeout?: number) => any
@@ -55,12 +55,12 @@ export class EnvironmentConfigManager {
             configPollingTimeoutMS = 5000,
             configCDNURI = 'https://config-cdn.devcycle.com',
             clientMode = false,
-            enableBetaRealTimeUpdates = false,
+            disableRealTimeUpdates = false,
         }: ConfigPollingOptions,
         configSource?: ConfigSource,
     ) {
         this.clientMode = clientMode
-        this.enableRealtimeUpdates = enableBetaRealTimeUpdates
+        this.enableRealtimeUpdates = !disableRealTimeUpdates
 
         this.configPollingIntervalMS =
             configPollingIntervalMS >= 1000 ? configPollingIntervalMS : 1000

--- a/lib/shared/types/src/types/apis/sdk/serverSDKTypes.ts
+++ b/lib/shared/types/src/types/apis/sdk/serverSDKTypes.ts
@@ -92,6 +92,13 @@ export interface DevCycleServerSDKOptions {
     enableClientBootstrapping?: boolean
 
     /**
+     * Disables real time updates and their associated SSE connection
+     * will default back to polling for config updates
+     */
+    disableRealTimeUpdates?: boolean
+
+    /**
+     * @deprecated real time updates are enabled by default now
      * BETA: Enable Real Time Updates and their associated SSE connection
      */
     enableBetaRealTimeUpdates?: boolean

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "@nx/web": "16.10.0",
         "@nx/webpack": "16.10.0",
         "@nx/workspace": "16.10.0",
-        "@playwright/test": "^1.36.0",
+        "@playwright/test": "^1.49.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
         "@react-native-async-storage/async-storage": "1.19.4",
         "@react-native-community/cli": "11.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8490,14 +8490,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.36.0":
-  version: 1.40.0
-  resolution: "@playwright/test@npm:1.40.0"
+"@playwright/test@npm:^1.49.1":
+  version: 1.49.1
+  resolution: "@playwright/test@npm:1.49.1"
   dependencies:
-    playwright: 1.40.0
+    playwright: 1.49.1
   bin:
     playwright: cli.js
-  checksum: 128f05978f9f5a557f0b7924ec134d43cb70c78d74bc3bf7b18576f00e72399100ddf1f4a139e05ea8275407d8e27be0203ac34f514319a2cbeb01eaf0be5be4
+  checksum: cdbd16df3d773dc8e522d79b4b961e25c2e1b1d4f3ec45eb711078ab5d11bca47caafe833e2be2f923328fbd012405a9ee31d9b449d184077598546a36847e69
   languageName: node
   linkType: hard
 
@@ -15305,7 +15305,7 @@ __metadata:
     "@openfeature/multi-provider-web": ^0.0.2
     "@openfeature/server-sdk": ^1.16.2
     "@openfeature/web-sdk": ^1.3.2
-    "@playwright/test": ^1.36.0
+    "@playwright/test": ^1.49.1
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     "@react-native-async-storage/async-storage": 1.19.4
     "@react-native-community/cli": 11.3.6
@@ -25886,27 +25886,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.40.0":
-  version: 1.40.0
-  resolution: "playwright-core@npm:1.40.0"
+"playwright-core@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright-core@npm:1.49.1"
   bin:
     playwright-core: cli.js
-  checksum: 57de5c91a4c404b120ed2af8541b21cdedcbc4f27477341157666d356bbee3b3fab8e61d020f0f450708fa2e8f6dc244b9224cb1985d5426e609cebed15af095
+  checksum: a940f4b10ff1de033b4b8594b5104b02849a892d9adda0d42330a872cd3d8d287ffd2b01fc33f33ccd34f8904bb8ae8220b878b62e899f3d9bcd1b0945ab45c7
   languageName: node
   linkType: hard
 
-"playwright@npm:1.40.0":
-  version: 1.40.0
-  resolution: "playwright@npm:1.40.0"
+"playwright@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright@npm:1.49.1"
   dependencies:
     fsevents: 2.3.2
-    playwright-core: 1.40.0
+    playwright-core: 1.49.1
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 7ba49e5376a6cfd1d32048dbdb2fd38e09182aa2e4619fdb23d3e6530fa6987f2f3fd34ad1d9d906fb4ec2da69ee7536eeb881982d60750fde809183caa607fc
+  checksum: c136d42d625e32614f90e5228a165dc8be48c5bfb52aca9210c6ff04161a409dbe42fe5ae4f05a2653f6a1b836876a04d3b0f24bcbbc053d1509c1d605b7c8d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Change the default bahaviour of the NodeJS SDK to default to using SSE connections.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
