### PR TITLE
fix: js-client-sdk missing dependancy issue with nodejs-server-sdk

### DIFF
--- a/lib/shared/bucketing-assembly-script/index.js
+++ b/lib/shared/bucketing-assembly-script/index.js
@@ -1,6 +1,7 @@
 const ProtobufTypes = require('./protobuf/compiled')
 const path = require('path')
 
+// This approach avoids using a named global variable that conflicts with itself
 const instantiate = async (debug = false, imports = {}) => {
     const releaseStr = debug ? 'debug' : 'release'
     const { instantiate } = require(`./build/bucketing-lib.${releaseStr}.js`)
@@ -23,7 +24,10 @@ const instantiate = async (debug = false, imports = {}) => {
         } catch {
             let fs
             try {
-                fs = require('node:fs/promises')
+                // Use dynamic import with string concatenation to prevent webpack
+                const prefix = 'node:'
+                const suffix = 'fs/promises'
+                fs = require(prefix + suffix)
             } catch {
                 fs = require('fs/promises')
             }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -30,9 +30,13 @@
         "fetch-retry": "^5.0.6"
     },
     "peerDependencies": {
+        "@devcycle/js-client-sdk": "^1.36.2",
         "@openfeature/multi-provider": "^0.1.2"
     },
     "peerDependenciesMeta": {
+        "@devcycle/js-client-sdk": {
+            "optional": true
+        },
         "@openfeature/multi-provider": {
             "optional": true
         }

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -422,7 +422,7 @@ export class DevCycleClient<
             const { generateClientPopulatedUser } = await import(
                 './clientUser.js'
             )
-            const populatedUser = generateClientPopulatedUser(
+            const populatedUser = await generateClientPopulatedUser(
                 incomingUser,
                 userAgent,
             )

--- a/sdk/nodejs/src/clientUser.ts
+++ b/sdk/nodejs/src/clientUser.ts
@@ -1,10 +1,29 @@
-import { DVCPopulatedUser, DevCycleUser } from '@devcycle/js-client-sdk'
+import { DevCycleUser } from '@devcycle/js-cloud-server-sdk'
 
-export const generateClientPopulatedUser = (
+/**
+ * This module handles client bootstrapping functionality that requires the js-client-sdk
+ *
+ * IMPORTANT: We intentionally keep this in a separate file and use dynamic imports
+ * with string concatenation to prevent TypeScript and bundlers from creating a hard
+ * dependency on @devcycle/js-client-sdk at build time.
+ *
+ * Why?
+ * 1. @devcycle/js-client-sdk is only needed for the optional client bootstrapping feature
+ * 2. We don't want to force all consumers to install this dependency if they don't use this feature
+ * 3. This technique allows the module to remain an optional peer dependency
+ * 4. The error handling in the client.ts file will provide a helpful message if the module is missing
+ *
+ * The string concatenation technique breaks static analysis of imports, preventing
+ * bundlers from trying to resolve or include the module during build time.
+ */
+export const generateClientPopulatedUser = async (
     user: DevCycleUser,
     userAgent: string,
-): DVCPopulatedUser => {
-    return new DVCPopulatedUser(
+): Promise<any> => {
+    const prefix = '@devcycle/'
+    const suffix = 'js-client-sdk'
+    const clientSdk = await import(prefix + suffix)
+    return new clientSdk.DVCPopulatedUser(
         user,
         {},
         undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,8 +4729,11 @@ __metadata:
     eventsource: ^2.0.2
     fetch-retry: ^5.0.6
   peerDependencies:
+    "@devcycle/js-client-sdk": ^1.36.2
     "@openfeature/multi-provider": ^0.1.2
   peerDependenciesMeta:
+    "@devcycle/js-client-sdk":
+      optional: true
     "@openfeature/multi-provider":
       optional: true
   languageName: unknown


### PR DESCRIPTION
- see clientUser.ts comment for description of why this is needed.
- Currently all Node.js/Next.js Typescript projects will error out like this: 
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/f6a36b6b-bba2-4f10-87f2-2371c3959251" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
