### PR TITLE
chore: Potential fix for code scanning alert no. 173: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-of-sdk.yml
+++ b/.github/workflows/update-of-sdk.yml
@@ -1,4 +1,7 @@
 name: Update DevCycle SDKs to Latest
+permissions:
+  contents: write
+  pull-requests: write
 on:
   schedule:
     - cron: "0 12 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/js-sdks/security/code-scanning/173](https://github.com/DevCycleHQ/js-sdks/security/code-scanning/173)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the operations in the workflow, the following permissions are needed:
- `contents: write` for committing and pushing changes to the repository.
- `pull-requests: write` for creating pull requests.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
