### PR TITLE
fix: setClientCustomData to not throw error to match test harness

### DIFF
--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -458,11 +458,7 @@ export class DevCycleClient<
     }
 
     setClientCustomData(clientCustomData: DVCCustomDataJSON): void {
-        if (!this.bucketingLib) {
-            throw new Error(
-                'Client must be initialized before calling setClientCustomData()',
-            )
-        }
+        if (!this.bucketingLib) return
         this.bucketingLib.setClientCustomData(
             this.sdkKey,
             JSON.stringify(clientCustomData),


### PR DESCRIPTION
- setClientCustomData to not throw error to match test harness


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
