### PR TITLE
docs: git commit conventions rule

### DIFF
--- a/.cursor/rules/gitCommitConventions.mdc
+++ b/.cursor/rules/gitCommitConventions.mdc
@@ -1,0 +1,31 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Git Commit Message Conventions
+
+- All git commit messages in this project must follow the Conventional Commits specification.
+- A commit message should be structured as `<type>(<scope>): <description>`, where:
+  - `type` is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, or `revert`.
+  - `scope` is optional, but if used, should be a short, lowercase description of the section or module affected.
+  - `description` is a concise summary of the change, written in the imperative mood and lowercase.
+- In this project, scopes are rarely used; most commit messages omit the scope and use the format `<type>: <description>`.
+- Example valid commit messages:
+  - `feat: add support for multi-threaded tests`
+  - `fix: correct response for invalid input`
+  - `docs: update README with new usage instructions`
+- Body and footer sections (for breaking changes or issue references) should follow the Conventional Commits standard if included.
+
+# Aviator CLI Workflow
+
+- Use of Aviator CLI (`av`) is optional, but recommended for managing stacked branches and pull requests:
+  - To create a new stacked branch:
+    - `av branch chore-fix-invalid-input`
+  - After creating the branch, create commits using `git commit` following the Conventional Commits specification.
+  - To synchronize and git push your stack after changes:
+    - `av sync --push=yes`
+  - To create a pull request for your branch:
+    - `av pr --title "<title>" --body "<body>"`
+- Prefer Aviator commands for stack management and PR creation to ensure consistency with team workflows, but standard git and GitHub workflows are also supported.
+- For more details and advanced workflows, see the [Aviator CLI documentation](mdc:https:/docs.aviator.co/aviator-cli) and [Aviator CLI Quickstart](mdc:https:/docs.aviator.co/aviator-cli/quickstart).


### PR DESCRIPTION
add rule for commit messages and Aviator CLI workflow

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
