### PR TITLE
fix: memoize track() call in next.js SDK

### DIFF
--- a/sdk/nextjs/src/client/useTrack.ts
+++ b/sdk/nextjs/src/client/useTrack.ts
@@ -1,10 +1,14 @@
 'use client'
 import type { DevCycleEvent } from '@devcycle/js-client-sdk'
 import { useDevCycleClient } from './internal/useDevCycleClient'
+import { useCallback } from 'react'
 
 export const useTrack = (): ((event: DevCycleEvent) => void) => {
     const client = useDevCycleClient()
-    return (event: DevCycleEvent) => {
-        client.track(event)
-    }
+    return useCallback(
+        (event: DevCycleEvent) => {
+            client.track(event)
+        },
+        [client],
+    )
 }


### PR DESCRIPTION
- Update to Next.js SDK to use `useCallback()` to memoize the `client.track()` call in `useTrack`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
