### PR TITLE
fix: replace deprecated nx print-affected commands

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -27,7 +27,7 @@ jobs:
               run: yarn --immutable
             - name: Check affected projects
               run: |
-                  if yarn nx print-affected --base=origin/main --select=projects | grep -E '(^nodejs|[^-]nodejs)'; then
+                  if yarn nx show projects --affected --base=origin/main | grep -E '(^nodejs|[^-]nodejs)'; then
                     echo "TRIGGER_NODEJS_TEST_HARNESS=true" >> $GITHUB_ENV
                   fi
             - uses: DevCycleHQ/test-harness@main

--- a/scripts/lerna-version-ci.sh
+++ b/scripts/lerna-version-ci.sh
@@ -46,7 +46,7 @@ VERSION_INCREMENT_TYPE="patch"
 parse_arguments "$@"
 
 if [ -z "$AFFECTED_PROJECTS" ]; then
-  AFFECTED_PROJECTS=$(yarn nx print-affected --base $LAST_TAGGED_SHA --select=projects)
+  AFFECTED_PROJECTS=$(yarn nx show projects --affected --base $LAST_TAGGED_SHA)
 fi
 
 echo "Affected projects: $AFFECTED_PROJECTS"

--- a/scripts/lerna-version.sh
+++ b/scripts/lerna-version.sh
@@ -25,7 +25,7 @@ fi
 
 echo "Last tagged sha: $LAST_TAGGED_SHA"
 
-AFFECTED_PROJECTS=$(yarn nx print-affected --base $LAST_TAGGED_SHA --select=projects)
+AFFECTED_PROJECTS=$(yarn nx show projects --affected --base $LAST_TAGGED_SHA)
 echo "Affected projects: $AFFECTED_PROJECTS"
 
 # exit if no affected projects


### PR DESCRIPTION
This PR fixes GitHub Action failures by replacing deprecated nx print-affected commands with nx show projects --affected syntax. Updated scripts/lerna-version-ci.sh and scripts/lerna-version.sh to use modern Nx 21.1.1 compatible commands.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
