### PR TITLE
fix: unsubscribe handling in EventEmitter

### DIFF
--- a/sdk/js/__tests__/EventEmitter.spec.js
+++ b/sdk/js/__tests__/EventEmitter.spec.js
@@ -81,6 +81,16 @@ describe('EventEmitter tests', () => {
             eventEmitter.unsubscribe('initialized', handler2)
             expect(eventEmitter.handlers['initialized'].length).toBe(0)
         })
+
+        it('should ignore unsubscribe if handler was not registered', () => {
+            const handler1 = jest.fn()
+            const handler2 = jest.fn()
+            const notHandler = jest.fn()
+            eventEmitter.subscribe('initialized', handler1)
+            eventEmitter.subscribe('initialized', handler2)
+            eventEmitter.unsubscribe('initialized', notHandler)
+            expect(eventEmitter.handlers['initialized'].length).toBe(2)
+        })
     })
 
     describe('emit', () => {

--- a/sdk/js/src/EventEmitter.ts
+++ b/sdk/js/src/EventEmitter.ts
@@ -53,12 +53,16 @@ export class EventEmitter {
             return
         }
 
-        if (handler) {
-            const handlerIndex = this.handlers[key].findIndex(
-                (h) => h === handler,
-            )
+        const handlers = this.handlers[key]
+        if (!handlers) {
+            return
+        }
 
-            this.handlers[key].splice(handlerIndex, 1)
+        if (handler) {
+            const handlerIndex = handlers.findIndex((h) => h === handler)
+            if (handlerIndex !== -1) {
+                handlers.splice(handlerIndex, 1)
+            }
         } else {
             this.handlers[key] = []
         }


### PR DESCRIPTION
## Summary
- avoid removing last handler when unsubscribing an unknown callback
- add test to cover unsubscribing a non-existent handler

## Testing
- `yarn install --immutable` *(fails: tunneling socket could not be established)*
- `yarn test` *(fails: project doesn't seem to have been installed)*