### PR TITLE
chore: add option to not throw error on user error in dvc js and react

### DIFF
--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -105,7 +105,7 @@ export function initializeDevCycle<
         | DevCycleOptionsWithDeferredInitialization,
     optionsArg: DevCycleOptions = {},
 ): DevCycleClient<Variables, CustomData> {
-    if (!sdkKey) {
+    if (!sdkKey && optionsArg?.throwOnError) {
         throw new UserError(
             'Missing SDK key! Call initialize with a valid SDK key',
         )
@@ -114,7 +114,8 @@ export function initializeDevCycle<
     if (
         !sdkKey.startsWith('client') &&
         !sdkKey.startsWith('dvc_client') &&
-        !optionsArg?.next
+        !optionsArg?.next &&
+        optionsArg?.throwOnError
     ) {
         throw new UserError(
             'Invalid SDK key provided. Please call initialize with a valid client SDK key',

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -140,6 +140,12 @@ export interface DevCycleOptions {
      * Example values ('of' for OpenFeature): 'js' | 'react' | 'react-native' | 'nextjs' | 'js-of' | 'react-of'
      */
     sdkPlatform?: string
+
+    /**
+     * Sets the option to not throw UserErrors when the DevCycle client is not initialized properly
+     * Default is true
+     */
+    throwOnError?: boolean
 }
 
 export interface DevCycleUser<T extends DVCCustomDataJSON = DVCCustomDataJSON> {

--- a/sdk/react/src/DevCycleProvider.tsx
+++ b/sdk/react/src/DevCycleProvider.tsx
@@ -19,13 +19,15 @@ export function DevCycleProvider(props: Props): React.ReactElement {
     const { config } = props
     const { user, options } = config
     const [isInitialized, setIsInitialized] = useState(false)
+    const throwOnError =
+        options?.throwOnError !== undefined ? options.throwOnError : true
     let sdkKey: string
     if ('sdkKey' in config) {
         sdkKey = config.sdkKey
     } else {
         sdkKey = config.envKey
     }
-    if (!sdkKey) {
+    if (!sdkKey && !options?.throwOnError) {
         throw new Error('You must provide a sdkKey to DevCycleProvider')
     }
 
@@ -35,6 +37,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
     if (clientRef.current === undefined) {
         clientRef.current = initializeDevCycleClient(sdkKey, user, {
             ...options,
+            throwOnError,
         })
     }
 
@@ -42,6 +45,7 @@ export function DevCycleProvider(props: Props): React.ReactElement {
         if (clientRef.current === undefined) {
             clientRef.current = initializeDevCycleClient(sdkKey, user, {
                 ...options,
+                throwOnError,
             })
             // react doesn't know the effect changed the ref, make sure it re-renders
             forceRerender({})


### PR DESCRIPTION
# Changes

- added option to js sdk to not throw `UserError` if the user specifies option

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
