### PR TITLE
fix: add split details to js bucketing

### DIFF
--- a/lib/shared/bucketing/__tests__/bucketing.test.ts
+++ b/lib/shared/bucketing/__tests__/bucketing.test.ts
@@ -237,7 +237,7 @@ describe('Config Parsing and Generating', () => {
                     variationKey: 'variation-1-key',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 feature2: {
@@ -249,7 +249,7 @@ describe('Config Parsing and Generating', () => {
                     variationKey: 'variation-feature-2-key',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 feature3: {
@@ -305,7 +305,7 @@ describe('Config Parsing and Generating', () => {
                     value: 'multivar first',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 'feature2.hello': {
@@ -316,7 +316,7 @@ describe('Config Parsing and Generating', () => {
                     value: 'multivar last',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 swagTest: {
@@ -327,7 +327,7 @@ describe('Config Parsing and Generating', () => {
                     value: 'man',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 test: {
@@ -338,7 +338,7 @@ describe('Config Parsing and Generating', () => {
                     value: 'scat',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 'bool-var': {
@@ -349,7 +349,7 @@ describe('Config Parsing and Generating', () => {
                     value: false,
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 'json-var': {
@@ -360,7 +360,7 @@ describe('Config Parsing and Generating', () => {
                     value: '{"hello":"world","num":610,"bool":true}',
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 'num-var': {
@@ -371,7 +371,7 @@ describe('Config Parsing and Generating', () => {
                     value: 610.61,
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
-                        details: 'Email',
+                        details: 'Random Distribution | Email',
                     },
                 },
                 feature4Var: {
@@ -974,7 +974,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details:
-                            'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                            'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
                     },
                 },
                 feature2: {
@@ -1006,7 +1006,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details:
-                            'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                            'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
                     },
                 },
                 feature2Var: {
@@ -1030,7 +1030,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details:
-                            'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                            'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
                     },
                 },
                 'json-var': {
@@ -1042,7 +1042,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details:
-                            'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                            'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
                     },
                 },
                 'num-var': {
@@ -1054,7 +1054,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details:
-                            'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                            'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
                     },
                 },
             },

--- a/lib/shared/bucketing/__tests__/bucketing.test.ts
+++ b/lib/shared/bucketing/__tests__/bucketing.test.ts
@@ -141,6 +141,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
             },
@@ -158,6 +159,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'bool-var': {
@@ -169,6 +171,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'json-var': {
@@ -180,6 +183,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'num-var': {
@@ -191,6 +195,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
             },
@@ -238,6 +243,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f3bc838a705c105eb62',
                     },
                 },
                 feature2: {
@@ -250,6 +256,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 feature3: {
@@ -262,19 +269,20 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Audience Match -> Email',
+                        target_id: '61536f468fd67f0091982531',
                     },
                 },
                 feature4: {
                     _id: '614ef8aa475928459060721c',
                     _variation: '615382338424cb11646d9668',
                     key: 'feature4',
-                    settings: undefined,
                     type: 'release',
                     variationKey: 'variation-feature-2-key',
                     variationName: 'feature 4 variation',
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Email',
+                        target_id: '61536f468fd67f0091982531',
                     },
                 },
             },
@@ -295,6 +303,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Audience Match -> Email',
+                        target_id: '61536f468fd67f0091982531',
                     },
                 },
                 'feature2.cool': {
@@ -306,6 +315,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'feature2.hello': {
@@ -317,6 +327,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 swagTest: {
@@ -328,6 +339,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f3bc838a705c105eb62',
                     },
                 },
                 test: {
@@ -339,6 +351,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f3bc838a705c105eb62',
                     },
                 },
                 'bool-var': {
@@ -350,6 +363,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f3bc838a705c105eb62',
                     },
                 },
                 'json-var': {
@@ -361,6 +375,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f3bc838a705c105eb62',
                     },
                 },
                 'num-var': {
@@ -372,6 +387,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.SPLIT,
                         details: 'Random Distribution | Email',
+                        target_id: '61536f3bc838a705c105eb62',
                     },
                 },
                 feature4Var: {
@@ -383,6 +399,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Email',
+                        target_id: '61536f468fd67f0091982531',
                     },
                 },
             },
@@ -420,6 +437,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
             },
@@ -437,6 +455,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'bool-var': {
@@ -448,6 +467,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'json-var': {
@@ -459,6 +479,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
                 'num-var': {
@@ -470,6 +491,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'User ID AND Country',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
             },
@@ -504,6 +526,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
             },
@@ -529,6 +552,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 'json-var': {
@@ -540,6 +564,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 'num-var': {
@@ -551,6 +576,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 swagTest: {
@@ -562,6 +588,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 test: {
@@ -573,6 +600,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
             },
@@ -631,6 +659,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
             },
@@ -649,6 +678,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
             },
@@ -709,6 +739,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 feature2: {
@@ -722,6 +753,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
             },
@@ -741,6 +773,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
                 'bool-var': {
@@ -752,6 +785,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 'json-var': {
@@ -763,6 +797,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 'num-var': {
@@ -774,6 +809,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 swagTest: {
@@ -785,6 +821,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 test: {
@@ -796,6 +833,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
             },
@@ -844,6 +882,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 feature2: {
@@ -857,6 +896,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
             },
@@ -876,6 +916,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
                 'bool-var': {
@@ -887,6 +928,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 'json-var': {
@@ -898,6 +940,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 'num-var': {
@@ -909,6 +952,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 swagTest: {
@@ -920,6 +964,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
                 test: {
@@ -931,6 +976,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'All Users',
+                        target_id: '61536f468fd67f0091982535',
                     },
                 },
             },
@@ -975,6 +1021,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.SPLIT,
                         details:
                             'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f468fd67f0091982534',
                     },
                 },
                 feature2: {
@@ -988,6 +1035,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
             },
@@ -1007,6 +1055,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.SPLIT,
                         details:
                             'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f468fd67f0091982534',
                     },
                 },
                 feature2Var: {
@@ -1019,6 +1068,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details:
                             'Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f669c69b86cccc5f15e',
                     },
                 },
                 'bool-var': {
@@ -1031,6 +1081,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.SPLIT,
                         details:
                             'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f468fd67f0091982534',
                     },
                 },
                 'json-var': {
@@ -1043,6 +1094,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.SPLIT,
                         details:
                             'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f468fd67f0091982534',
                     },
                 },
                 'num-var': {
@@ -1055,6 +1107,7 @@ describe('Config Parsing and Generating', () => {
                         reason: EVAL_REASONS.SPLIT,
                         details:
                             'Rollout | Platform Version AND Custom Data -> favouriteFood AND Custom Data -> favouriteDrink',
+                        target_id: '61536f468fd67f0091982534',
                     },
                 },
             },
@@ -1380,6 +1433,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Custom Data -> favouriteNull',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
             },
@@ -1397,6 +1451,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Custom Data -> favouriteNull',
+                        target_id: '61536f468fd67f0091982533',
                     },
                 },
             },
@@ -1450,6 +1505,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Custom Data -> favouriteNull',
+                        target_id: '61536f468fd67f0091982532',
                     },
                 },
             },
@@ -1467,6 +1523,7 @@ describe('Config Parsing and Generating', () => {
                     eval: {
                         reason: EVAL_REASONS.TARGETING_MATCH,
                         details: 'Custom Data -> favouriteNull',
+                        target_id: '61536f468fd67f0091982532',
                     },
                 },
             },

--- a/lib/shared/bucketing/__tests__/bucketing.test.ts
+++ b/lib/shared/bucketing/__tests__/bucketing.test.ts
@@ -5,6 +5,7 @@ import {
     EVAL_REASONS,
     EvalReason,
     FeatureType,
+    FilterType,
     PublicRollout,
     Rollout,
 } from '@devcycle/types'
@@ -1626,7 +1627,7 @@ describe('Bounded Hash Limits', () => {
                     _id: 'id',
                     filters: {
                         operator: AudienceOperator.and,
-                        filters: [],
+                        filters: [{ type: FilterType.all }],
                     },
                 },
                 distribution: [
@@ -1651,20 +1652,50 @@ describe('Bounded Hash Limits', () => {
             },
         },
         {
-            name: 'Single Distribution',
-            expectedVariation: 'var1',
+            name: 'Random Distribution & Rollout',
+            expectedVariation: '', // Don't test specific variation for random distribution
             target: {
                 _id: 'target',
                 _audience: {
                     _id: 'id',
                     filters: {
                         operator: AudienceOperator.and,
-                        filters: [],
+                        filters: [{ type: FilterType.all }],
                     },
                 },
                 distribution: [
                     {
-                        _variation: 'var1',
+                        _variation: 'var5',
+                        percentage: 0.6667,
+                    },
+                    {
+                        _variation: 'var6',
+                        percentage: 0.3333,
+                    },
+                ],
+                bucketingKey: 'user_id',
+                rollout: {
+                    startDate: new Date(moment().subtract(1, 'days').toDate()),
+                    startPercentage: 0,
+                    type: 'schedule',
+                } as Rollout,
+            },
+        },
+        {
+            name: 'Single Distribution',
+            expectedVariation: 'var7',
+            target: {
+                _id: 'target',
+                _audience: {
+                    _id: 'id',
+                    filters: {
+                        operator: AudienceOperator.and,
+                        filters: [{ type: FilterType.all }],
+                    },
+                },
+                distribution: [
+                    {
+                        _variation: 'var7',
                         percentage: 1,
                     },
                 ],
@@ -1679,10 +1710,25 @@ describe('Bounded Hash Limits', () => {
                 const variation = decideTargetVariation({
                     target: tc.target,
                     boundedHash: 0.2555,
+                    reasonDetails: 'All Users',
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
                     expect(variation.variation).toBe(tc.expectedVariation)
+                    expect(variation.eval?.reason).toBe(
+                        EVAL_REASONS.TARGETING_MATCH,
+                    )
+                    expect(variation.eval?.details).toBe('All Users')
+                } else if (tc.target.rollout) {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | Rollout | All Users',
+                    )
+                } else {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | All Users',
+                    )
                 }
             })
 
@@ -1690,10 +1736,25 @@ describe('Bounded Hash Limits', () => {
                 const variation = decideTargetVariation({
                     target: tc.target,
                     boundedHash: 0,
+                    reasonDetails: 'All Users',
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
                     expect(variation.variation).toBe(tc.expectedVariation)
+                    expect(variation.eval?.reason).toBe(
+                        EVAL_REASONS.TARGETING_MATCH,
+                    )
+                    expect(variation.eval?.details).toBe('All Users')
+                } else if (tc.target.rollout) {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | Rollout | All Users',
+                    )
+                } else {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | All Users',
+                    )
                 }
             })
 
@@ -1701,10 +1762,25 @@ describe('Bounded Hash Limits', () => {
                 const variation = decideTargetVariation({
                     target: tc.target,
                     boundedHash: 1,
+                    reasonDetails: 'All Users',
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
                     expect(variation.variation).toBe(tc.expectedVariation)
+                    expect(variation.eval?.reason).toBe(
+                        EVAL_REASONS.TARGETING_MATCH,
+                    )
+                    expect(variation.eval?.details).toBe('All Users')
+                } else if (tc.target.rollout) {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | Rollout | All Users',
+                    )
+                } else {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | All Users',
+                    )
                 }
             })
 
@@ -1712,10 +1788,25 @@ describe('Bounded Hash Limits', () => {
                 const variation = decideTargetVariation({
                     target: tc.target,
                     boundedHash: 0.9999999,
+                    reasonDetails: 'All Users',
                 })
                 expect(variation).toBeDefined()
                 if (tc.expectedVariation) {
                     expect(variation.variation).toBe(tc.expectedVariation)
+                    expect(variation.eval?.reason).toBe(
+                        EVAL_REASONS.TARGETING_MATCH,
+                    )
+                    expect(variation.eval?.details).toBe('All Users')
+                } else if (tc.target.rollout) {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | Rollout | All Users',
+                    )
+                } else {
+                    expect(variation.eval?.reason).toBe(EVAL_REASONS.SPLIT)
+                    expect(variation.eval?.details).toBe(
+                        'Random Distribution | All Users',
+                    )
                 }
             })
         })

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -99,6 +99,7 @@ export const decideTargetVariation = ({
                 eval: {
                     reason: evalReason,
                     details: evalReasonDetails,
+                    target_id: target._id,
                 },
             }
         }

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -71,6 +71,20 @@ export const decideTargetVariation = ({
     const isRollout = target.rollout !== undefined
     const isRandomDistribution = target.distribution.length !== 1
 
+    let evalReason = EVAL_REASONS.TARGETING_MATCH
+    let evalReasonDetails = reasonDetails
+
+    if (isRandomDistribution || isRollout) {
+        evalReason = EVAL_REASONS.SPLIT
+        const evalReasonPrefix =
+            isRandomDistribution && isRollout
+                ? `${EVAL_REASON_DETAILS.RANDOM_DISTRIBUTION} | ${EVAL_REASON_DETAILS.ROLLOUT}`
+                : isRandomDistribution
+                ? EVAL_REASON_DETAILS.RANDOM_DISTRIBUTION
+                : EVAL_REASON_DETAILS.ROLLOUT
+        evalReasonDetails = `${evalReasonPrefix} | ${reasonDetails}`
+    }
+
     let distributionIndex = 0
     const previousDistributionIndex = 0
     for (const variation of variations) {
@@ -82,16 +96,10 @@ export const decideTargetVariation = ({
         ) {
             return {
                 variation: variation._variation,
-                eval:
-                    isRollout || isRandomDistribution
-                        ? {
-                              reason: EVAL_REASONS.SPLIT,
-                              details: reasonDetails ?? undefined,
-                          }
-                        : {
-                              reason: EVAL_REASONS.TARGETING_MATCH,
-                              details: reasonDetails ?? undefined,
-                          },
+                eval: {
+                    reason: evalReason,
+                    details: evalReasonDetails,
+                },
             }
         }
     }

--- a/lib/shared/bucketing/src/bucketing.ts
+++ b/lib/shared/bucketing/src/bucketing.ts
@@ -72,7 +72,7 @@ export const decideTargetVariation = ({
     const isRandomDistribution = target.distribution.length !== 1
 
     let evalReason = EVAL_REASONS.TARGETING_MATCH
-    let evalReasonDetails = reasonDetails
+    let evalReasonDetails = reasonDetails ?? ''
 
     if (isRandomDistribution || isRollout) {
         evalReason = EVAL_REASONS.SPLIT
@@ -82,7 +82,7 @@ export const decideTargetVariation = ({
                 : isRandomDistribution
                 ? EVAL_REASON_DETAILS.RANDOM_DISTRIBUTION
                 : EVAL_REASON_DETAILS.ROLLOUT
-        evalReasonDetails = `${evalReasonPrefix} | ${reasonDetails}`
+        evalReasonDetails = `${evalReasonPrefix} | ${evalReasonDetails}`
     }
 
     let distributionIndex = 0

--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -79,6 +79,7 @@ export enum DEFAULT_REASON_DETAILS {
 export type EvalReason = {
     reason: EVAL_REASONS
     details?: string
+    target_id?: string
 }
 
 const boolTransform = ({ value }: { value: unknown }) => {

--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -57,6 +57,9 @@ export enum EVAL_REASON_DETAILS {
     APP_VERSION = 'App Version',
     DEVICE_MODEL = 'Device Model',
     CUSTOM_DATA = 'Custom Data',
+    // Split Details
+    RANDOM_DISTRIBUTION = 'Random Distribution',
+    ROLLOUT = 'Rollout',
 }
 
 export enum DEFAULT_REASON_DETAILS {

--- a/sdk/js-cloud-server/__tests__/cloudClient.spec.ts
+++ b/sdk/js-cloud-server/__tests__/cloudClient.spec.ts
@@ -40,6 +40,8 @@ describe('DevCycleCloudClient without EdgeDB', () => {
             expect(res.type).toEqual('Boolean')
             expect(res.eval).toEqual({
                 reason: 'TARGETING_MATCH',
+                details: 'User ID',
+                target_id: 'test-target-id',
             })
 
             await expect(
@@ -144,6 +146,8 @@ describe('DevCycleCloudClient without EdgeDB', () => {
                     defaultValue: false,
                     eval: {
                         reason: 'TARGETING_MATCH',
+                        details: 'User ID',
+                        target_id: 'test-target-id',
                     },
                 },
             })
@@ -179,6 +183,8 @@ describe('DevCycleCloudClient without EdgeDB', () => {
                     type: 'release',
                     eval: {
                         reason: 'TARGETING_MATCH',
+                        details: 'User ID',
+                        target_id: 'test-target-id',
                     },
                 },
             })
@@ -274,6 +280,8 @@ describe('DevCycleCloudClient with EdgeDB Enabled', () => {
             expect(res.isDefaulted).toBe(false)
             expect(res.eval).toEqual({
                 reason: 'OPT_IN',
+                details: 'Opt-In',
+                target_id: 'test-target-id-edgedb',
             })
 
             await expect(
@@ -366,6 +374,8 @@ describe('DevCycleCloudClient with EdgeDB Enabled', () => {
                     defaultValue: false,
                     eval: {
                         reason: 'OPT_IN',
+                        details: 'Opt-In',
+                        target_id: 'test-target-id-edgedb',
                     },
                 },
             })
@@ -401,6 +411,8 @@ describe('DevCycleCloudClient with EdgeDB Enabled', () => {
                     type: 'release',
                     eval: {
                         reason: 'OPT_IN',
+                        details: 'Opt-In',
+                        target_id: 'test-target-id-edgedb',
                     },
                 },
             })

--- a/sdk/js-cloud-server/src/__mocks__/handlers.ts
+++ b/sdk/js-cloud-server/src/__mocks__/handlers.ts
@@ -1,5 +1,5 @@
 // src/mocks/handlers.js
-import { EVAL_REASONS } from '@devcycle/types'
+import { EVAL_REASON_DETAILS, EVAL_REASONS } from '@devcycle/types'
 import { http, HttpResponse } from 'msw'
 
 export const handlers = [
@@ -31,6 +31,8 @@ export const handlers = [
                         defaultValue: false,
                         eval: {
                             reason: EVAL_REASONS.OPT_IN,
+                            details: EVAL_REASON_DETAILS.OPT_IN,
+                            target_id: 'test-target-id-edgedb',
                         },
                     },
                     { status: 200 },
@@ -44,6 +46,8 @@ export const handlers = [
                         defaultValue: false,
                         eval: {
                             reason: EVAL_REASONS.TARGETING_MATCH,
+                            details: EVAL_REASON_DETAILS.USER_ID,
+                            target_id: 'test-target-id',
                         },
                     },
                     { status: 200 },
@@ -76,6 +80,8 @@ export const handlers = [
                                 defaultValue: false,
                                 eval: {
                                     reason: EVAL_REASONS.OPT_IN,
+                                    details: EVAL_REASON_DETAILS.OPT_IN,
+                                    target_id: 'test-target-id-edgedb',
                                 },
                             },
                         },
@@ -91,6 +97,8 @@ export const handlers = [
                                 defaultValue: false,
                                 eval: {
                                     reason: EVAL_REASONS.TARGETING_MATCH,
+                                    details: EVAL_REASON_DETAILS.USER_ID,
+                                    target_id: 'test-target-id',
                                 },
                             },
                         },
@@ -127,6 +135,8 @@ export const handlers = [
                                 type: 'release',
                                 eval: {
                                     reason: EVAL_REASONS.OPT_IN,
+                                    details: EVAL_REASON_DETAILS.OPT_IN,
+                                    target_id: 'test-target-id-edgedb',
                                 },
                             },
                         },
@@ -144,6 +154,8 @@ export const handlers = [
                                 type: 'release',
                                 eval: {
                                     reason: EVAL_REASONS.TARGETING_MATCH,
+                                    details: EVAL_REASON_DETAILS.USER_ID,
+                                    target_id: 'test-target-id',
                                 },
                             },
                         },


### PR DESCRIPTION
- fix: adds `Random Distribution` or `Rollout` to eval reason details to better identify the evaluation reason of `SPLIT` 
- chore: adds new attribute of `target_id` to eval reason
- chore: updates test expectations for Random Distributions & Rollouts to include the proper evaluation reasons