### PR TITLE
feat: create @devcycle/openfeature-nestjs-provider to set sdkPlatform metadata

### DIFF
--- a/lib/shared/types/src/types/apis/sdk/serverSDKTypes.ts
+++ b/lib/shared/types/src/types/apis/sdk/serverSDKTypes.ts
@@ -110,4 +110,10 @@ export interface DevCycleServerSDKOptions {
      * @min 60000
      */
     sseConfigPollingIntervalMS?: number
+
+    /**
+     * The platform the SDK is running in. This is used for logging purposes.
+     * Example values ('of' for OpenFeature): 'nodejs' | 'nodejs-of' | 'nestjs' | 'nestjs-of'
+     */
+    sdkPlatform?: string
 }

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -63,6 +63,7 @@ export class DevCycleClient<
     private bucketingTracker?: NodeJS.Timer
     private bucketingImportPromise: Promise<void>
     private platformDetails: DevCyclePlatformDetails
+    private sdkPlatform?: string
 
     get isInitialized(): boolean {
         return this._isInitialized
@@ -72,6 +73,7 @@ export class DevCycleClient<
         this.clientUUID = randomUUID()
         this.hostname = os.hostname()
         this.sdkKey = sdkKey
+        this.sdkPlatform = options?.sdkPlatform
 
         this.logger =
             options?.logger || dvcDefaultLogger({ level: options?.logLevel })
@@ -161,8 +163,8 @@ export class DevCycleClient<
         if (!this.bucketingLib) return
 
         this.platformDetails = getNodeJSPlatformDetails()
-        if (this.openFeatureProvider) {
-            this.platformDetails.sdkPlatform = 'nodejs-of'
+        if (this.sdkPlatform || this.openFeatureProvider) {
+            this.platformDetails.sdkPlatform = this.sdkPlatform ?? 'nodejs-of'
         }
         this.bucketingLib.setPlatformData(JSON.stringify(this.platformDetails))
     }

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -24,6 +24,7 @@ class DevCycleCloudClient<
     Variables extends VariableDefinitions = VariableDefinitions,
 > extends InternalDevCycleCloudClient<Variables> {
     private openFeatureProvider: DevCycleProvider
+    private sdkPlatform?: string
 
     constructor(
         sdkKey: string,
@@ -31,6 +32,7 @@ class DevCycleCloudClient<
         platformDetails: DevCyclePlatformDetails,
     ) {
         super(sdkKey, options, platformDetails)
+        this.sdkPlatform = options.sdkPlatform
     }
 
     async getOpenFeatureProvider(): Promise<DevCycleProvider> {
@@ -39,7 +41,7 @@ class DevCycleCloudClient<
         this.openFeatureProvider = new DevCycleProvider(this, {
             logger: this.logger,
         })
-        this.platformDetails.sdkPlatform = 'nodejs-of'
+        this.platformDetails.sdkPlatform = this.sdkPlatform ?? 'nodejs-of'
         return this.openFeatureProvider
     }
 }

--- a/sdk/openfeature-nestjs-provider/.babelrc
+++ b/sdk/openfeature-nestjs-provider/.babelrc
@@ -1,0 +1,10 @@
+{
+    "presets": [
+        [
+            "@nx/js/babel",
+            {
+                "useBuiltIns": "usage"
+            }
+        ]
+    ]
+}

--- a/sdk/openfeature-nestjs-provider/.eslintrc.json
+++ b/sdk/openfeature-nestjs-provider/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*", "node_modules/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/sdk/openfeature-nestjs-provider/README.md
+++ b/sdk/openfeature-nestjs-provider/README.md
@@ -1,0 +1,15 @@
+# OpenFeature NestJS SDK DevCycle Provider
+
+This library provides a DevCycle OpenFeature Provider for the [OpenFeature NestJS SDK](https://openfeature.dev/docs/reference/technologies/server/javascript/nestjs).
+
+## Building
+
+Run `yarn nx build openfeature-nestjs-provider` to build the library.
+
+## Running Unit Tests
+
+Run `yarn nx test openfeature-nestjs-provider` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Usage
+
+See our [documentation](https://docs.devcycle.com/sdk/server-side-sdks/nestjs/nextjs-openfeature) for more information.

--- a/sdk/openfeature-nestjs-provider/jest.config.ts
+++ b/sdk/openfeature-nestjs-provider/jest.config.ts
@@ -1,0 +1,32 @@
+/* eslint-disable */
+export default {
+    displayName: 'openfeature-nestjs-provider',
+    preset: '../../jest.preset.js',
+    globals: {},
+    transform: {
+        '^.+\\.[tj]s$': [
+            'ts-jest',
+            {
+                tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+        ],
+    },
+    moduleFileExtensions: ['ts', 'js'],
+    coverageDirectory: '../../coverage/sdk/openfeature-nestjs-provider',
+    collectCoverage: true,
+    collectCoverageFrom: [
+        '<rootDir>/src/**/*.{ts,js}',
+        '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',
+    ],
+}
+
+module.exports.reporters = [
+    'default',
+    [
+        'jest-junit',
+        {
+            outputDirectory: 'test-results',
+            outputName: `${module.exports.displayName}.xml`,
+        },
+    ],
+]

--- a/sdk/openfeature-nestjs-provider/package.json
+++ b/sdk/openfeature-nestjs-provider/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@devcycle/openfeature-nestjs-provider",
+    "version": "1.0.0",
+    "description": "OpenFeature NestJS SDK Provider",
+    "license": "MIT",
+    "author": "DevCycle <support@devcycle.com>",
+    "keywords": [
+        "devcycle",
+        "feature flag",
+        "javascript",
+        "server",
+        "openfeature",
+        "nestjs",
+        "sdk"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/DevCycleHQ/js-sdks.git"
+    },
+    "homepage": "https://devcycle.com",
+    "dependencies": {
+        "@devcycle/nodejs-server-sdk": "^1.41.2"
+    },
+    "exports": {
+        ".": {
+            "import": "./src/index.js",
+            "require": "./src/index.js",
+            "types": "./src/index.d.ts"
+        }
+    }
+}

--- a/sdk/openfeature-nestjs-provider/project.json
+++ b/sdk/openfeature-nestjs-provider/project.json
@@ -1,0 +1,45 @@
+{
+    "name": "openfeature-nestjs-provider",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "implicitDependencies": ["js"],
+    "targets": {
+        "build": {
+            "executor": "@nx/js:tsc",
+            "outputs": ["{options.outputPath}"],
+            "options": {
+                "outputPath": "dist/sdk/openfeature-nestjs-provider",
+                "tsConfig": "sdk/openfeature-nestjs-provider/tsconfig.lib.json",
+                "packageJson": "sdk/openfeature-nestjs-provider/package.json",
+                "main": "sdk/openfeature-nestjs-provider/src/index.ts",
+                "assets": ["sdk/openfeature-nestjs-provider/*.md"],
+                "external": ["js", "openfeature-web-provider"]
+            }
+        },
+        "lint": {
+            "executor": "@nx/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["sdk/openfeature-nestjs-provider/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": [
+                "{workspaceRoot}/coverage/sdk/openfeature-nestjs-provider"
+            ],
+            "options": {
+                "jestConfig": "sdk/openfeature-nestjs-provider/jest.config.ts",
+                "passWithNoTests": true
+            }
+        },
+        "npm-publish": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "../../../scripts/npm-safe-publish.sh \"@devcycle/openfeature-nestjs-provider\"",
+                "cwd": "dist/sdk/openfeature-nestjs-provider",
+                "forwardAllArgs": true
+            }
+        }
+    },
+    "tags": []
+}

--- a/sdk/openfeature-nestjs-provider/src/index.ts
+++ b/sdk/openfeature-nestjs-provider/src/index.ts
@@ -1,0 +1,21 @@
+import { DevCycleServerSDKOptions, VariableDefinitions } from '@devcycle/types'
+import {
+    initializeDevCycle as originalInitialize,
+    DevCycleClient,
+    DevCycleCloudClient,
+} from '@devcycle/nodejs-server-sdk'
+
+// Re-export everything from the nodejs-server-sdk
+export * from '@devcycle/nodejs-server-sdk'
+
+/**
+ * Initialize DevCycle with NestJS-specific platform settings
+ */
+export function initializeDevCycle<
+    Variables extends VariableDefinitions = VariableDefinitions,
+>(
+    sdkKey: string,
+    options: DevCycleServerSDKOptions = {},
+): DevCycleClient<Variables> | DevCycleCloudClient<Variables> {
+    return originalInitialize(sdkKey, { ...options, sdkPlatform: 'nestjs-of' })
+}

--- a/sdk/openfeature-nestjs-provider/tsconfig.json
+++ b/sdk/openfeature-nestjs-provider/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/sdk/openfeature-nestjs-provider/tsconfig.lib.json
+++ b/sdk/openfeature-nestjs-provider/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": ["node"]
+    },
+    "include": ["**/*.ts", "strategy.ts"],
+    "exclude": [
+        "jest.config.ts",
+        "**/*.spec.ts",
+        "**/*.test.ts",
+        "**/__mocks__/**/*.ts"
+    ]
+}

--- a/sdk/openfeature-nestjs-provider/tsconfig.spec.json
+++ b/sdk/openfeature-nestjs-provider/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "types": ["jest", "node"]
+    },
+    "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4751,6 +4751,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@devcycle/openfeature-nestjs-provider@workspace:sdk/openfeature-nestjs-provider":
+  version: 0.0.0-use.local
+  resolution: "@devcycle/openfeature-nestjs-provider@workspace:sdk/openfeature-nestjs-provider"
+  dependencies:
+    "@devcycle/nodejs-server-sdk": ^1.41.2
+  languageName: unknown
+  linkType: soft
+
 "@devcycle/openfeature-nodejs-example@workspace:dev-apps/openfeature-nodejs":
   version: 0.0.0-use.local
   resolution: "@devcycle/openfeature-nodejs-example@workspace:dev-apps/openfeature-nodejs"


### PR DESCRIPTION
- Create new `@devcycle/openfeature-nestjs-provider` package to set `sdkPlatform` when using OpenFeatures NestJS SDK with DevCycle.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
