### PR TITLE
feat: filter featureVars for variable events in js-sdk

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,12 @@
             }
         },
         {
+            "files": ["**/__tests__/**/*", "**/*.spec.*"],
+            "env": {
+                "jest": true
+            }
+        },
+        {
             "files": ["*.ts", "*.tsx"],
             "extends": ["plugin:@nx/typescript", "./eslint-common.js"],
             "rules": {

--- a/sdk/js/__tests__/RequestEvent.spec.js
+++ b/sdk/js/__tests__/RequestEvent.spec.js
@@ -33,4 +33,82 @@ describe('RequestEvent tests', () => {
         const requestEvent = new DVCRequestEvent(event)
         expect(requestEvent.clientDate).toEqual(event.date)
     })
+
+    describe('filterFeatureVars tests', () => {
+        const mockConfig = {
+            settings: {
+                filterFeatureVars: true
+            },
+            variables: {
+                'test-var': {
+                    _feature: 'feature-1'
+                }
+            },
+            featureVariationMap: {
+                'feature-1': 'variation-1',
+                'feature-2': 'variation-2'
+            }
+        }
+
+        it('should filter feature vars for variableEvaluated events when filterFeatureVars is enabled', () => {
+            const event = {
+                type: EventTypes.variableEvaluated,
+                target: 'test-var'
+            }
+            const requestEvent = new DVCRequestEvent(event, 'user-1', mockConfig)
+            expect(requestEvent.featureVars).toEqual({
+                'feature-1': 'variation-1'
+            })
+        })
+
+        it('should filter feature vars for variableDefaulted events when filterFeatureVars is enabled', () => {
+            const event = {
+                type: EventTypes.variableDefaulted,
+                target: 'test-var'
+            }
+            const requestEvent = new DVCRequestEvent(event, 'user-1', mockConfig)
+            expect(requestEvent.featureVars).toEqual({
+                'feature-1': 'variation-1'
+            })
+        })
+
+        it('should return empty feature vars when variable not found', () => {
+            const event = {
+                type: EventTypes.variableEvaluated,
+                target: 'non-existent-var'
+            }
+            const requestEvent = new DVCRequestEvent(event, 'user-1', mockConfig)
+            expect(requestEvent.featureVars).toEqual({})
+        })
+
+        it('should return all feature vars for non-variable events', () => {
+            const event = {
+                type: 'customEvent'
+            }
+            const requestEvent = new DVCRequestEvent(event, 'user-1', mockConfig)
+            expect(requestEvent.featureVars).toEqual(mockConfig.featureVariationMap)
+        })
+
+        it('should return all feature vars when filterFeatureVars is disabled', () => {
+            const configWithoutFilter = {
+                ...mockConfig,
+                settings: undefined
+            }
+            const event = {
+                type: EventTypes.variableEvaluated,
+                target: 'test-var'
+            }
+            const requestEvent = new DVCRequestEvent(event, 'user-1', configWithoutFilter)
+            expect(requestEvent.featureVars).toEqual(mockConfig.featureVariationMap)
+        })
+
+        it('should handle undefined config', () => {
+            const event = {
+                type: EventTypes.variableEvaluated,
+                target: 'test-var'
+            }
+            const requestEvent = new DVCRequestEvent(event, 'user-1', undefined)
+            expect(requestEvent.featureVars).toEqual({})
+        })
+    })
 })

--- a/sdk/js/src/EventQueue.ts
+++ b/sdk/js/src/EventQueue.ts
@@ -110,7 +110,7 @@ export class EventQueue<
             try {
                 const res = await publishEvents(
                     this.sdkKey,
-                    this.client.config || null,
+                    this.client.config,
                     user,
                     eventRequest,
                     this.client.logger,

--- a/sdk/js/src/Request.ts
+++ b/sdk/js/src/Request.ts
@@ -1,6 +1,7 @@
 import { DevCycleEvent, DevCycleOptions, UserError } from './types'
 import { DVCPopulatedUser } from './User'
-import { serializeUserSearchParams, generateEventPayload } from './utils'
+import { serializeUserSearchParams } from './utils'
+import { generateEventPayload } from './RequestEvent'
 import type { BucketedUserConfig, DVCLogger } from '@devcycle/types'
 import {
     ResponseError,
@@ -88,7 +89,7 @@ export const getConfigJson = async (
 
 export const publishEvents = async (
     sdkKey: string | null,
-    config: BucketedUserConfig | null,
+    config: BucketedUserConfig | undefined,
     user: DVCPopulatedUser,
     events: DevCycleEvent[],
     logger: DVCLogger,

--- a/sdk/js/src/utils.ts
+++ b/sdk/js/src/utils.ts
@@ -1,11 +1,4 @@
-import { DevCycleEvent } from './types'
-import { DVCRequestEvent } from './RequestEvent'
-import { DVCPopulatedUser } from './User'
-import type {
-    BucketedUserConfig,
-    SDKEventRequestBody,
-    DVCClientAPIUser,
-} from '@devcycle/types'
+import { DVCClientAPIUser } from '@devcycle/types'
 
 const convertToQueryFriendlyFormat = (property?: any): any => {
     if (property instanceof Date) {
@@ -57,23 +50,6 @@ export const checkParamType = (
     }
 }
 
-export function generateEventPayload(
-    config: BucketedUserConfig | null,
-    user: DVCPopulatedUser,
-    events: DevCycleEvent[],
-): SDKEventRequestBody {
-    return {
-        events: events.map((event) => {
-            return new DVCRequestEvent(
-                event,
-                user.user_id,
-                config?.featureVariationMap,
-            )
-        }),
-        user,
-    }
-}
-
 // The `self` property is available only in WorkerScope environments (which don't have access to window)
 // ServiceWorkerGlobalScope is the name of the class when in a service worker environment
 // https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope
@@ -90,5 +66,4 @@ export function checkIsServiceWorker(): boolean {
 export default {
     serializeUserSearchParams,
     checkParamDefined,
-    generateEventPayload,
 }


### PR DESCRIPTION
- filter `featureVars` in js-sdk using `settings.filterFeatureVars` and `variable._feature`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat-add-featureid-sdk-api","parentHead":"1de690a2753a17f90f993949218ca9e9d2d4a553","parentPull":1046,"trunk":"main"}
```
-->
