### PR TITLE
feat: create openfeature-react-provider to track usage of react OF provider

### DIFF
--- a/sdk/js/__tests__/Request.spec.ts
+++ b/sdk/js/__tests__/Request.spec.ts
@@ -18,13 +18,17 @@ describe('Request tests', () => {
 
     describe('getConfigJson', () => {
         it('should call get with serialized user and SDK key in params', async () => {
-            const user = { user_id: 'my_user', isAnonymous: false }
+            const user = {
+                user_id: 'my_user',
+                isAnonymous: false,
+                sdkPlatform: 'js',
+            }
             const sdkKey = 'my_sdk_key'
             await Request.getConfigJson(
                 sdkKey,
                 user as DVCPopulatedUser,
                 defaultLogger,
-                { sdkPlatform: 'js' },
+                undefined,
                 {
                     sse: true,
                     lastModified: 1234,
@@ -34,8 +38,8 @@ describe('Request tests', () => {
 
             expect(fetchRequestMock).toBeCalledWith(
                 'https://sdk-api.devcycle.com/v1/sdkConfig?sdkKey=' +
-                    `${sdkKey}&user_id=${user.user_id}&isAnonymous=false&sse=1` +
-                    `&sseLastModified=1234&sseEtag=etag&sdkPlatform=js`,
+                    `${sdkKey}&user_id=${user.user_id}&isAnonymous=false&sdkPlatform=js&sse=1` +
+                    `&sseLastModified=1234&sseEtag=etag`,
                 expect.objectContaining({
                     headers: { 'Content-Type': 'application/json' },
                     method: 'GET',

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -27,11 +27,7 @@ import type {
 import { getVariableTypeFromValue } from '@devcycle/types'
 import { ConfigRequestConsolidator } from './ConfigRequestConsolidator'
 import { dvcDefaultLogger } from './logger'
-import type {
-    DVCLogger,
-    SSEConnectionInterface,
-    SSEConnectionConstructor,
-} from '@devcycle/types'
+import type { DVCLogger, SSEConnectionInterface } from '@devcycle/types'
 import { StreamingConnection } from './StreamingConnection'
 
 type variableUpdatedHandler = (

--- a/sdk/js/src/Request.ts
+++ b/sdk/js/src/Request.ts
@@ -54,9 +54,6 @@ export const getConfigJson = async (
     if (options?.enableObfuscation) {
         queryParams.append('obfuscated', '1')
     }
-    if (options?.sdkPlatform) {
-        queryParams.append('sdkPlatform', options.sdkPlatform)
-    }
 
     const url =
         `${options?.apiProxyURL || CLIENT_SDK_URL}${CONFIG_PATH}?` +

--- a/sdk/js/src/User.ts
+++ b/sdk/js/src/User.ts
@@ -11,6 +11,7 @@ type StaticData = Pick<
     | 'deviceModel'
     | 'sdkType'
     | 'sdkVersion'
+    | 'sdkPlatform'
 >
 
 export class DVCPopulatedUser implements DevCycleUser {
@@ -32,6 +33,7 @@ export class DVCPopulatedUser implements DevCycleUser {
     readonly deviceModel: string
     readonly sdkType: 'client'
     readonly sdkVersion: string
+    readonly sdkPlatform?: string
 
     constructor(
         user: DevCycleUser,
@@ -89,6 +91,7 @@ export class DVCPopulatedUser implements DevCycleUser {
                     : userAgentString ?? 'SSR - unknown'
             this.sdkType = 'client'
             this.sdkVersion = packageJson.version
+            this.sdkPlatform = options?.sdkPlatform
         }
     }
 
@@ -100,6 +103,7 @@ export class DVCPopulatedUser implements DevCycleUser {
             deviceModel: this.deviceModel,
             sdkType: this.sdkType,
             sdkVersion: this.sdkVersion,
+            sdkPlatform: this.sdkPlatform,
         }
     }
 

--- a/sdk/openfeature-react-provider/.babelrc
+++ b/sdk/openfeature-react-provider/.babelrc
@@ -1,0 +1,10 @@
+{
+    "presets": [
+        [
+            "@nx/js/babel",
+            {
+                "useBuiltIns": "usage"
+            }
+        ]
+    ]
+}

--- a/sdk/openfeature-react-provider/.eslintrc.json
+++ b/sdk/openfeature-react-provider/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*", "node_modules/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/sdk/openfeature-react-provider/README.md
+++ b/sdk/openfeature-react-provider/README.md
@@ -1,0 +1,19 @@
+# OpenFeature DevCycle React Web Provider
+
+This library provides a Javascript implementation of the [OpenFeature](https://openfeature.dev/) Web Provider interface for [DevCycle React Client SDK](https://docs.devcycle.com/sdk/client-side-sdks/react/).
+
+## Building
+
+Run `yarn nx build openfeature-react-provider` to build the library.
+
+## Running Unit Tests
+
+Run `yarn nx test openfeature-web-provider` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Example App
+
+See the [example app](/dev-apps/openfeature-web) for a working example of the OpenFeature Web DevCycle Provider.
+
+## Usage
+
+See our [documentation](https://docs.devcycle.com/sdk/client-side-sdks/react/react-openfeature) for more information.

--- a/sdk/openfeature-react-provider/__mocks__/@devcycle/js-client-sdk.ts
+++ b/sdk/openfeature-react-provider/__mocks__/@devcycle/js-client-sdk.ts
@@ -1,0 +1,9 @@
+// Need to disable this to keep the working jest mock
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { initializeDevCycle } from '@devcycle/js-client-sdk'
+
+const { DevCycleClient } = jest.createMockFromModule<
+    typeof import('@devcycle/js-client-sdk/src/Client')
+>('@devcycle/js-client-sdk/src/Client')
+
+export { DevCycleClient, initializeDevCycle }

--- a/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
+++ b/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
@@ -1,0 +1,506 @@
+global.fetch = jest.fn()
+import DevCycleReactProvider from '../src/index'
+import {
+    Client,
+    OpenFeature,
+    StandardResolutionReasons,
+} from '@openfeature/web-sdk'
+
+let variableMock: any
+let identifyUserMock: any
+let isInitializedMock: any
+
+const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+}
+
+async function initOFClient(): Promise<{
+    ofClient: Client
+    provider: DevCycleReactProvider
+}> {
+    const options = { logger }
+    OpenFeature.setContext({ targetingKey: 'node_sdk_test' })
+    const provider = new DevCycleReactProvider('dvc_client_sdk_key', options)
+    await OpenFeature.setProviderAndWait(provider)
+
+    if (provider.devcycleClient) {
+        isInitializedMock = jest
+            .spyOn(provider.devcycleClient, 'isInitialized', 'get')
+            .mockReturnValue(true)
+        identifyUserMock = jest
+            .spyOn(provider.devcycleClient, 'identifyUser')
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            .mockResolvedValue({})
+        variableMock = jest
+            .spyOn(provider.devcycleClient, 'variable')
+            .mockReturnValue({
+                key: 'boolean-flag',
+                value: true,
+                defaultValue: false,
+                isDefaulted: false,
+                evalReason: undefined,
+                onUpdate: jest.fn(),
+            })
+    }
+    const ofClient = OpenFeature.getClient()
+    return { ofClient, provider }
+}
+
+describe('DevCycleReactProvider Unit Tests', () => {
+    afterEach(() => {
+        variableMock?.mockClear()
+        identifyUserMock?.mockClear()
+        isInitializedMock?.mockClear()
+    })
+
+    it('should setup an OpenFeature provider with a DevCycleClient', async () => {
+        const { ofClient, provider } = await initOFClient()
+        expect(ofClient).toBeDefined()
+        expect(provider).toBeDefined()
+        expect(provider.devcycleClient).toBeDefined()
+    })
+
+    describe('User Context', () => {
+        // OF doesn't expose context errors to the user through a handler / hook yet.
+        // This is likely to change in future versions based off slack discussions.
+        //
+        // it('should throw error if targetingKey is missing', async () => {
+        //     const { ofClient } = await initOFClient()
+        //     variableMock.mockReturnValue({
+        //         key: 'boolean-flag',
+        //         value: false,
+        //         defaultValue: false,
+        //         isDefaulted: true,
+        //         evalReason: undefined,
+        //         onUpdate: jest.fn(),
+        //     })
+        //
+        //     await OpenFeature.setContext({})
+        //
+        //     expect(errHandler).toHaveBeenCalled()
+        //     expect(errHook).toHaveBeenCalled()
+        //
+        //     const details = ofClient.getBooleanDetails('boolean-flag', false)
+        //     expect(details).toEqual({
+        //         flagKey: 'boolean-flag',
+        //         value: false,
+        //         errorCode: 'TARGETING_KEY_MISSING',
+        //         errorMessage: 'Missing targetingKey or user_id in context',
+        //         reason: 'ERROR',
+        //         flagMetadata: {},
+        //     })
+        // })
+        //
+        // it('should throw error if targetingKey is not a string', async () => {
+        //     const { ofClient } = await initOFClient()
+        //     await OpenFeature.setContext({ user_id: 123 })
+        //
+        //     expect(ofClient.getBooleanDetails('boolean-flag', false)).toEqual({
+        //         flagKey: 'boolean-flag',
+        //         value: false,
+        //         errorCode: 'INVALID_CONTEXT',
+        //         errorMessage: 'targetingKey or user_id must be a string',
+        //         reason: 'ERROR',
+        //         flagMetadata: {},
+        //     })
+        // })
+
+        it('should convert Context properties to DevCycleUser properties', async () => {
+            const { ofClient, provider } = await initOFClient()
+            const dvcUser = {
+                user_id: 'user_id',
+                email: 'email',
+                name: 'name',
+                language: 'en',
+                country: 'CA',
+                appVersion: '1.0.11',
+                appBuild: 1000,
+                customData: { custom: 'data' },
+                privateCustomData: { private: 'data' },
+            }
+            await OpenFeature.setContext(dvcUser)
+
+            expect(ofClient.getBooleanValue('boolean-flag', false)).toEqual(
+                true,
+            )
+            expect(provider.devcycleClient?.identifyUser).toHaveBeenCalledWith(
+                dvcUser,
+            )
+            expect(provider.devcycleClient?.variable).toHaveBeenCalledWith(
+                'boolean-flag',
+                false,
+            )
+        })
+
+        it('should skip DevCycleUser properties that are not the correct type', async () => {
+            const { ofClient, provider } = await initOFClient()
+            const dvcUser = {
+                user_id: 'user_id',
+                appVersion: 1.0,
+                appBuild: 'string',
+                customData: 'data',
+            }
+            await OpenFeature.setContext(dvcUser)
+
+            expect(ofClient.getBooleanValue('boolean-flag', false)).toEqual(
+                true,
+            )
+
+            expect(provider.devcycleClient?.identifyUser).toHaveBeenCalledWith({
+                user_id: 'user_id',
+            })
+            expect(provider.devcycleClient?.variable).toHaveBeenCalledWith(
+                'boolean-flag',
+                false,
+            )
+            expect(logger.warn).toHaveBeenCalledWith(
+                'Expected DevCycleUser property "appVersion" to be "string" but got "number" in EvaluationContext. ' +
+                    'Ignoring value.',
+            )
+            expect(logger.warn).toHaveBeenCalledWith(
+                'Expected DevCycleUser property "appBuild" to be "number" but got "string" in EvaluationContext. ' +
+                    'Ignoring value.',
+            )
+            expect(logger.warn).toHaveBeenCalledWith(
+                'Expected DevCycleUser property "customData" to be "object" but got "string" in EvaluationContext. ' +
+                    'Ignoring value.',
+            )
+        })
+
+        it(
+            'should skip Context properties that are sub-objects as DevCycleUser ' +
+                'only supports flat properties',
+            async () => {
+                const { ofClient, provider } = await initOFClient()
+                const dvcUser = {
+                    user_id: 'user_id',
+                    nullKey: null,
+                    obj: { key: 'value' },
+                }
+                await OpenFeature.setContext(dvcUser)
+
+                expect(ofClient.getBooleanValue('boolean-flag', false)).toEqual(
+                    true,
+                )
+
+                expect(
+                    provider.devcycleClient?.identifyUser,
+                ).toHaveBeenCalledWith({
+                    user_id: 'user_id',
+                    customData: { nullKey: null },
+                })
+                expect(provider.devcycleClient?.variable).toHaveBeenCalledWith(
+                    'boolean-flag',
+                    false,
+                )
+                expect(logger.warn).toHaveBeenCalledWith(
+                    'EvaluationContext property "obj" is an Object. ' +
+                        'DevCycleUser only supports flat customData properties of type ' +
+                        'string / number / boolean / null',
+                )
+            },
+        )
+
+        it('should skip customData key that is not a flat json property', async () => {
+            const { ofClient, provider } = await initOFClient()
+            const dvcUser = {
+                user_id: 'user_id',
+                customData: { obj: { key: 'value' }, num: 610 },
+            }
+            await OpenFeature.setContext(dvcUser)
+            expect(ofClient.getBooleanValue('boolean-flag', false)).toEqual(
+                true,
+            )
+
+            expect(provider.devcycleClient?.identifyUser).toHaveBeenCalledWith({
+                user_id: 'user_id',
+                customData: { num: 610 },
+            })
+            expect(provider.devcycleClient?.variable).toHaveBeenCalledWith(
+                'boolean-flag',
+                false,
+            )
+            expect(logger.warn).toHaveBeenCalledWith(
+                'EvaluationContext property "customData" contains "obj" property of type object.' +
+                    'DevCycleUser only supports flat customData properties of type string / number / boolean / null',
+            )
+        })
+    })
+
+    describe('Boolean Flags', () => {
+        it('should resolve a boolean flag value', async () => {
+            const { ofClient } = await initOFClient()
+            expect(ofClient.getBooleanValue('boolean-flag', false)).toEqual(
+                true,
+            )
+        })
+
+        it('should resolve a boolean flag details', async () => {
+            const { ofClient } = await initOFClient()
+            expect(ofClient.getBooleanDetails('boolean-flag', false)).toEqual({
+                flagKey: 'boolean-flag',
+                value: true,
+                reason: StandardResolutionReasons.TARGETING_MATCH,
+                flagMetadata: {},
+            })
+        })
+
+        it('should return default value if flag is not found', async () => {
+            const { ofClient } = await initOFClient()
+            variableMock.mockReturnValue({
+                key: 'boolean-flag',
+                value: false,
+                defaultValue: false,
+                isDefaulted: true,
+                evalReason: undefined,
+                onUpdate: jest.fn(),
+            })
+
+            expect(ofClient.getBooleanDetails('boolean-flag', false)).toEqual({
+                flagKey: 'boolean-flag',
+                value: false,
+                reason: StandardResolutionReasons.DEFAULT,
+                flagMetadata: {},
+            })
+        })
+    })
+
+    describe('String Flags', () => {
+        let openFeatureClient: Client
+        beforeEach(async () => {
+            const { ofClient } = await initOFClient()
+            openFeatureClient = ofClient
+
+            variableMock.mockReturnValue({
+                key: 'string-flag',
+                value: 'string-value',
+                defaultValue: 'string-default',
+                isDefaulted: false,
+                evalReason: undefined,
+                onUpdate: jest.fn(),
+            })
+        })
+
+        it('should resolve a string flag value', async () => {
+            expect(
+                openFeatureClient.getStringValue(
+                    'string-flag',
+                    'string-default',
+                ),
+            ).toEqual('string-value')
+        })
+
+        it('should resolve a string flag details', async () => {
+            expect(
+                openFeatureClient.getStringDetails(
+                    'string-flag',
+                    'string-default',
+                ),
+            ).toEqual({
+                flagKey: 'string-flag',
+                value: 'string-value',
+                reason: StandardResolutionReasons.TARGETING_MATCH,
+                flagMetadata: {},
+            })
+        })
+    })
+
+    describe('Number Flags', () => {
+        let openFeatureClient: Client
+        beforeEach(async () => {
+            const { ofClient } = await initOFClient()
+            openFeatureClient = ofClient
+
+            variableMock.mockReturnValue({
+                key: 'num-flag',
+                value: 610,
+                defaultValue: 2056,
+                isDefaulted: false,
+                evalReason: undefined,
+                onUpdate: jest.fn(),
+            })
+        })
+
+        it('should resolve a number flag value', async () => {
+            expect(openFeatureClient.getNumberValue('num-flag', 2056)).toEqual(
+                610,
+            )
+        })
+
+        it('should resolve a number flag details', async () => {
+            expect(
+                openFeatureClient.getNumberDetails('num-flag', 2056),
+            ).toEqual({
+                flagKey: 'num-flag',
+                value: 610,
+                reason: StandardResolutionReasons.TARGETING_MATCH,
+                flagMetadata: {},
+            })
+        })
+    })
+
+    describe('JSON Flags', () => {
+        let openFeatureClient: Client
+        beforeEach(async () => {
+            const { ofClient } = await initOFClient()
+            openFeatureClient = ofClient
+
+            variableMock.mockReturnValue({
+                key: 'json-flag',
+                value: { hello: 'world' },
+                defaultValue: { default: 'value' },
+                isDefaulted: false,
+                evalReason: undefined,
+                onUpdate: jest.fn(),
+            })
+        })
+
+        it('should resolve a json flag value', async () => {
+            expect(
+                openFeatureClient.getObjectValue('json-flag', {
+                    default: 'value',
+                }),
+            ).toEqual({ hello: 'world' })
+        })
+
+        it('should resolve a json flag details', async () => {
+            expect(
+                openFeatureClient.getObjectDetails('json-flag', {
+                    default: 'value',
+                }),
+            ).toEqual({
+                flagKey: 'json-flag',
+                value: { hello: 'world' },
+                reason: StandardResolutionReasons.TARGETING_MATCH,
+                flagMetadata: {},
+            })
+        })
+
+        it('should return default value if json default is not an object', async () => {
+            expect(
+                openFeatureClient.getObjectDetails('json-flag', ['arry']),
+            ).toEqual({
+                flagKey: 'json-flag',
+                value: ['arry'],
+                reason: 'ERROR',
+                errorCode: 'PARSE_ERROR',
+                errorMessage:
+                    'DevCycle only supports object values for JSON flags',
+                flagMetadata: {},
+            })
+            expect(
+                openFeatureClient.getObjectDetails('json-flag', 610),
+            ).toEqual({
+                flagKey: 'json-flag',
+                value: 610,
+                reason: 'ERROR',
+                errorCode: 'PARSE_ERROR',
+                errorMessage:
+                    'DevCycle only supports object values for JSON flags',
+                flagMetadata: {},
+            })
+            expect(
+                openFeatureClient.getObjectDetails('json-flag', 'string'),
+            ).toEqual({
+                flagKey: 'json-flag',
+                value: 'string',
+                reason: 'ERROR',
+                errorCode: 'PARSE_ERROR',
+                errorMessage:
+                    'DevCycle only supports object values for JSON flags',
+                flagMetadata: {},
+            })
+            expect(
+                openFeatureClient.getObjectDetails('json-flag', false),
+            ).toEqual({
+                flagKey: 'json-flag',
+                value: false,
+                reason: 'ERROR',
+                errorCode: 'PARSE_ERROR',
+                errorMessage:
+                    'DevCycle only supports object values for JSON flags',
+                flagMetadata: {},
+            })
+            expect(
+                openFeatureClient.getObjectDetails('json-flag', null),
+            ).toEqual({
+                flagKey: 'json-flag',
+                value: null,
+                reason: 'ERROR',
+                errorCode: 'PARSE_ERROR',
+                errorMessage:
+                    'DevCycle does not support null default values for JSON flags',
+                flagMetadata: {},
+            })
+        })
+    })
+
+    describe('Tracking Events', () => {
+        let trackMock: any
+        let openFeatureClient: Client
+        let provider: DevCycleReactProvider
+
+        beforeEach(async () => {
+            const init = await initOFClient()
+            openFeatureClient = init.ofClient
+            provider = init.provider
+
+            if (provider.devcycleClient) {
+                trackMock = jest
+                    .spyOn(provider.devcycleClient, 'track')
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    .mockResolvedValue()
+            }
+        })
+
+        afterEach(() => {
+            trackMock?.mockClear()
+        })
+
+        it('should track an event with just a name', () => {
+            openFeatureClient.track('event-name')
+
+            expect(trackMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'event-name',
+                }),
+            )
+        })
+
+        it('should track an event with value and metadata', () => {
+            openFeatureClient.track('event-name', {
+                value: 123,
+                someKey: 'someValue',
+                otherKey: true,
+            })
+
+            expect(trackMock).toHaveBeenCalledWith({
+                type: 'event-name',
+                value: 123,
+                metaData: {
+                    someKey: 'someValue',
+                    otherKey: true,
+                },
+            })
+        })
+
+        it('should track an event with just metadata', () => {
+            openFeatureClient.track('event-name', {
+                someKey: 'someValue',
+            })
+
+            expect(trackMock).toHaveBeenCalledWith({
+                type: 'event-name',
+                value: undefined,
+                metaData: {
+                    someKey: 'someValue',
+                },
+            })
+        })
+    })
+})

--- a/sdk/openfeature-react-provider/jest.config.ts
+++ b/sdk/openfeature-react-provider/jest.config.ts
@@ -1,0 +1,32 @@
+/* eslint-disable */
+export default {
+    displayName: 'openfeature-react-provider',
+    preset: '../../jest.preset.js',
+    globals: {},
+    transform: {
+        '^.+\\.[tj]s$': [
+            'ts-jest',
+            {
+                tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+        ],
+    },
+    moduleFileExtensions: ['ts', 'js'],
+    coverageDirectory: '../../coverage/sdk/openfeature-react-provider',
+    collectCoverage: true,
+    collectCoverageFrom: [
+        '<rootDir>/src/**/*.{ts,js}',
+        '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',
+    ],
+}
+
+module.exports.reporters = [
+    'default',
+    [
+        'jest-junit',
+        {
+            outputDirectory: 'test-results',
+            outputName: `${module.exports.displayName}.xml`,
+        },
+    ],
+]

--- a/sdk/openfeature-react-provider/package.json
+++ b/sdk/openfeature-react-provider/package.json
@@ -1,0 +1,47 @@
+{
+    "name": "@devcycle/openfeature-react-provider",
+    "version": "1.0.0",
+    "description": "OpenFeature React SDK Provider for DevCycle React SDK",
+    "license": "MIT",
+    "author": "DevCycle <support@devcycle.com>",
+    "keywords": [
+        "devcycle",
+        "feature flag",
+        "javascript",
+        "client",
+        "openfeature",
+        "web",
+        "react",
+        "sdk"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/DevCycleHQ/js-sdks.git"
+    },
+    "homepage": "https://devcycle.com",
+    "dependencies": {
+        "@devcycle/js-client-sdk": "^1.35.0",
+        "@devcycle/openfeature-web-provider": "^1.0.0"
+    },
+    "peerDependencies": {
+        "@openfeature/multi-provider-web": "^0.0.3",
+        "@openfeature/web-sdk": "^1.4.1"
+    },
+    "peerDependenciesMeta": {
+        "@openfeature/multi-provider-web": {
+            "optional": true
+        }
+    },
+    "exports": {
+        ".": {
+            "import": "./src/index.js",
+            "require": "./src/index.js",
+            "types": "./src/index.d.ts"
+        },
+        "./strategy": {
+            "import": "./strategy.js",
+            "require": "./strategy.js",
+            "types": "./strategy.d.ts"
+        }
+    }
+}

--- a/sdk/openfeature-react-provider/project.json
+++ b/sdk/openfeature-react-provider/project.json
@@ -1,0 +1,44 @@
+{
+    "name": "openfeature-react-provider",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "implicitDependencies": ["js"],
+    "targets": {
+        "build": {
+            "executor": "@nx/js:tsc",
+            "outputs": ["{options.outputPath}"],
+            "options": {
+                "outputPath": "dist/sdk/openfeature-react-provider",
+                "tsConfig": "sdk/openfeature-react-provider/tsconfig.lib.json",
+                "packageJson": "sdk/openfeature-react-provider/package.json",
+                "main": "sdk/openfeature-react-provider/src/index.ts",
+                "assets": ["sdk/openfeature-react-provider/*.md"],
+                "external": ["js", "openfeature-web-provider"]
+            }
+        },
+        "lint": {
+            "executor": "@nx/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["sdk/openfeature-react-provider/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": [
+                "{workspaceRoot}/coverage/sdk/openfeature-react-provider"
+            ],
+            "options": {
+                "jestConfig": "sdk/openfeature-react-provider/jest.config.ts"
+            }
+        },
+        "npm-publish": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "../../../scripts/npm-safe-publish.sh \"@devcycle/openfeature-react-provider\"",
+                "cwd": "dist/sdk/openfeature-react-provider",
+                "forwardAllArgs": true
+            }
+        }
+    },
+    "tags": []
+}

--- a/sdk/openfeature-react-provider/src/index.ts
+++ b/sdk/openfeature-react-provider/src/index.ts
@@ -1,0 +1,9 @@
+import { DevCycleOptions } from '@devcycle/js-client-sdk'
+import DevCycleProvider from '@devcycle/openfeature-web-provider'
+
+export default class DevCycleReactProvider extends DevCycleProvider {
+    constructor(sdkKey: string, options: DevCycleOptions = {}) {
+        options.sdkPlatform = 'react-of'
+        super(sdkKey, options)
+    }
+}

--- a/sdk/openfeature-react-provider/strategy.ts
+++ b/sdk/openfeature-react-provider/strategy.ts
@@ -1,0 +1,1 @@
+export * from '@devcycle/openfeature-web-provider/strategy'

--- a/sdk/openfeature-react-provider/tsconfig.json
+++ b/sdk/openfeature-react-provider/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/sdk/openfeature-react-provider/tsconfig.lib.json
+++ b/sdk/openfeature-react-provider/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": ["node"]
+    },
+    "include": ["**/*.ts", "strategy.ts"],
+    "exclude": [
+        "jest.config.ts",
+        "**/*.spec.ts",
+        "**/*.test.ts",
+        "**/__mocks__/**/*.ts"
+    ]
+}

--- a/sdk/openfeature-react-provider/tsconfig.spec.json
+++ b/sdk/openfeature-react-provider/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "types": ["jest", "node"]
+    },
+    "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/sdk/openfeature-web-provider/README.md
+++ b/sdk/openfeature-web-provider/README.md
@@ -1,7 +1,6 @@
 # OpenFeature DevCycle Javascript Web Provider
 
-This library provides a Javascript implementation of the [OpenFeature](https://openfeature.dev/) Web Provider interface 
-for [DevCycle Javascript Client SDK](https://docs.devcycle.com/sdk/client-side-sdks/javascript/).
+This library provides a Javascript implementation of the [OpenFeature](https://openfeature.dev/) Web Provider interface for [DevCycle Javascript Client SDK](https://docs.devcycle.com/sdk/client-side-sdks/javascript/).
 
 ## Building
 
@@ -17,94 +16,4 @@ See the [example app](/dev-apps/openfeature-web) for a working example of the Op
 
 ## Usage
 
-See our [documentation](https://docs.devcycle.com/sdk/client-side-sdks/javascript/javascript-usage) for more information.
-
-```typescript
-import DevCycleProvider from '@devcycle/openfeature-web-provider'
-import { OpenFeature } from '@openfeature/web-sdk'
-
-... 
-
-const user = { user_id: 'user_id' }
-
-// Initialize the DevCycle Provider
-const devcycleProvider = new DevCycleProvider(DEVCYCLE_CLIENT_SDK_KEY)
-// Set the context before the provider is set to ensure the DevCycle SDK is initialized with a user context.
-await OpenFeature.setContext(user)
-// Set the DevCycleProvider for OpenFeature
-await OpenFeature.setProviderAndWait(devcycleProvider)
-// Get the OpenFeature client
-const openFeatureClient = OpenFeature.getClient()
-
-// Retrieve a boolean flag from the OpenFeature client
-const boolFlag = openFeatureClient.getBooleanValue('boolean-flag', false)
-```
-
-#### Passing DVCOptions to the DevCycleProvider
-
-Ensure that you pass any custom DVCOptions to the DevCycleProvider constructor
-
-```typescript
-const options = { logger: dvcDefaultLogger({ level: 'debug' }) }
-await OpenFeature.setProviderAndWait(new DevCycleProvider(DEVCYCLE_CLIENT_SDK_KEY, options))
-```
-
-#### Required TargetingKey
-
-For DevCycle SDK to work we require either a `targetingKey` or `user_id` to be set on the OpenFeature context. 
-This is used to identify the user as the `user_id` for a `DVCUser` in DevCycle.
-
-#### Context properties to DVCUser
-
-The provider will automatically translate known `DVCUser` properties from the OpenFeature context to the `DVCUser` object.
-[DVCUser TypeScript Interface](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/nodejs/src/models/user.ts#L16)
-
-For example all these properties will be set on the `DVCUser`:
-```typescript
-await OpenFeature.setContext({
-    user_id: 'user_id',
-    email: 'email@devcycle.com',
-    name: 'name',
-    language: 'en',
-    country: 'CA',
-    appVersion: '1.0.11',
-    appBuild: 1000,
-    customData: { custom: 'data' },
-    privateCustomData: { private: 'data' }
-})
-```
-
-Context properties that are not known `DVCUser` properties will be automatically 
-added to the `customData` property of the `DVCUser`.
-
-#### Context Limitations
-
-DevCycle only supports flat JSON Object properties used in the Context. Non-flat properties will be ignored.
-
-For example `obj` will be ignored: 
-```typescript
-await OpenFeature.setContext({
-    user_id: 'user_id',
-    obj: { key: 'value' }
-})
-```
-
-#### JSON Flag Limitations
-
-The OpenFeature spec for JSON flags allows for any type of valid JSON value to be set as the flag value.
-
-For example the following are all valid default value types to use with OpenFeature:
-```typescript
-// Invalid JSON values for the DevCycle SDK, will return defaults
-openFeatureClient.getObjectValue('json-flag', ['arry'])
-openFeatureClient.getObjectValue('json-flag', 610)
-openFeatureClient.getObjectValue('json-flag', false)
-openFeatureClient.getObjectValue('json-flag', 'string')
-openFeatureClient.getObjectValue('json-flag', null)
-```
-
-However, these are not valid types for the DevCycle SDK, the DevCycle SDK only supports JSON Objects:
-```typescript
-// Valid JSON Object as the default value, will be evaluated by the DevCycle SDK
-openFeatureClient.getObjectValue('json-flag', { default: 'value' })
-```
+See our [documentation](https://docs.devcycle.com/sdk/client-side-sdks/javascript/javascript-openfeature) for more information.

--- a/sdk/openfeature-web-provider/package.json
+++ b/sdk/openfeature-web-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@devcycle/openfeature-web-provider",
-    "version": "0.21.0",
+    "version": "1.0.0",
     "description": "OpenFeature Web SDK Provider for DevCycle JS SDK",
     "license": "MIT",
     "author": "DevCycle <support@devcycle.com>",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -48,6 +48,12 @@
             "@devcycle/openfeature-web-provider/strategy": [
                 "sdk/openfeature-web-provider/strategy.ts"
             ],
+            "@devcycle/openfeature-react-provider": [
+                "sdk/openfeature-react-provider/src/index.ts"
+            ],
+            "@devcycle/openfeature-react-provider/strategy": [
+                "sdk/openfeature-react-provider/strategy.ts"
+            ],
             "@devcycle/react-client-sdk": ["sdk/react/src/index.ts"],
             "@devcycle/react-native-client-sdk": [
                 "sdk/react-native/src/index.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,13 +4741,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@devcycle/openfeature-react-provider@workspace:sdk/openfeature-react-provider":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/openfeature-react-provider@workspace:sdk/openfeature-react-provider"
+  dependencies:
+    "@devcycle/js-client-sdk": ^1.35.0
+    "@devcycle/openfeature-web-provider": ^1.0.0
+  peerDependencies:
+    "@openfeature/multi-provider-web": ^0.0.3
+    "@openfeature/web-sdk": ^1.4.1
+  peerDependenciesMeta:
+    "@openfeature/multi-provider-web":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
 "@devcycle/openfeature-web-example@workspace:dev-apps/openfeature-web":
   version: 0.0.0-use.local
   resolution: "@devcycle/openfeature-web-example@workspace:dev-apps/openfeature-web"
   languageName: unknown
   linkType: soft
 
-"@devcycle/openfeature-web-provider@workspace:sdk/openfeature-web-provider":
+"@devcycle/openfeature-web-provider@^1.0.0, @devcycle/openfeature-web-provider@workspace:sdk/openfeature-web-provider":
   version: 0.0.0-use.local
   resolution: "@devcycle/openfeature-web-provider@workspace:sdk/openfeature-web-provider"
   dependencies:


### PR DESCRIPTION
- create new @devcycle/openfeature-react-provider 1.0.0 package to track usage of Devcycle with the React OpenFeature SDK
- update @devcycle/openfeature-web-provider to 1.0.0
- cleanup README.md files

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
