### PR TITLE
feat: update the nestJS OF provider to use the new DevCycleProvider to set the sdkPlatform

### DIFF
--- a/sdk/openfeature-nestjs-provider/src/index.ts
+++ b/sdk/openfeature-nestjs-provider/src/index.ts
@@ -1,21 +1,26 @@
-import { DevCycleServerSDKOptions, VariableDefinitions } from '@devcycle/types'
 import {
-    initializeDevCycle as originalInitialize,
-    DevCycleClient,
-    DevCycleCloudClient,
+    DevCycleOptionsLocalEnabled,
+    DevCycleOptionsCloudEnabled,
+    DevCycleProvider,
 } from '@devcycle/nodejs-server-sdk'
 
 // Re-export everything from the nodejs-server-sdk
 export * from '@devcycle/nodejs-server-sdk'
 
-/**
- * Initialize DevCycle with NestJS-specific platform settings
- */
-export function initializeDevCycle<
-    Variables extends VariableDefinitions = VariableDefinitions,
->(
-    sdkKey: string,
-    options: DevCycleServerSDKOptions = {},
-): DevCycleClient<Variables> | DevCycleCloudClient<Variables> {
-    return originalInitialize(sdkKey, { ...options, sdkPlatform: 'nestjs-of' })
+export class DevCycleNestJSProvider extends DevCycleProvider {
+    constructor(
+        sdkKey: string,
+        options: DevCycleOptionsLocalEnabled | DevCycleOptionsCloudEnabled = {},
+    ) {
+        const updatedOptions = {
+            ...options,
+            sdkPlatform: 'nestjs-of',
+        }
+
+        if (options.enableCloudBucketing === true) {
+            super(sdkKey, { ...updatedOptions, enableCloudBucketing: true })
+        } else {
+            super(sdkKey, { ...updatedOptions, enableCloudBucketing: false })
+        }
+    }
 }

--- a/sdk/openfeature-nestjs-provider/src/index.ts
+++ b/sdk/openfeature-nestjs-provider/src/index.ts
@@ -7,6 +7,12 @@ import {
 // Re-export everything from the nodejs-server-sdk
 export * from '@devcycle/nodejs-server-sdk'
 
+function isCloudEnabled(
+    options: DevCycleOptionsLocalEnabled | DevCycleOptionsCloudEnabled,
+): options is DevCycleOptionsCloudEnabled {
+    return options.enableCloudBucketing === true
+}
+
 export class DevCycleNestJSProvider extends DevCycleProvider {
     constructor(
         sdkKey: string,
@@ -17,10 +23,10 @@ export class DevCycleNestJSProvider extends DevCycleProvider {
             sdkPlatform: 'nestjs-of',
         }
 
-        if (options.enableCloudBucketing === true) {
-            super(sdkKey, { ...updatedOptions, enableCloudBucketing: true })
+        if (isCloudEnabled(updatedOptions)) {
+            super(sdkKey, updatedOptions)
         } else {
-            super(sdkKey, { ...updatedOptions, enableCloudBucketing: false })
+            super(sdkKey, updatedOptions)
         }
     }
 }


### PR DESCRIPTION
- update the nestJS OF provider to use the new DevCycleProvider to set the sdkPlatform

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
