### PR TITLE
chore: Potential fix for code scanning alert no. 182: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -1,4 +1,6 @@
 name: Run Test Harness
+permissions:
+    contents: read
 on:
     pull_request:
         branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/js-sdks/security/code-scanning/182](https://github.com/DevCycleHQ/js-sdks/security/code-scanning/182)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's steps, it primarily reads repository contents and uses a secret token for authentication. Therefore, the `contents: read` permission is sufficient. If additional permissions are required in the future, they can be added explicitly.

The `permissions` block will be added at the root of the workflow file, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
