### PR TITLE
fix: DVCPopulatedUser user_id and isAnonymous handling to be consistent with other SDKs

### DIFF
--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -694,7 +694,9 @@ describe('DevCycleClient tests', () => {
         })
 
         it('should throw an error if the user is invalid', async () => {
-            await expect(client.identifyUser({ user_id: '', isAnonymous: false })).rejects.toThrow(
+            await expect(
+                client.identifyUser({ user_id: '', isAnonymous: false }),
+            ).rejects.toThrow(
                 new Error(
                     'A User cannot be created with isAnonymous: false without a valid user_id',
                 ),

--- a/sdk/js/__tests__/Client.spec.js
+++ b/sdk/js/__tests__/Client.spec.js
@@ -694,9 +694,9 @@ describe('DevCycleClient tests', () => {
         })
 
         it('should throw an error if the user is invalid', async () => {
-            await expect(client.identifyUser({ user_id: '' })).rejects.toThrow(
+            await expect(client.identifyUser({ user_id: '', isAnonymous: false })).rejects.toThrow(
                 new Error(
-                    'A User cannot be created with a user_id that is an empty string',
+                    'A User cannot be created with isAnonymous: false without a valid user_id',
                 ),
             )
         })

--- a/sdk/js/__tests__/User.spec.js
+++ b/sdk/js/__tests__/User.spec.js
@@ -71,7 +71,10 @@ describe('DVCPopulatedUser tests', () => {
     })
 
     it('should use provided user_id when isAnonymous is true', () => {
-        const user = new DVCPopulatedUser({ user_id: 'abc123', isAnonymous: true })
+        const user = new DVCPopulatedUser({
+            user_id: 'abc123',
+            isAnonymous: true,
+        })
         expect(user.user_id).toBe('abc123')
         expect(user.isAnonymous).toBe(true)
     })
@@ -80,7 +83,9 @@ describe('DVCPopulatedUser tests', () => {
         const createUser = () => {
             new DVCPopulatedUser({ isAnonymous: false })
         }
-        expect(createUser).toThrow('A User cannot be created with isAnonymous: false without a valid user_id')
+        expect(createUser).toThrow(
+            'A User cannot be created with isAnonymous: false without a valid user_id',
+        )
     })
 
     it('should create an anonymous user if the user id is an empty string', () => {
@@ -99,6 +104,8 @@ describe('DVCPopulatedUser tests', () => {
         const createUser = () => {
             new DVCPopulatedUser({ user_id: '', isAnonymous: false })
         }
-        expect(createUser).toThrow('A User cannot be created with isAnonymous: false without a valid user_id')
+        expect(createUser).toThrow(
+            'A User cannot be created with isAnonymous: false without a valid user_id',
+        )
     })
 })

--- a/sdk/js/__tests__/User.spec.js
+++ b/sdk/js/__tests__/User.spec.js
@@ -58,29 +58,47 @@ describe('DVCPopulatedUser tests', () => {
         expect(user.isAnonymous).toBe(false)
     })
 
-    it('should NOT throw an error if no user id and no anonymous flag set', () => {
-        const createUser = () => {
-            new DVCPopulatedUser({})
-        }
-        expect(createUser).not.toThrow(expect.any(Error))
+    it('should create an anonymous user if no user id and no anonymous flag set', () => {
+        const user = new DVCPopulatedUser({})
+        expect(uuidValidate(user.user_id)).toBe(true)
+        expect(user.isAnonymous).toBe(true)
     })
 
     it('should create an anonymous user id if isAnonymous is true', () => {
         const newUser = new DVCPopulatedUser({ isAnonymous: true })
         expect(uuidValidate(newUser.user_id)).toBe(true)
+        expect(newUser.isAnonymous).toBe(true)
     })
 
-    it('should throw an error if the user id is an empty string', () => {
-        const createUser = () => {
-            new DVCPopulatedUser({ user_id: '' })
-        }
-        expect(createUser).toThrow(expect.any(Error))
+    it('should use provided user_id when isAnonymous is true', () => {
+        const user = new DVCPopulatedUser({ user_id: 'abc123', isAnonymous: true })
+        expect(user.user_id).toBe('abc123')
+        expect(user.isAnonymous).toBe(true)
     })
 
-    it('should throw an error if the user id is a string of only whitespace', () => {
+    it('should throw an error if isAnonymous is false without a user_id', () => {
         const createUser = () => {
-            new DVCPopulatedUser({ user_id: '     ' })
+            new DVCPopulatedUser({ isAnonymous: false })
         }
-        expect(createUser).toThrow(expect.any(Error))
+        expect(createUser).toThrow('A User cannot be created with isAnonymous: false without a valid user_id')
+    })
+
+    it('should create an anonymous user if the user id is an empty string', () => {
+        const user = new DVCPopulatedUser({ user_id: '' })
+        expect(uuidValidate(user.user_id)).toBe(true)
+        expect(user.isAnonymous).toBe(true)
+    })
+
+    it('should treat whitespace-only user_id as valid', () => {
+        const user = new DVCPopulatedUser({ user_id: '     ' })
+        expect(user.user_id).toBe('     ')
+        expect(user.isAnonymous).toBe(false)
+    })
+
+    it('should throw an error if isAnonymous is false with empty string user_id', () => {
+        const createUser = () => {
+            new DVCPopulatedUser({ user_id: '', isAnonymous: false })
+        }
+        expect(createUser).toThrow('A User cannot be created with isAnonymous: false without a valid user_id')
     })
 })

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -494,7 +494,7 @@ export class DevCycleClient<
 
         let oldAnonymousId: string | null | undefined
         let anonUser: DVCPopulatedUser
-        
+
         const promise = new Promise<DVCVariableSet>((resolve, reject) => {
             this.eventQueue?.flushEvents()
 

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -248,8 +248,6 @@ export class DevCycleClient<
         }
         this.eventEmitter.emitInitialized(true)
 
-        // Anonymous user ID saving is now handled in User.ts constructor
-
         return this
     }
 
@@ -466,7 +464,6 @@ export class DevCycleClient<
                 )
             }
             const config = await this.requestConsolidator.queue(updatedUser)
-            // Anonymous user ID saving is now handled in User.ts constructor
             return config.variables || {}
         } catch (err) {
             this.eventEmitter.emitError(err)
@@ -516,7 +513,6 @@ export class DevCycleClient<
                 })
                 .then(() => this.requestConsolidator.queue(anonUser))
                 .then(async (config) => {
-                    // Anonymous user ID saving is now handled in User.ts constructor
                     resolve(config.variables || {})
                 })
                 .catch(async (e) => {

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -498,8 +498,8 @@ export class DevCycleClient<
             this.onInitialized
                 .then(() => this.store.loadAnonUserId())
                 .then(async (cachedAnonId) => {
-                    await this.store.removeAnonUserId()
                     oldAnonymousId = cachedAnonId
+                    await this.store.removeAnonUserId()
                     // Create the new anonymous user AFTER removing the old ID
                     anonUser = new DVCPopulatedUser(
                         { isAnonymous: true },
@@ -509,9 +509,8 @@ export class DevCycleClient<
                         undefined,
                         this.store,
                     )
-                    return
+                    return this.requestConsolidator.queue(anonUser)
                 })
-                .then(() => this.requestConsolidator.queue(anonUser))
                 .then(async (config) => {
                     resolve(config.variables || {})
                 })

--- a/sdk/js/src/User.ts
+++ b/sdk/js/src/User.ts
@@ -1,4 +1,5 @@
 import { DevCycleOptions, DevCycleUser, DVCCustomDataJSON } from './types'
+import { CacheStore } from './CacheStore'
 import { v4 as uuidv4 } from 'uuid'
 import packageJson from '../package.json'
 import UAParser from 'ua-parser-js'
@@ -35,12 +36,25 @@ export class DVCPopulatedUser implements DevCycleUser {
     readonly sdkVersion: string
     readonly sdkPlatform?: string
 
+    private generateAndSaveAnonUserId(
+        anonymousUserId?: string,
+        store?: CacheStore,
+    ): string {
+        const userId = anonymousUserId || uuidv4()
+        // Save newly generated anonymous user ID to storage
+        if (!anonymousUserId && store) {
+            void store.saveAnonUserId(userId)
+        }
+        return userId
+    }
+
     constructor(
         user: DevCycleUser,
         options: DevCycleOptions,
         staticData?: StaticData,
         anonymousUserId?: string,
         headerUserAgent?: string,
+        store?: CacheStore,
     ) {
         // Treat empty string user_id as null
         const normalizedUserId = user.user_id === '' ? undefined : user.user_id
@@ -55,11 +69,16 @@ export class DVCPopulatedUser implements DevCycleUser {
         // Set user_id and isAnonymous based on the input
         if (user.isAnonymous === true) {
             // Case: { isAnonymous: true } or { user_id: 'abc', isAnonymous: true }
-            this.user_id = user.user_id || anonymousUserId || uuidv4()
+            this.user_id =
+                normalizedUserId ||
+                this.generateAndSaveAnonUserId(anonymousUserId, store)
             this.isAnonymous = true
         } else if (!normalizedUserId) {
             // Case: {} (empty object) - set as anonymous
-            this.user_id = anonymousUserId || uuidv4()
+            this.user_id = this.generateAndSaveAnonUserId(
+                anonymousUserId,
+                store,
+            )
             this.isAnonymous = true
         } else {
             // Case: { user_id: 'abc' } or { user_id: 'abc', isAnonymous: false }

--- a/sdk/js/src/User.ts
+++ b/sdk/js/src/User.ts
@@ -42,17 +42,30 @@ export class DVCPopulatedUser implements DevCycleUser {
         anonymousUserId?: string,
         headerUserAgent?: string,
     ) {
-        if (user.user_id?.trim() === '') {
+        // Treat empty string user_id as null
+        const normalizedUserId = user.user_id === '' ? undefined : user.user_id
+
+        // Validate required fields
+        if (user.isAnonymous === false && !normalizedUserId) {
             throw new Error(
-                'A User cannot be created with a user_id that is an empty string',
+                'A User cannot be created with isAnonymous: false without a valid user_id',
             )
         }
 
-        this.user_id =
-            user.isAnonymous || !user.user_id
-                ? user.user_id || anonymousUserId || uuidv4()
-                : user.user_id
-        this.isAnonymous = user.isAnonymous || !user.user_id
+        // Set user_id and isAnonymous based on the input
+        if (user.isAnonymous === true) {
+            // Case: { isAnonymous: true } or { user_id: 'abc', isAnonymous: true }
+            this.user_id = user.user_id || anonymousUserId || uuidv4()
+            this.isAnonymous = true
+        } else if (!normalizedUserId) {
+            // Case: {} (empty object) - set as anonymous
+            this.user_id = anonymousUserId || uuidv4()
+            this.isAnonymous = true
+        } else {
+            // Case: { user_id: 'abc' } or { user_id: 'abc', isAnonymous: false }
+            this.user_id = normalizedUserId
+            this.isAnonymous = user.isAnonymous ?? false
+        }
         this.email = user.email
         this.name = user.name
         this.language = user.language

--- a/sdk/openfeature-angular-provider/__tests__/DevCycleAngularProvider.test.ts
+++ b/sdk/openfeature-angular-provider/__tests__/DevCycleAngularProvider.test.ts
@@ -201,7 +201,7 @@ describe('DevCycleReactProvider Unit Tests', () => {
                     false,
                 )
                 expect(logger.warn).toHaveBeenCalledWith(
-                    'EvaluationContext property "obj" is an Object. ' +
+                    'Unknown EvaluationContext property "obj" type. ' +
                         'DevCycleUser only supports flat customData properties of type ' +
                         'string / number / boolean / null',
                 )

--- a/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
+++ b/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
@@ -201,7 +201,7 @@ describe('DevCycleReactProvider Unit Tests', () => {
                     false,
                 )
                 expect(logger.warn).toHaveBeenCalledWith(
-                    'EvaluationContext property "obj" is an Object. ' +
+                    'Unknown EvaluationContext property "obj" type. ' +
                         'DevCycleUser only supports flat customData properties of type ' +
                         'string / number / boolean / null',
                 )

--- a/sdk/openfeature-web-provider/src/DevCycleProvider.ts
+++ b/sdk/openfeature-web-provider/src/DevCycleProvider.ts
@@ -302,7 +302,8 @@ export default class DevCycleProvider implements Provider {
                     dvcUserData[key] = value
                 } else {
                     this._devcycleClient?.logger.warn(
-                        `Expected isAnonymous to be boolean but got "${typeof value}" in EvaluationContext. Ignoring value.`,
+                        `Expected isAnonymous to be boolean but got "${typeof value}" in ` +
+                            `EvaluationContext. Ignoring value.`,
                     )
                 }
             } else if (key === 'privateCustomData') {


### PR DESCRIPTION
## Update DVCPopulatedUser constructor logic for anonymous user handling, and OpenFeature Web Provider anon user Contexts

This pull request introduces significant updates to the handling of anonymous users, alongside improvements to test coverage and error messaging. The most important changes include refining the logic for anonymous and non-anonymous user creation, updating test cases to reflect the new behavior, updating the OpenFeature Web Provider to handle anon Contexts, and enhancing the flexibility of user ID resolution in various contexts.

### User Creation Logic Updates:
* [`sdk/js/src/User.ts`](diffhunk://#diff-c043fbefa1714bfa4e7dc2c288591e7c668c1db171aa82a454c2b2eef00aaa97R39-R87): Enhanced the `DVCPopulatedUser` class to handle cases where `user_id` is an empty string or missing. Introduced a `generateAndSaveAnonUserId` method to create and optionally store anonymous user IDs. Improved validation to ensure `isAnonymous: false` requires a valid `user_id`.

* [`sdk/js/src/Client.ts`](diffhunk://#diff-7e88ae7eb811449dfe4a792952dab7d8accab565833b6a8a5764488a232d4325R210-R211): Updated the `DevCycleClient` to remove redundant logic for saving anonymous user IDs and ensure proper handling of anonymous user creation during initialization and user updates. 

### Test Coverage Enhancements:
* [`sdk/js/__tests__/User.spec.js`](diffhunk://#diff-14fe0afb5745007258545fb9cc3d78caece8562444a2be2c765b0ef63b5052beL61-R109): Overhauled test cases for `DVCPopulatedUser` to verify the new behaviour for anonymous and non-anonymous users, including edge cases like empty strings and whitespace-only `user_id` values.

* [`sdk/openfeature-web-provider/__tests__/DevCycleProvider.test.ts`](diffhunk://#diff-e58d167eddde158b90ed1d76bf8c728bb1d1505c7b10a943047e1dc1be2fdf04R142-R232): Added tests for fallback logic when resolving `user_id` from `targetingKey`, `userId`, or other sources. Verified behaviour when no valid user ID is provided and when `isAnonymous` is explicitly set. [[1]](diffhunk://#diff-e58d167eddde158b90ed1d76bf8c728bb1d1505c7b10a943047e1dc1be2fdf04R142-R232) [[2]](diffhunk://#diff-e58d167eddde158b90ed1d76bf8c728bb1d1505c7b10a943047e1dc1be2fdf04L172-R261)

### Error Messaging Improvements:
* [`sdk/js/__tests__/Client.spec.js`](diffhunk://#diff-e690cf47bd486dffaa20b9313392a6cb432489fc90c59293e8e9deda7e58f2d1L697-R701): Updated error messages in `DevCycleClient` tests to reflect the new validation rules for `isAnonymous` and `user_id`.

* [`sdk/openfeature-web-provider/__tests__/DevCycleProvider.test.ts`](diffhunk://#diff-e58d167eddde158b90ed1d76bf8c728bb1d1505c7b10a943047e1dc1be2fdf04L204-R292): Improved warnings for invalid `EvaluationContext` properties, including mismatched types for `isAnonymous` and `customData`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
