### PR TITLE
fix: ignore devcycle-js-sdks package in lerna-version script

### DIFF
--- a/scripts/lerna-version-ci.sh
+++ b/scripts/lerna-version-ci.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 # Get the last tagged sha from the output of "git describe"
 LAST_TAG=$(git describe --always --first-parent --abbrev=0)
-IGNORED_PACKAGES=()
+IGNORED_PACKAGES=("devcycle-js-sdks")
 
 echo "::info::Last Tag $LAST_TAG"
 LAST_TAGGED_SHA=$(git rev-list -n 1 $LAST_TAG)


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
