### PR TITLE
chore: Potential fix for code scanning alert no. 177: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cf-worker-example-test.yml
+++ b/.github/workflows/cf-worker-example-test.yml
@@ -1,4 +1,6 @@
 name: Run CF Worker Example App
+permissions:
+    contents: read
 on:
     pull_request:
         branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/js-sdks/security/code-scanning/177](https://github.com/DevCycleHQ/js-sdks/security/code-scanning/177)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since the workflow only reads repository contents and does not perform any write operations, the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
