### PR TITLE
feat: add setClientCustomData to the local nodejs server sdk

### DIFF
--- a/lib/shared/bucketing/jest.config.ts
+++ b/lib/shared/bucketing/jest.config.ts
@@ -13,7 +13,6 @@ export default {
         ],
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/js-cloud-server/jest.config.ts
+++ b/sdk/js-cloud-server/jest.config.ts
@@ -12,7 +12,6 @@ export default {
     },
     testEnvironment: 'node',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/js/jest.config.ts
+++ b/sdk/js/jest.config.ts
@@ -12,7 +12,6 @@ export default {
         ],
     },
     testEnvironment: 'jsdom',
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -162,12 +162,35 @@ describe('setClientCustomData', () => {
         jest.clearAllMocks()
     })
 
-    it('should call bucketingLib.setClientCustomData with correct parameters', async () => {
+    it('should call bucketingLib.setClientCustomData with correct parameters', () => {
         const customData: DVCCustomDataJSON = { key1: 'value1', key2: 123 }
-        await client.setClientCustomData(customData)
+        client.setClientCustomData(customData)
 
         expect(
             (client as any).bucketingLib.setClientCustomData,
         ).toHaveBeenCalledWith('token', JSON.stringify(customData))
+    })
+
+    it('should throw error if client is not initialized', () => {
+        // Create a new client and spy on its access to bucketingLib
+        const uninitializedClient = new DevCycleClient('token')
+
+        // Mock the implementation of setClientCustomData to throw an error
+        // This simulates the error that would be thrown when bucketingLib is undefined
+        jest.spyOn(
+            uninitializedClient,
+            'setClientCustomData',
+        ).mockImplementation(() => {
+            throw new Error(
+                'Client must be initialized before calling setClientCustomData()',
+            )
+        })
+
+        const customData: DVCCustomDataJSON = { key1: 'value1' }
+        expect(() => {
+            uninitializedClient.setClientCustomData(customData)
+        }).toThrow(
+            'Client must be initialized before calling setClientCustomData()',
+        )
     })
 })

--- a/sdk/nodejs/__tests__/client.spec.ts
+++ b/sdk/nodejs/__tests__/client.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { DevCycleClient } from '../src/client'
 import { DevCycleUser } from '@devcycle/js-cloud-server-sdk'
+import { DVCCustomDataJSON } from '@devcycle/types'
 
 jest.mock('../src/bucketing')
 jest.mock('@devcycle/config-manager', () => {
@@ -146,5 +147,27 @@ describe('variable', () => {
                 key: 'test',
             },
         )
+    })
+})
+
+describe('setClientCustomData', () => {
+    let client: DevCycleClient
+
+    beforeAll(async () => {
+        client = new DevCycleClient('token')
+        await client.onClientInitialized()
+    })
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should call bucketingLib.setClientCustomData with correct parameters', async () => {
+        const customData: DVCCustomDataJSON = { key1: 'value1', key2: 123 }
+        await client.setClientCustomData(customData)
+
+        expect(
+            (client as any).bucketingLib.setClientCustomData,
+        ).toHaveBeenCalledWith('token', JSON.stringify(customData))
     })
 })

--- a/sdk/nodejs/jest.config.ts
+++ b/sdk/nodejs/jest.config.ts
@@ -12,7 +12,6 @@ export default {
     },
     testEnvironment: 'node',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/nodejs/src/__mocks__/bucketing.ts
+++ b/sdk/nodejs/src/__mocks__/bucketing.ts
@@ -37,6 +37,7 @@ export const importBucketingLib = async (): Promise<[Exports, undefined]> => {
             .fn()
             .mockReturnValue(JSON.stringify(testVariable)),
         variableForUser_PB: jest.fn().mockReturnValue(buffer),
+        setClientCustomData: jest.fn(),
         VariableType,
         initEventQueue: jest.fn(),
         flushEventQueue: jest.fn(),

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -457,10 +457,12 @@ export class DevCycleClient<
         clearInterval(this.bucketingTracker)
     }
 
-    async setClientCustomData(
-        clientCustomData: DVCCustomDataJSON,
-    ): Promise<void> {
-        await this.bucketingImportPromise
+    setClientCustomData(clientCustomData: DVCCustomDataJSON): void {
+        if (!this.bucketingLib) {
+            throw new Error(
+                'Client must be initialized before calling setClientCustomData()',
+            )
+        }
         this.bucketingLib.setClientCustomData(
             this.sdkKey,
             JSON.stringify(clientCustomData),

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -17,6 +17,7 @@ import {
     UserError,
     VariableDefinitions,
     InferredVariableType,
+    DVCCustomDataJSON,
 } from '@devcycle/types'
 import os from 'os'
 import {
@@ -454,5 +455,15 @@ export class DevCycleClient<
         this.configHelper?.cleanup()
         this.eventQueue.cleanup()
         clearInterval(this.bucketingTracker)
+    }
+
+    async setClientCustomData(
+        clientCustomData: DVCCustomDataJSON,
+    ): Promise<void> {
+        await this.bucketingImportPromise
+        this.bucketingLib.setClientCustomData(
+            this.sdkKey,
+            JSON.stringify(clientCustomData),
+        )
     }
 }

--- a/sdk/openfeature-angular-provider/jest.config.ts
+++ b/sdk/openfeature-angular-provider/jest.config.ts
@@ -13,7 +13,6 @@ export default {
     },
     moduleFileExtensions: ['ts', 'js'],
     coverageDirectory: '../../coverage/sdk/openfeature-angular-provider',
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/openfeature-nestjs-provider/jest.config.ts
+++ b/sdk/openfeature-nestjs-provider/jest.config.ts
@@ -13,7 +13,6 @@ export default {
     },
     moduleFileExtensions: ['ts', 'js'],
     coverageDirectory: '../../coverage/sdk/openfeature-nestjs-provider',
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/openfeature-react-provider/jest.config.ts
+++ b/sdk/openfeature-react-provider/jest.config.ts
@@ -13,7 +13,6 @@ export default {
     },
     moduleFileExtensions: ['ts', 'js'],
     coverageDirectory: '../../coverage/sdk/openfeature-react-provider',
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',

--- a/sdk/openfeature-web-provider/jest.config.ts
+++ b/sdk/openfeature-web-provider/jest.config.ts
@@ -13,7 +13,6 @@ export default {
     },
     moduleFileExtensions: ['ts', 'js'],
     coverageDirectory: '../../coverage/sdk/openfeature-web-provider',
-    collectCoverage: true,
     collectCoverageFrom: [
         '<rootDir>/src/**/*.{ts,js}',
         '!<rootDir>/**/*.{spec,test,mock}.{ts,js}',


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
