### PR TITLE
fix: check all filters on top level ORs for a truthy match before returning false

### DIFF
--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
@@ -36,8 +36,10 @@ export function _evaluateOperator(
         for (let i = 0; i < operator.filters.length; i++) {
             const filter = operator.filters[i]
             if (filter.operatorClass !== null) {
-                const evalResult = _evaluateOperator(filter.operatorClass as AudienceOperator, audiences, user, clientCustomData)
-                // Instead of returning the value from only the first filter, we want to return true if any of the filters are true
+                const evalResult =
+                    _evaluateOperator(filter.operatorClass as AudienceOperator, audiences, user, clientCustomData)
+                // Instead of returning the value from only the first filter,
+                // we want to return true if any of the filters are true
                 if (evalResult) {
                     return true
                 }

--- a/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/bucketing/segmentation.ts
@@ -36,7 +36,11 @@ export function _evaluateOperator(
         for (let i = 0; i < operator.filters.length; i++) {
             const filter = operator.filters[i]
             if (filter.operatorClass !== null) {
-                return _evaluateOperator(filter.operatorClass as AudienceOperator, audiences, user, clientCustomData)
+                const evalResult = _evaluateOperator(filter.operatorClass as AudienceOperator, audiences, user, clientCustomData)
+                // Instead of returning the value from only the first filter, we want to return true if any of the filters are true
+                if (evalResult) {
+                    return true
+                }
             } else if (filter.filterClass !== null
                 && doesUserPassFilter(filter.filterClass as AudienceFilter, audiences, user, clientCustomData)) {
                 return true

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -80,7 +80,7 @@ export const reusableTopLevelOrAudience: PublicAudience[] = [
     },
 ]
 
-export const nestedOrAudience: PublicAudience[] = [
+export const reusableNestedOrAudience: PublicAudience[] = [
     {
         _id: '614ef6ea475929459060721c',
         filters: {
@@ -306,7 +306,7 @@ export const audiences: TargetAudience[] = [
                     type: FilterType.audienceMatch,
                     comparator: FilterComparator['='],
                     // Top Level OR audience
-                    _audiences: ['614ef6ea475929459060721b'],
+                    _audiences: [reusableTopLevelOrAudience[0]._id],
                 },
             ],
             operator: AudienceOperator.and,
@@ -320,7 +320,7 @@ export const audiences: TargetAudience[] = [
                     type: FilterType.audienceMatch,
                     comparator: FilterComparator['='],
                     // Nested OR audience
-                    _audiences: ['614ef6ea475929459060721c'],
+                    _audiences: [reusableNestedOrAudience[0]._id],
                 },
             ],
             operator: AudienceOperator.and,
@@ -937,7 +937,7 @@ export const configWithTopLevelOrAudience: ConfigBody = {
 export const configWithNestedOrAudience: ConfigBody = {
     project,
     environment,
-    audiences: configBodyAudiences(nestedOrAudience),
+    audiences: configBodyAudiences(reusableNestedOrAudience),
     features: [
         {
             _id: '614ef6aa475928459060721d',

--- a/lib/shared/bucketing-test-data/src/data/testData.ts
+++ b/lib/shared/bucketing-test-data/src/data/testData.ts
@@ -51,6 +51,77 @@ export const reusableAudiences: PublicAudience[] = [
     },
 ]
 
+export const reusableTopLevelOrAudience: PublicAudience[] = [
+    {
+        _id: '614ef6ea475929459060721b',
+        filters: {
+            filters: [
+                {
+                    type: FilterType.user,
+                    subType: UserSubType.user_id,
+                    comparator: FilterComparator['='],
+                    values: ['A', 'B', 'C', 'D'],
+                },
+                {
+                    type: FilterType.user,
+                    subType: UserSubType.email,
+                    comparator: FilterComparator['='],
+                    values: ['email@email.com'],
+                },
+                {
+                    type: FilterType.user,
+                    subType: UserSubType.appVersion,
+                    comparator: FilterComparator['>'],
+                    values: ['0.1.0'],
+                },
+            ],
+            operator: AudienceOperator.or,
+        },
+    },
+]
+
+export const nestedOrAudience: PublicAudience[] = [
+    {
+        _id: '614ef6ea475929459060721c',
+        filters: {
+            filters: [
+                {
+                    filters: [
+                        {
+                            type: FilterType.user,
+                            subType: UserSubType.user_id,
+                            comparator: FilterComparator['='],
+                            values: ['A', 'B', 'C', 'D'],
+                        },
+                        {
+                            type: FilterType.user,
+                            subType: UserSubType.customData,
+                            dataKey: 'favouriteFood',
+                            dataKeyType: DataKeyType.string,
+                            comparator: FilterComparator['='],
+                            values: ['pizza'],
+                        },
+                    ],
+                    operator: AudienceOperator.or,
+                },
+                {
+                    type: FilterType.user,
+                    subType: UserSubType.email,
+                    comparator: FilterComparator['='],
+                    values: ['email@email.com'],
+                },
+                {
+                    type: FilterType.user,
+                    subType: UserSubType.appVersion,
+                    comparator: FilterComparator['>'],
+                    values: ['0.0.0'],
+                },
+            ],
+            operator: AudienceOperator.or,
+        },
+    },
+]
+
 export const audiences: TargetAudience[] = [
     {
         _id: '',
@@ -222,6 +293,34 @@ export const audiences: TargetAudience[] = [
                     subType: UserSubType.email,
                     comparator: FilterComparator['='],
                     values: ['testwithfood@email.com'],
+                },
+            ],
+            operator: AudienceOperator.and,
+        },
+    },
+    {
+        _id: '',
+        filters: {
+            filters: [
+                {
+                    type: FilterType.audienceMatch,
+                    comparator: FilterComparator['='],
+                    // Top Level OR audience
+                    _audiences: ['614ef6ea475929459060721b'],
+                },
+            ],
+            operator: AudienceOperator.and,
+        },
+    },
+    {
+        _id: '',
+        filters: {
+            filters: [
+                {
+                    type: FilterType.audienceMatch,
+                    comparator: FilterComparator['='],
+                    // Nested OR audience
+                    _audiences: ['614ef6ea475929459060721c'],
                 },
             ],
             operator: AudienceOperator.and,
@@ -781,6 +880,89 @@ export const configWithNullCustomData: ConfigBody = {
     variables,
     variableHashes,
     clientSDKKey: 'test',
+}
+
+export const configWithTopLevelOrAudience: ConfigBody = {
+    project,
+    environment,
+    audiences: configBodyAudiences(reusableTopLevelOrAudience),
+    features: [
+        {
+            _id: '614ef6aa475928459060721d',
+            type: FeatureType.permission,
+            key: 'feature4',
+            configuration: {
+                _id: '61536f62502d80fff97ed641',
+                targets: [
+                    {
+                        _id: '61536f468fd67f0091982532',
+                        _audience: audiences[5],
+                        distribution: [
+                            {
+                                _variation: variations[5]._id,
+                                percentage: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+            variations: [variations[5]],
+        },
+        {
+            _id: '614ef6aa475928459060721e',
+            type: FeatureType.ops,
+            key: 'top_level_or_feature',
+            configuration: {
+                _id: '61536f62502d80fff97ed642',
+                targets: [
+                    {
+                        _id: '61536f468fd67f0091982533',
+                        _audience: audiences[9],
+                        distribution: [
+                            {
+                                _variation: variations[5]._id,
+                                percentage: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+            variations: [variations[5]],
+        },
+    ],
+    variables,
+    variableHashes,
+}
+
+export const configWithNestedOrAudience: ConfigBody = {
+    project,
+    environment,
+    audiences: configBodyAudiences(nestedOrAudience),
+    features: [
+        {
+            _id: '614ef6aa475928459060721d',
+            type: FeatureType.permission,
+            key: 'nested_or_feature',
+            configuration: {
+                _id: '61536f62502d80fff97ed641',
+                targets: [
+                    {
+                        _id: '61536f468fd67f0091982533',
+                        _audience: audiences[10],
+                        distribution: [
+                            {
+                                _variation: variations[5]._id,
+                                percentage: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+            variations: [variations[5]],
+        },
+    ],
+    variables,
+    variableHashes,
 }
 
 export const configWithBucketingKey = (bucketingKey: string): ConfigBody => ({


### PR DESCRIPTION
- fix: check all filters defined when the `filter.operator` is an OR before returning true or false