### PR TITLE
chore: cleanup OF providers builds

### DIFF
--- a/sdk/openfeature-angular-provider/project.json
+++ b/sdk/openfeature-angular-provider/project.json
@@ -11,8 +11,7 @@
                 "tsConfig": "sdk/openfeature-angular-provider/tsconfig.lib.json",
                 "packageJson": "sdk/openfeature-angular-provider/package.json",
                 "main": "sdk/openfeature-angular-provider/src/index.ts",
-                "assets": ["sdk/openfeature-angular-provider/*.md"],
-                "external": ["js", "openfeature-web-provider"]
+                "assets": ["sdk/openfeature-angular-provider/*.md"]
             }
         },
         "lint": {

--- a/sdk/openfeature-react-provider/project.json
+++ b/sdk/openfeature-react-provider/project.json
@@ -11,8 +11,7 @@
                 "tsConfig": "sdk/openfeature-react-provider/tsconfig.lib.json",
                 "packageJson": "sdk/openfeature-react-provider/package.json",
                 "main": "sdk/openfeature-react-provider/src/index.ts",
-                "assets": ["sdk/openfeature-react-provider/*.md"],
-                "external": ["js", "openfeature-web-provider"]
+                "assets": ["sdk/openfeature-react-provider/*.md"]
             }
         },
         "lint": {

--- a/sdk/openfeature-web-provider/project.json
+++ b/sdk/openfeature-web-provider/project.json
@@ -11,8 +11,7 @@
                 "tsConfig": "sdk/openfeature-web-provider/tsconfig.lib.json",
                 "packageJson": "sdk/openfeature-web-provider/package.json",
                 "main": "sdk/openfeature-web-provider/src/index.ts",
-                "assets": ["sdk/openfeature-web-provider/*.md"],
-                "external": ["js"]
+                "assets": ["sdk/openfeature-web-provider/*.md"]
             }
         },
         "lint": {


### PR DESCRIPTION
- remove externals options, which was forcing shared-types to be bundled


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
