### PR TITLE
fix: handle the bounded hash limit for edge cases

### DIFF
--- a/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
+++ b/lib/shared/bucketing-assembly-script/__tests__/bucketing/bucketing.test.ts
@@ -21,7 +21,11 @@ import { configWithBucketingKey } from '../helpers/configWithBucketingKey'
 
 import moment from 'moment'
 import * as uuid from 'uuid'
-import { AudienceOperator, BucketedUserConfig, SDKVariable } from '@devcycle/types'
+import {
+    AudienceOperator,
+    BucketedUserConfig,
+    SDKVariable,
+} from '@devcycle/types'
 import { cleanupSDK, initSDK } from '../setPlatformData'
 import {
     variableForUserPB,

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -56,11 +56,12 @@ export class Target extends JSON.Value {
         for (let i = 0; i < this._sortedDistribution.length; i++) {
             const distribution = this._sortedDistribution[i]
             distributionIndex += distribution.percentage
-            if (boundedHash >= previousDistributionIndex && (boundedHash < distributionIndex || (distributionIndex == 1 && boundedHash == 1))) {
+            if (boundedHash >= previousDistributionIndex && 
+                (boundedHash < distributionIndex || (distributionIndex == 1 && boundedHash == 1))) {
                 return distribution._variation
             }
         }
-        throw new Error(`Failed to decide target variation: ${this._id} ${boundedHash} ${distributionIndex}`)
+        throw new Error(`Failed to decide target variation: ${this._id}`)
     }
 
     stringify(): string {

--- a/lib/shared/bucketing-assembly-script/assembly/types/target.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/target.ts
@@ -56,11 +56,11 @@ export class Target extends JSON.Value {
         for (let i = 0; i < this._sortedDistribution.length; i++) {
             const distribution = this._sortedDistribution[i]
             distributionIndex += distribution.percentage
-            if (boundedHash >= previousDistributionIndex && boundedHash < distributionIndex) {
+            if (boundedHash >= previousDistributionIndex && (boundedHash < distributionIndex || (distributionIndex == 1 && boundedHash == 1))) {
                 return distribution._variation
             }
         }
-        throw new Error(`Failed to decide target variation: ${this._id}`)
+        throw new Error(`Failed to decide target variation: ${this._id} ${boundedHash} ${distributionIndex}`)
     }
 
     stringify(): string {

--- a/lib/shared/bucketing-assembly-script/assembly/types/targetV2.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/targetV2.ts
@@ -58,7 +58,8 @@ export class TargetV2 extends JSON.Value {
         for (let i = 0; i < this._sortedDistribution.length; i++) {
             const distribution = this._sortedDistribution[i]
             distributionIndex += distribution.percentage
-            if (boundedHash >= previousDistributionIndex && (boundedHash < distributionIndex || (distributionIndex == 1 && boundedHash == 1))) {
+            if (boundedHash >= previousDistributionIndex && 
+                (boundedHash < distributionIndex || (distributionIndex == 1 && boundedHash == 1))) {
                 return distribution._variation
             }
         }

--- a/lib/shared/bucketing-assembly-script/assembly/types/targetV2.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/targetV2.ts
@@ -58,7 +58,7 @@ export class TargetV2 extends JSON.Value {
         for (let i = 0; i < this._sortedDistribution.length; i++) {
             const distribution = this._sortedDistribution[i]
             distributionIndex += distribution.percentage
-            if (boundedHash >= previousDistributionIndex && boundedHash < distributionIndex) {
+            if (boundedHash >= previousDistributionIndex && (boundedHash < distributionIndex || (distributionIndex == 1 && boundedHash == 1))) {
                 return distribution._variation
             }
         }

--- a/lib/shared/bucketing/__tests__/bucketing.test.ts
+++ b/lib/shared/bucketing/__tests__/bucketing.test.ts
@@ -1625,7 +1625,7 @@ describe('Bounded Hash Limits', () => {
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
-                    expect(variation).toBe(tc.expectedVariation)
+                    expect(variation.variation).toBe(tc.expectedVariation)
                 }
             })
 
@@ -1636,7 +1636,7 @@ describe('Bounded Hash Limits', () => {
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
-                    expect(variation).toBe(tc.expectedVariation)
+                    expect(variation.variation).toBe(tc.expectedVariation)
                 }
             })
 
@@ -1647,7 +1647,7 @@ describe('Bounded Hash Limits', () => {
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
-                    expect(variation).toBe(tc.expectedVariation)
+                    expect(variation.variation).toBe(tc.expectedVariation)
                 }
             })
 
@@ -1658,7 +1658,7 @@ describe('Bounded Hash Limits', () => {
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
-                    expect(variation).toBe(tc.expectedVariation)
+                    expect(variation.variation).toBe(tc.expectedVariation)
                 }
             })
         })

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -77,7 +77,8 @@ export const decideTargetVariation = ({
         distributionIndex += variation.percentage
         if (
             boundedHash >= previousDistributionIndex &&
-            boundedHash < distributionIndex
+            (boundedHash < distributionIndex ||
+                (distributionIndex == 1 && boundedHash == 1))
         ) {
             return {
                 variation: variation._variation,


### PR DESCRIPTION
- add checking for rare case when the bounded hash is 1 
- add test for the bucketing libs

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
