### PR TITLE
chore: add missing tsconfig.base refrences

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -54,6 +54,15 @@
             "@devcycle/openfeature-react-provider/strategy": [
                 "sdk/openfeature-react-provider/strategy.ts"
             ],
+            "@devcycle/openfeature-angular-provider": [
+                "sdk/openfeature-angular-provider/src/index.ts"
+            ],
+            "@devcycle/openfeature-angular-provider/strategy": [
+                "sdk/openfeature-angular-provider/strategy.ts"
+            ],
+            "@devcycle/openfeature-nestjs-provider": [
+                "sdk/openfeature-nestjs-provider/src/index.ts"
+            ],
             "@devcycle/react-client-sdk": ["sdk/react/src/index.ts"],
             "@devcycle/react-native-client-sdk": [
                 "sdk/react-native/src/index.ts"


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
