### PR TITLE
chore: add tests for invalid config response

### DIFF
--- a/sdk/js/__tests__/index.spec.js
+++ b/sdk/js/__tests__/index.spec.js
@@ -96,8 +96,9 @@ describe('initializeDevCycle tests', () => {
     it('should not throw an error and use default config when config api throws an error', async () => {
         const user = { user_id: 'testuser' }
 
-        getConfigJsonSpy.mockImplementation(() => {
-            throw new Error('api error')
+        getConfigJsonSpy.mockResolvedValue({
+            invalidProp1: {},
+            invalidProp2: [],
         })
 
         /** @type {DVC.DevCycleClient} */
@@ -107,6 +108,7 @@ describe('initializeDevCycle tests', () => {
         }).not.toThrow()
 
         await client.onClientInitialized()
+        expect(client.allFeatures()).toEqual({})
         expect(getConfigJsonSpy).toHaveBeenCalledTimes(1)
         const variable = client.variable('test', false)
         expect(variable.isDefaulted).toEqual(true)
@@ -115,8 +117,9 @@ describe('initializeDevCycle tests', () => {
     it('should not throw an error and use default config when deffered', async () => {
         const user = { user_id: 'testuser' }
 
-        getConfigJsonSpy.mockImplementation(() => {
-            throw new Error('api error')
+        getConfigJsonSpy.mockResolvedValue({
+            invalidProp1: {},
+            invalidProp2: [],
         })
 
         const client = DVC.initializeDevCycle(test_key, {

--- a/sdk/js/__tests__/index.spec.js
+++ b/sdk/js/__tests__/index.spec.js
@@ -2,9 +2,6 @@ import * as DVC from '../src'
 import * as Request from '../src/Request'
 
 jest.mock('../src/Request')
-jest.spyOn(Request, 'getConfigJson').mockImplementation(() => {
-    return Promise.resolve({})
-})
 
 const test_key = 'client_test_sdk_key'
 const test_server_key = 'dvc_server_key'
@@ -18,6 +15,23 @@ const invalidOptionsError =
     'Invalid options! Call initialize with valid options'
 
 describe('initializeDevCycle tests', () => {
+    /**
+     * @type {jest.SpyInstance}
+     */
+    let getConfigJsonSpy
+
+    beforeEach(() => {
+        getConfigJsonSpy = jest
+            .spyOn(Request, 'getConfigJson')
+            .mockImplementation(() => {
+                return Promise.resolve({})
+            })
+    })
+
+    afterEach(() => {
+        getConfigJsonSpy.mockRestore()
+    })
+
     it('should return client for initialize and initializeDevCycle', () => {
         const user = { user_id: 'user1' }
         let client = DVC.initializeDevCycle(test_key, user)
@@ -77,5 +91,41 @@ describe('initializeDevCycle tests', () => {
 
         window.dispatchEvent(new Event('pagehide'))
         expect(flushMock).toBeCalled()
+    })
+
+    it('should not throw an error and use default config when config api throws an error', async () => {
+        const user = { user_id: 'testuser' }
+
+        getConfigJsonSpy.mockImplementation(() => {
+            throw new Error('api error')
+        })
+
+        /** @type {DVC.DevCycleClient} */
+        let client
+        expect(() => {
+            client = DVC.initializeDevCycle(test_key, user)
+        }).not.toThrow()
+
+        await client.onClientInitialized()
+        expect(getConfigJsonSpy).toHaveBeenCalledTimes(1)
+        const variable = client.variable('test', false)
+        expect(variable.isDefaulted).toEqual(true)
+        expect(variable.value).toEqual(false)
+    })
+    it('should not throw an error and use default config when deffered', async () => {
+        const user = { user_id: 'testuser' }
+
+        getConfigJsonSpy.mockImplementation(() => {
+            throw new Error('api error')
+        })
+
+        const client = DVC.initializeDevCycle(test_key, {
+            deferInitialization: true,
+        })
+        await expect(client.identifyUser(user)).resolves.not.toThrow()
+        expect(getConfigJsonSpy).toHaveBeenCalledTimes(1)
+        const variable = client.variable('test', false)
+        expect(variable.isDefaulted).toEqual(true)
+        expect(variable.value).toEqual(false)
     })
 })


### PR DESCRIPTION
it looks like the js-sdk handles errors on initializing so i just added these tests to confirm the same scenario that caused issue in ios sdk is covered. Please suggest any other tests/dependant libraries i could add tests to but i think they rely directly on the js initialization.