### PR TITLE
feat: change OpenFeature imports and DevCycleProvider interface

### DIFF
--- a/dev-apps/openfeature-nodejs/src/main.ts
+++ b/dev-apps/openfeature-nodejs/src/main.ts
@@ -65,7 +65,7 @@ async function startDevCycle() {
         ...context,
         user_id: context.targetingKey,
     }
-    const allFeatures = await provider.devcycleClient.allFeatures(dvcUser)
+    const allFeatures = provider.devcycleClient.allFeatures(dvcUser)
     console.log(`All Features: ${JSON.stringify(allFeatures)}`)
 }
 

--- a/dev-apps/openfeature-nodejs/src/main.ts
+++ b/dev-apps/openfeature-nodejs/src/main.ts
@@ -1,5 +1,5 @@
 import { OpenFeature, Client } from '@openfeature/server-sdk'
-import { initializeDevCycle } from '@devcycle/nodejs-server-sdk'
+import { DevCycleProvider } from '@devcycle/nodejs-server-sdk'
 
 const DEVCYCLE_SERVER_SDK_KEY =
     process.env['DEVCYCLE_SERVER_SDK_KEY'] || '<DEVCYCLE_SERVER_SDK_KEY>'
@@ -7,9 +7,10 @@ const DEVCYCLE_SERVER_SDK_KEY =
 let openFeatureClient: Client
 
 async function startDevCycle() {
-    await OpenFeature.setProviderAndWait(
-        initializeDevCycle(DEVCYCLE_SERVER_SDK_KEY).getOpenFeatureProvider(),
-    )
+    const provider = new DevCycleProvider(DEVCYCLE_SERVER_SDK_KEY, {
+        logLevel: 'debug',
+    })
+    await OpenFeature.setProviderAndWait(provider)
     openFeatureClient = OpenFeature.getClient()
 
     console.log('DevCycle OpenFeature client initialized')
@@ -59,6 +60,22 @@ async function startDevCycle() {
         metaDataFieldBoolean: true,
         metaDataFieldDouble: 1.23,
     })
+
+    const dvcUser = {
+        ...context,
+        user_id: context.targetingKey,
+    }
+    console.log(
+        `All Features: ${JSON.stringify(
+            provider.devcycleClient.allFeatures(dvcUser),
+        )}`,
+    )
+
+    console.log(
+        `All Variables: ${JSON.stringify(
+            provider.devcycleClient.allVariables(dvcUser),
+        )}`,
+    )
 }
 
 startDevCycle()

--- a/dev-apps/openfeature-nodejs/src/main.ts
+++ b/dev-apps/openfeature-nodejs/src/main.ts
@@ -8,9 +8,7 @@ let openFeatureClient: Client
 
 async function startDevCycle() {
     await OpenFeature.setProviderAndWait(
-        await initializeDevCycle(
-            DEVCYCLE_SERVER_SDK_KEY,
-        ).getOpenFeatureProvider(),
+        initializeDevCycle(DEVCYCLE_SERVER_SDK_KEY).getOpenFeatureProvider(),
     )
     openFeatureClient = OpenFeature.getClient()
 

--- a/dev-apps/openfeature-nodejs/src/main.ts
+++ b/dev-apps/openfeature-nodejs/src/main.ts
@@ -65,17 +65,8 @@ async function startDevCycle() {
         ...context,
         user_id: context.targetingKey,
     }
-    console.log(
-        `All Features: ${JSON.stringify(
-            provider.devcycleClient.allFeatures(dvcUser),
-        )}`,
-    )
-
-    console.log(
-        `All Variables: ${JSON.stringify(
-            provider.devcycleClient.allVariables(dvcUser),
-        )}`,
-    )
+    const allFeatures = await provider.devcycleClient.allFeatures(dvcUser)
+    console.log(`All Features: ${JSON.stringify(allFeatures)}`)
 }
 
 startDevCycle()

--- a/sdk/nodejs/__tests__/initialize.spec.ts
+++ b/sdk/nodejs/__tests__/initialize.spec.ts
@@ -17,9 +17,8 @@ describe('NodeJS SDK Initialize', () => {
     })
 
     it('successfully creates a OpenFeature provider - local', async () => {
-        const provider = await initializeDevCycle(
-            'dvc_server_token',
-        ).getOpenFeatureProvider()
+        const provider =
+            initializeDevCycle('dvc_server_token').getOpenFeatureProvider()
         expect(provider).toBeDefined()
         await OpenFeature.setProviderAndWait(provider)
         expect(provider.status).toBe('READY')
@@ -28,7 +27,7 @@ describe('NodeJS SDK Initialize', () => {
     })
 
     it('successfully creates a OpenFeature provider - cloud', async () => {
-        const provider = await initializeDevCycle('dvc_server_token', {
+        const provider = initializeDevCycle('dvc_server_token', {
             enableCloudBucketing: true,
         }).getOpenFeatureProvider()
         expect(provider).toBeDefined()

--- a/sdk/nodejs/__tests__/initialize.spec.ts
+++ b/sdk/nodejs/__tests__/initialize.spec.ts
@@ -1,4 +1,8 @@
-import { DevCycleCloudClient, initializeDevCycle } from '../src/index'
+import {
+    DevCycleCloudClient,
+    DevCycleProvider,
+    initializeDevCycle,
+} from '../src/index'
 import { OpenFeature } from '@openfeature/server-sdk'
 
 jest.mock('../src/bucketing')
@@ -16,9 +20,10 @@ describe('NodeJS SDK Initialize', () => {
         expect(client).toBeDefined()
     })
 
-    it('successfully creates a OpenFeature provider - local', async () => {
-        const provider =
-            initializeDevCycle('dvc_server_token').getOpenFeatureProvider()
+    it('successfully creates a OpenFeature provider from dvcClient - local', async () => {
+        const provider = await initializeDevCycle(
+            'dvc_server_token',
+        ).getOpenFeatureProvider()
         expect(provider).toBeDefined()
         await OpenFeature.setProviderAndWait(provider)
         expect(provider.status).toBe('READY')
@@ -26,11 +31,30 @@ describe('NodeJS SDK Initialize', () => {
         expect(client).toBeDefined()
     })
 
-    it('successfully creates a OpenFeature provider - cloud', async () => {
-        const provider = initializeDevCycle('dvc_server_token', {
+    it('successfully creates a OpenFeature provider - local', async () => {
+        const provider = new DevCycleProvider('dvc_server_token')
+        await OpenFeature.setProviderAndWait(provider)
+        expect(provider.status).toBe('READY')
+        const client = OpenFeature.getClient()
+        expect(client).toBeDefined()
+    })
+
+    it('successfully creates a OpenFeature provider from dvcClient - cloud', async () => {
+        const provider = await initializeDevCycle('dvc_server_token', {
             enableCloudBucketing: true,
         }).getOpenFeatureProvider()
         expect(provider).toBeDefined()
+        expect(provider.status).toBe('READY') // onIntialized() is always true for cloud
+        await OpenFeature.setProviderAndWait(provider)
+        expect(provider.status).toBe('READY')
+        const client = OpenFeature.getClient()
+        expect(client).toBeDefined()
+    })
+
+    it('successfully creates a OpenFeature provider - cloud', async () => {
+        const provider = new DevCycleProvider('dvc_server_token', {
+            enableCloudBucketing: true,
+        })
         expect(provider.status).toBe('READY') // onIntialized() is always true for cloud
         await OpenFeature.setProviderAndWait(provider)
         expect(provider.status).toBe('READY')

--- a/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
+++ b/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
@@ -58,7 +58,7 @@ describe.each(['DevCycleClient', 'DevCycleCloudClient'])(
                           },
                       )
             await OpenFeature.setProviderAndWait(
-                await dvcClient.getOpenFeatureProvider(),
+                dvcClient.getOpenFeatureProvider(),
             )
             const ofClient = OpenFeature.getClient()
             ofClient.setContext({ targetingKey: 'node_sdk_test' })

--- a/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
+++ b/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
@@ -58,7 +58,7 @@ describe.each(['DevCycleClient', 'DevCycleCloudClient'])(
                           },
                       )
             await OpenFeature.setProviderAndWait(
-                dvcClient.getOpenFeatureProvider(),
+                await dvcClient.getOpenFeatureProvider(),
             )
             const ofClient = OpenFeature.getClient()
             ofClient.setContext({ targetingKey: 'node_sdk_test' })

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -23,13 +23,13 @@
         "@devcycle/bucketing-assembly-script": "^1.31.2",
         "@devcycle/js-cloud-server-sdk": "^1.21.2",
         "@devcycle/types": "^1.22.2",
+        "@openfeature/server-sdk": "^1.17.1",
         "cross-fetch": "^4.0.0",
         "eventsource": "^2.0.2",
         "fetch-retry": "^5.0.6"
     },
     "peerDependencies": {
-        "@openfeature/multi-provider": "^0.1.2",
-        "@openfeature/server-sdk": "^1.17.1"
+        "@openfeature/multi-provider": "^0.1.2"
     },
     "peerDependenciesMeta": {
         "@openfeature/multi-provider": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -23,6 +23,7 @@
         "@devcycle/bucketing-assembly-script": "^1.31.2",
         "@devcycle/js-cloud-server-sdk": "^1.21.2",
         "@devcycle/types": "^1.22.2",
+        "@openfeature/core": "^1.7.2",
         "@openfeature/server-sdk": "^1.17.1",
         "cross-fetch": "^4.0.0",
         "eventsource": "^2.0.2",

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -178,7 +178,7 @@ export class DevCycleClient<
         })
     }
 
-    getOpenFeatureProvider(): DevCycleProvider {
+    async getOpenFeatureProvider(): Promise<DevCycleProvider> {
         if (this.openFeatureProvider) return this.openFeatureProvider
 
         this.openFeatureProvider = new DevCycleProvider(this, {

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -33,7 +33,7 @@ class DevCycleCloudClient<
         super(sdkKey, options, platformDetails)
     }
 
-    getOpenFeatureProvider(): DevCycleProvider {
+    async getOpenFeatureProvider(): Promise<DevCycleProvider> {
         if (this.openFeatureProvider) return this.openFeatureProvider
 
         this.openFeatureProvider = new DevCycleProvider(this, {
@@ -45,6 +45,7 @@ class DevCycleCloudClient<
 }
 
 export {
+    DevCycleProvider,
     DevCycleClient,
     DevCycleCloudClient,
     DevCycleUser,
@@ -89,7 +90,7 @@ export { ConfigSource }
 
 export { UserError } from '@devcycle/types'
 
-type DevCycleOptionsCloudEnabled = DevCycleServerSDKOptions & {
+export type DevCycleOptionsCloudEnabled = DevCycleServerSDKOptions & {
     enableCloudBucketing: true
 }
 

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -18,11 +18,7 @@ import {
 } from '@devcycle/js-cloud-server-sdk'
 import { DevCycleServerSDKOptions, VariableDefinitions } from '@devcycle/types'
 import { getNodeJSPlatformDetails } from './utils/platformDetails'
-
-// Dynamically import the OpenFeature Provider, as it's an optional peer dependency
-type DevCycleProviderConstructor =
-    typeof import('./open-feature/DevCycleProvider').DevCycleProvider
-type DevCycleProvider = InstanceType<DevCycleProviderConstructor>
+import { DevCycleProvider } from './open-feature/DevCycleProvider'
 
 class DevCycleCloudClient<
     Variables extends VariableDefinitions = VariableDefinitions,
@@ -37,24 +33,10 @@ class DevCycleCloudClient<
         super(sdkKey, options, platformDetails)
     }
 
-    async getOpenFeatureProvider(): Promise<DevCycleProvider> {
-        let DevCycleProviderClass
-
-        try {
-            const importedModule = await import(
-                './open-feature/DevCycleProvider.js'
-            )
-            DevCycleProviderClass = importedModule.DevCycleProvider
-        } catch (error) {
-            throw new Error(
-                'Missing "@openfeature/server-sdk" and/or "@openfeature/core" ' +
-                    'peer dependencies to get OpenFeature Provider',
-            )
-        }
-
+    getOpenFeatureProvider(): DevCycleProvider {
         if (this.openFeatureProvider) return this.openFeatureProvider
 
-        this.openFeatureProvider = new DevCycleProviderClass(this, {
+        this.openFeatureProvider = new DevCycleProvider(this, {
             logger: this.logger,
         })
         this.platformDetails.sdkPlatform = 'nodejs-of'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4723,6 +4723,7 @@ __metadata:
     "@devcycle/bucketing-assembly-script": ^1.31.2
     "@devcycle/js-cloud-server-sdk": ^1.21.2
     "@devcycle/types": ^1.22.2
+    "@openfeature/server-sdk": ^1.17.1
     cross-fetch: ^4.0.0
     eventsource: ^2.0.2
     fetch-retry: ^5.0.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -4723,6 +4723,7 @@ __metadata:
     "@devcycle/bucketing-assembly-script": ^1.31.2
     "@devcycle/js-cloud-server-sdk": ^1.21.2
     "@devcycle/types": ^1.22.2
+    "@openfeature/core": ^1.7.2
     "@openfeature/server-sdk": ^1.17.1
     cross-fetch: ^4.0.0
     eventsource: ^2.0.2
@@ -8424,6 +8425,13 @@ __metadata:
   version: 1.7.0
   resolution: "@openfeature/core@npm:1.7.0"
   checksum: 9cf14c65d10a7e982cfe65c095891d61176e3b2f34cc5dbd017959d7cfdb80e41148332f1ee285bf681d0eeb5b511aee24096ae88f0a72334173b0ff8d891797
+  languageName: node
+  linkType: hard
+
+"@openfeature/core@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@openfeature/core@npm:1.7.2"
+  checksum: 8d367403a39740efd2be6bf49615fcf898d7d7f225affc497322e6004c3372b837650bab6a495b6c8b40dc822ae8965e04f4c009a997fa228b13e7bd3ae4b17e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,7 +4729,6 @@ __metadata:
     fetch-retry: ^5.0.6
   peerDependencies:
     "@openfeature/multi-provider": ^0.1.2
-    "@openfeature/server-sdk": ^1.17.1
   peerDependenciesMeta:
     "@openfeature/multi-provider":
       optional: true


### PR DESCRIPTION
- Change OpenFeature imports from a dynamic import (which has always caused us problems), to a straight require.
- This is a bit of a reversion to the old way we had it setup, and will require all SDK users using Yarn to add the OpenFeature packages.
- But this will mean that all SDKs will come with OpenFeature setup (good thing!), and the `getOpenFeatureProvider()` method no longer needs to be `async` which was causing complications with SDKs like NestJS.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
