### PR TITLE
feat: added hooks to js cloud server

### DIFF
--- a/sdk/js-cloud-server/__tests__/cloudClient.spec.ts
+++ b/sdk/js-cloud-server/__tests__/cloudClient.spec.ts
@@ -441,8 +441,11 @@ describe('DevCycleCloudClient with Hooks', () => {
     beforeAll(async () => {
         client = DVC.initializeDevCycle('dvc_server_token', {
             logLevel: 'error',
-            enableEdgeDB: true,
         })
+    })
+
+    afterEach(async () => {
+        await client.clearHooks()
     })
 
     it('should run hooks in correct order', async () => {
@@ -455,8 +458,8 @@ describe('DevCycleCloudClient with Hooks', () => {
         const onFinally = jest.fn()
         const error = jest.fn()
         client.addHook(new EvalHook(before, after, onFinally, error))
-        const variable = await client.variable(user, 'test-key', 'test')
-        expect(variable.value).toEqual('test')
+        const variable = await client.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
         expect(before).toHaveBeenCalled()
         expect(after).toHaveBeenCalled()
         expect(onFinally).toHaveBeenCalled()
@@ -468,16 +471,14 @@ describe('DevCycleCloudClient with Hooks', () => {
             user_id: 'node_sdk_test',
             country: 'CA',
         }
-        const before = jest.fn(() => {
-            throw new Error('test')
-        })
-        const after = jest.fn()
-        const onFinally = jest.fn()
-        const error = jest.fn()
+        const before = jest.fn().mockRejectedValue(new Error('test'))
+        const after = jest.fn().mockResolvedValue({})
+        const onFinally = jest.fn().mockResolvedValue({})
+        const error = jest.fn().mockResolvedValue({})
         client.addHook(new EvalHook(before, after, onFinally, error))
-        const variable = await client.variable(user, 'test-key', 'test')
-        expect(variable.value).toEqual('test')
-        expect(variable.isDefaulted).toEqual(true)
+        const variable = await client.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
+        expect(variable.isDefaulted).toEqual(false)
         expect(before).toHaveBeenCalled()
         expect(after).not.toHaveBeenCalled()
         expect(onFinally).toHaveBeenCalled()
@@ -489,16 +490,14 @@ describe('DevCycleCloudClient with Hooks', () => {
             user_id: 'node_sdk_test',
             country: 'CA',
         }
-        const before = jest.fn()
-        const after = jest.fn(() => {
-            throw new Error('test')
-        })
-        const onFinally = jest.fn()
-        const error = jest.fn()
+        const before = jest.fn().mockResolvedValue({})
+        const after = jest.fn().mockRejectedValue(new Error('test'))
+        const onFinally = jest.fn().mockResolvedValue({})
+        const error = jest.fn().mockResolvedValue({})
         client.addHook(new EvalHook(before, after, onFinally, error))
-        const variable = await client.variable(user, 'test-key', 'test')
-        expect(variable.value).toEqual('test')
-        expect(variable.isDefaulted).toEqual(true)
+        const variable = await client.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
+        expect(variable.isDefaulted).toEqual(false)
         expect(before).toHaveBeenCalled()
         expect(after).toHaveBeenCalled()
         expect(onFinally).toHaveBeenCalled()
@@ -510,16 +509,14 @@ describe('DevCycleCloudClient with Hooks', () => {
             user_id: 'node_sdk_test',
             country: 'CA',
         }
-        const before = jest.fn()
-        const after = jest.fn()
-        const onFinally = jest.fn(() => {
-            throw new Error('test')
-        })
-        const error = jest.fn()
+        const before = jest.fn().mockResolvedValue({})
+        const after = jest.fn().mockResolvedValue({})
+        const onFinally = jest.fn().mockRejectedValue(new Error('test'))
+        const error = jest.fn().mockResolvedValue({})
         client.addHook(new EvalHook(before, after, onFinally, error))
-        const variable = await client.variable(user, 'test-key', 'test')
-        expect(variable.value).toEqual('test')
-        expect(variable.isDefaulted).toEqual(true)
+        const variable = await client.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
+        expect(variable.isDefaulted).toEqual(false)
         expect(before).toHaveBeenCalled()
         expect(after).toHaveBeenCalled()
         expect(onFinally).toHaveBeenCalled()
@@ -530,18 +527,17 @@ describe('DevCycleCloudClient with Hooks', () => {
             user_id: 'node_sdk_test',
             country: 'CA',
         }
-        const before = jest.fn()
-        const after = jest.fn()
-        const onFinally = jest.fn()
-        const error = jest.fn(() => {
-            throw new Error('test')
-        })
+        const before = jest.fn().mockResolvedValue({})
+        const after = jest.fn().mockRejectedValue(new Error('test'))
+        const onFinally = jest.fn().mockResolvedValue({})
+        const error = jest.fn().mockRejectedValue(new Error('test'))
         client.addHook(new EvalHook(before, after, onFinally, error))
-        const variable = await client.variable(user, 'test-key', 'test')
-        expect(variable.value).toEqual('test')
-        expect(variable.isDefaulted).toEqual(true)
+        const variable = await client.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
+        expect(variable.isDefaulted).toEqual(false)
         expect(before).toHaveBeenCalled()
         expect(after).toHaveBeenCalled()
         expect(onFinally).toHaveBeenCalled()
+        expect(error).toHaveBeenCalled()
     })
 })

--- a/sdk/js-cloud-server/__tests__/evalHooksRunner.test.ts
+++ b/sdk/js-cloud-server/__tests__/evalHooksRunner.test.ts
@@ -1,0 +1,205 @@
+import { EvalHook } from '../src/hooks/EvalHook'
+import { EvalHooksRunner } from '../src/hooks/EvalHooksRunner'
+
+describe('EvalHooksRunner', () => {
+    it('should run hooks in correct order when resolver succeeds', async () => {
+        const hooksRunner = new EvalHooksRunner()
+        const hook1 = new EvalHook(
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        const hook2 = new EvalHook(
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        hooksRunner.enqueue(hook1)
+        hooksRunner.enqueue(hook2)
+        const result = hooksRunner.runHooksForEvaluation(
+            { user_id: 'test-user' },
+            'test-key',
+            'test-value',
+            async () => {
+                return {
+                    key: 'test-key',
+                    defaultValue: 'test-value',
+                    type: 'String',
+                    value: 'test-value',
+                    isDefaulted: false,
+                }
+            },
+        )
+        expect(result).toEqual({
+            key: 'test-key',
+            defaultValue: 'test-value',
+            isDefaulted: false,
+            type: 'String',
+            value: 'test-value',
+        })
+        expect(hook1.before).toHaveBeenCalledTimes(1)
+        expect(hook1.after).toHaveBeenCalledTimes(1)
+        expect(hook1.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook1.error).not.toHaveBeenCalled()
+        expect(hook2.before).toHaveBeenCalledTimes(1)
+        expect(hook2.after).toHaveBeenCalledTimes(1)
+        expect(hook2.onFinally).toHaveBeenCalledTimes(1)
+    })
+
+    it('should run hooks in correct order when resolver fails', () => {
+        const hooksRunner = new EvalHooksRunner()
+        const hook1 = new EvalHook(
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        const hook2 = new EvalHook(
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        hooksRunner.enqueue(hook1)
+        hooksRunner.enqueue(hook2)
+
+        expect(() =>
+            hooksRunner.runHooksForEvaluation(
+                { user_id: 'test-user' },
+                'test-key',
+                'test-value',
+                async () => {
+                    throw new Error('test-error')
+                },
+            ),
+        ).toThrow('test-error')
+
+        expect(hook1.before).toHaveBeenCalledTimes(1)
+        expect(hook1.after).toHaveBeenCalledTimes(0)
+        expect(hook1.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook1.error).toHaveBeenCalledTimes(1)
+        expect(hook2.before).toHaveBeenCalledTimes(1)
+        expect(hook2.after).toHaveBeenCalledTimes(0)
+        expect(hook2.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook2.error).toHaveBeenCalledTimes(1)
+    })
+
+    it('should change user in before hook', async () => {
+        const hooksRunner = new EvalHooksRunner()
+        const hook1 = new EvalHook(
+            jest.fn().mockImplementation((context) => {
+                return {
+                    ...context,
+                    user: {
+                        user_id: 'test-user-2',
+                    },
+                }
+            }),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        const hook2 = new EvalHook(
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        hooksRunner.enqueue(hook1)
+        hooksRunner.enqueue(hook2)
+        const resolver = jest.fn().mockImplementation((context) => {
+            return {
+                key: 'test-key',
+                defaultValue: 'test-value',
+                type: 'String',
+                value: 'test-value',
+                isDefaulted: false,
+            }
+        })
+        const result = await hooksRunner.runHooksForEvaluation(
+            { user_id: 'test-user' },
+            'test-key',
+            'test-value',
+            resolver,
+        )
+        expect(result).toEqual({
+            key: 'test-key',
+            defaultValue: 'test-value',
+            type: 'String',
+            value: 'test-value',
+            isDefaulted: false,
+        })
+        expect(hook1.before).toHaveBeenCalledTimes(1)
+        expect(hook1.after).toHaveBeenCalledTimes(1)
+        expect(hook1.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook1.error).not.toHaveBeenCalled()
+        expect(hook2.before).toHaveBeenCalledTimes(1)
+        expect(hook2.after).toHaveBeenCalledTimes(1)
+        expect(hook2.onFinally).toHaveBeenCalledTimes(1)
+
+        expect(hook2.before).toHaveBeenCalledWith(
+            expect.objectContaining({
+                user: {
+                    user_id: 'test-user-2',
+                },
+            }),
+        )
+        expect(resolver.mock.instances[0]).toEqual(
+            expect.objectContaining({
+                user: {
+                    user_id: 'test-user-2',
+                },
+            }),
+        )
+    })
+
+    it('should still work if before hook errors', async () => {
+        const hooksRunner = new EvalHooksRunner()
+        const hook1 = new EvalHook(
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        const hook2 = new EvalHook(
+            jest.fn().mockImplementation((context) => {
+                context.user.user_id = 'test-user-2'
+                throw new Error('test-error')
+            }),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+            jest.fn().mockResolvedValue({}),
+        )
+        hooksRunner.enqueue(hook1)
+        hooksRunner.enqueue(hook2)
+
+        const variable = {
+            key: 'test-key',
+            defaultValue: 'test-value',
+            type: 'String',
+            value: 'test-value',
+            isDefaulted: false,
+        }
+        const resolver = jest.fn().mockImplementation((context) => {
+            return variable
+        })
+        const result = await hooksRunner.runHooksForEvaluation(
+            { user_id: 'test-user' },
+            'test-key',
+            'test-value',
+            resolver,
+        )
+        expect(result).toEqual(variable)
+
+        expect(hook1.before).toHaveBeenCalledTimes(1)
+        expect(hook1.after).toHaveBeenCalledTimes(0)
+        expect(hook1.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook1.error).toHaveBeenCalledTimes(1)
+        expect(hook2.before).toHaveBeenCalledTimes(1)
+        expect(hook2.after).toHaveBeenCalledTimes(0)
+        expect(hook2.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook2.error).toHaveBeenCalledTimes(1)
+    })
+})

--- a/sdk/js-cloud-server/src/cloudClient.ts
+++ b/sdk/js-cloud-server/src/cloudClient.ts
@@ -29,6 +29,8 @@ import {
 } from './request'
 import { DevCycleUser } from './models/user'
 import { ResponseError } from '@devcycle/server-request'
+import { EvalHooksRunner } from './hooks/EvalHooksRunner'
+import { EvalHook } from './hooks/EvalHook'
 
 const castIncomingUser = (user: DevCycleUser) => {
     if (!(user instanceof DevCycleUser)) {
@@ -78,6 +80,7 @@ export class DevCycleCloudClient<
     protected logger: DVCLogger
     private options: DevCycleServerSDKOptions
     protected platformDetails: DevCyclePlatformDetails
+    private hooksRunner: EvalHooksRunner
 
     constructor(
         sdkKey: string,
@@ -89,6 +92,7 @@ export class DevCycleCloudClient<
             options.logger || dvcDefaultLogger({ level: options.logLevel })
         this.options = options
         this.platformDetails = platformDetails
+        this.hooksRunner = new EvalHooksRunner()
         this.logger.info('Running DevCycle NodeJS SDK in Cloud Bucketing mode')
     }
 
@@ -101,6 +105,19 @@ export class DevCycleCloudClient<
     }
 
     async variable<
+        K extends string & keyof Variables,
+        T extends DVCVariableValue & Variables[K],
+    >(user: DevCycleUser, key: K, defaultValue: T): Promise<DVCVariable<T>> {
+        return this.hooksRunner.runHooksForEvaluation(
+            user,
+            key,
+            defaultValue,
+            async (context) =>
+                this._variable(context.user ?? user, key, defaultValue),
+        )
+    }
+
+    async _variable<
         K extends string & keyof Variables,
         T extends DVCVariableValue & Variables[K],
     >(user: DevCycleUser, key: K, defaultValue: T): Promise<DVCVariable<T>> {
@@ -264,5 +281,9 @@ export class DevCycleCloudClient<
                 }`,
             )
         }
+    }
+
+    async addHook(hook: EvalHook): Promise<void> {
+        this.hooksRunner.enqueue(hook)
     }
 }

--- a/sdk/js-cloud-server/src/cloudClient.ts
+++ b/sdk/js-cloud-server/src/cloudClient.ts
@@ -113,7 +113,7 @@ export class DevCycleCloudClient<
             key,
             defaultValue,
             async (context) =>
-                this._variable(context.user ?? user, key, defaultValue),
+                this._variable(context?.user ?? user, key, defaultValue),
         )
     }
 
@@ -285,5 +285,9 @@ export class DevCycleCloudClient<
 
     async addHook(hook: EvalHook): Promise<void> {
         this.hooksRunner.enqueue(hook)
+    }
+
+    async clearHooks(): Promise<void> {
+        this.hooksRunner.clear()
     }
 }

--- a/sdk/js-cloud-server/src/hooks/EvalHook.ts
+++ b/sdk/js-cloud-server/src/hooks/EvalHook.ts
@@ -1,0 +1,22 @@
+import { DVCVariable, DVCVariableValue } from '../../src/'
+import { HookContext } from './HookContext'
+
+export class EvalHook {
+    constructor(
+        readonly before: <T extends DVCVariableValue>(
+            context: HookContext<T>,
+        ) => Promise<HookContext<T> | void>,
+        readonly after: <T extends DVCVariableValue>(
+            context: HookContext<T>,
+            variableDetails: DVCVariable<T>,
+        ) => Promise<void>,
+        readonly onFinally: <T extends DVCVariableValue>(
+            context: HookContext<T>,
+            variableDetails: DVCVariable<T> | undefined,
+        ) => Promise<void>,
+        readonly error: <T extends DVCVariableValue>(
+            context: HookContext<T>,
+            error: Error,
+        ) => Promise<void>,
+    ) {}
+}

--- a/sdk/js-cloud-server/src/hooks/EvalHooksRunner.ts
+++ b/sdk/js-cloud-server/src/hooks/EvalHooksRunner.ts
@@ -1,0 +1,129 @@
+import { DevCycleUser, DVCVariable } from '../../src/'
+import { EvalHook } from './EvalHook'
+import { HookContext } from './HookContext'
+import { DVCLogger } from '@devcycle/types'
+import { VariableValue as DVCVariableValue } from '@devcycle/types'
+
+export class EvalHooksRunner {
+    constructor(
+        private readonly hooks: EvalHook[] = [],
+        private readonly logger?: DVCLogger,
+    ) {}
+
+    async runHooksForEvaluation<T extends DVCVariableValue>(
+        user: DevCycleUser,
+        key: string,
+        defaultValue: T,
+        resolver: (context: HookContext<T>) => Promise<DVCVariable<T>>,
+    ): Promise<DVCVariable<T>> {
+        const context = new HookContext<T>(user, key, defaultValue, {})
+        const savedHooks = [...this.hooks]
+        const reversedHooks = [...savedHooks].reverse()
+
+        let beforeContext = context
+        let variableDetails: DVCVariable<T>
+        try {
+            beforeContext = await this.runBefore(savedHooks, context)
+            variableDetails = await resolver(beforeContext)
+            await this.runAfter(savedHooks, beforeContext, variableDetails)
+        } catch (error) {
+            await this.runError(reversedHooks, context, error)
+            await this.runFinally(reversedHooks, context, undefined)
+            if (
+                error.name === 'BeforeHookError' ||
+                error.name === 'AfterHookError'
+            ) {
+                // make sure to return with a variable if before or after hook errors
+                return await resolver(context)
+            }
+            throw error
+        }
+        await this.runFinally(reversedHooks, context, variableDetails)
+        return variableDetails
+    }
+
+    private async runBefore<T extends DVCVariableValue>(
+        hooks: EvalHook[],
+        context: HookContext<T>,
+    ): Promise<HookContext<T>> {
+        const contextCopy = { ...context }
+        try {
+            for (const hook of hooks) {
+                const newContext = await hook.before(contextCopy)
+                if (newContext) {
+                    Object.assign(contextCopy, {
+                        ...contextCopy,
+                        ...newContext,
+                    })
+                }
+            }
+        } catch (error) {
+            this.logger?.error('Error running before hooks', error)
+            throw new BeforeHookError(error)
+        }
+        return contextCopy
+    }
+
+    private async runAfter<T extends DVCVariableValue>(
+        hooks: EvalHook[],
+        context: HookContext<T>,
+        variableDetails: DVCVariable<T>,
+    ): Promise<void> {
+        try {
+            for (const hook of hooks) {
+                await hook.after(context, variableDetails)
+            }
+        } catch (error) {
+            this.logger?.error('Error running after hooks', error)
+            throw new AfterHookError(error)
+        }
+    }
+
+    private async runFinally<T extends DVCVariableValue>(
+        hooks: EvalHook[],
+        context: HookContext<T>,
+        variableDetails: DVCVariable<T> | undefined,
+    ): Promise<void> {
+        try {
+            for (const hook of hooks) {
+                await hook.onFinally(context, variableDetails)
+            }
+        } catch (error) {
+            this.logger?.error('Error running finally hooks', error)
+        }
+    }
+
+    private async runError<T extends DVCVariableValue>(
+        hooks: EvalHook[],
+        context: HookContext<T>,
+        error: Error,
+    ): Promise<void> {
+        try {
+            for (const hook of hooks) {
+                await hook.error(context, error)
+            }
+        } catch (error) {
+            this.logger?.error('Error running error hooks', error)
+        }
+    }
+
+    enqueue(hook: EvalHook): void {
+        this.hooks.push(hook)
+    }
+}
+
+class BeforeHookError extends Error {
+    constructor(error: Error) {
+        super(error.message)
+        this.name = 'BeforeHookError'
+        this.stack = error.stack
+    }
+}
+
+class AfterHookError extends Error {
+    constructor(error: Error) {
+        super(error.message)
+        this.name = 'AfterHookError'
+        this.stack = error.stack
+    }
+}

--- a/sdk/js-cloud-server/src/hooks/EvalHooksRunner.ts
+++ b/sdk/js-cloud-server/src/hooks/EvalHooksRunner.ts
@@ -6,7 +6,7 @@ import { VariableValue as DVCVariableValue } from '@devcycle/types'
 
 export class EvalHooksRunner {
     constructor(
-        private readonly hooks: EvalHook[] = [],
+        private hooks: EvalHook[] = [],
         private readonly logger?: DVCLogger,
     ) {}
 
@@ -25,7 +25,7 @@ export class EvalHooksRunner {
         try {
             beforeContext = await this.runBefore(savedHooks, context)
             variableDetails = await resolver(beforeContext)
-            await this.runAfter(savedHooks, beforeContext, variableDetails)
+            await this.runAfter(reversedHooks, beforeContext, variableDetails)
         } catch (error) {
             await this.runError(reversedHooks, context, error)
             await this.runFinally(reversedHooks, context, undefined)
@@ -109,6 +109,10 @@ export class EvalHooksRunner {
 
     enqueue(hook: EvalHook): void {
         this.hooks.push(hook)
+    }
+
+    clear(): void {
+        this.hooks = []
     }
 }
 

--- a/sdk/js-cloud-server/src/hooks/HookContext.ts
+++ b/sdk/js-cloud-server/src/hooks/HookContext.ts
@@ -1,0 +1,10 @@
+import { DevCycleUser, DVCVariableValue } from '../../src/'
+
+export class HookContext<T extends DVCVariableValue> {
+    constructor(
+        public user: DevCycleUser,
+        public readonly variableKey: string,
+        public readonly defaultValue: T,
+        public readonly metadata: { [key: string]: string },
+    ) {}
+}

--- a/sdk/js-cloud-server/src/index.ts
+++ b/sdk/js-cloud-server/src/index.ts
@@ -2,7 +2,7 @@ import { DevCycleServerSDKOptions } from '@devcycle/types'
 import { DevCycleCloudClient } from './cloudClient'
 import { isValidServerSDKKey } from './utils/paramUtils'
 import { DevCycleUser } from './models/user'
-
+import { EvalHook } from './hooks/EvalHook'
 export { DevCycleCloudClient, DevCycleUser }
 export * from './models/populatedUser'
 export * from './models/user'
@@ -11,7 +11,7 @@ export * from './types'
 export * from './request'
 export * from './utils/logger'
 export * from './utils/paramUtils'
-
+export * from './hooks/EvalHook'
 type DevCycleCloudOptions = Pick<
     DevCycleServerSDKOptions,
     'logger' | 'logLevel' | 'enableEdgeDB' | 'bucketingAPIURI'

--- a/sdk/nodejs/__tests__/initialize.spec.ts
+++ b/sdk/nodejs/__tests__/initialize.spec.ts
@@ -1,3 +1,4 @@
+import { EvalHook } from '@devcycle/js-cloud-server-sdk'
 import {
     DevCycleCloudClient,
     DevCycleProvider,
@@ -90,5 +91,144 @@ describe('NodeJS SDK Initialize', () => {
                 enableCloudBucketing: true,
             }),
         ).toThrow('Missing SDK key! Call initialize with a valid SDK key')
+    })
+})
+
+describe('NodeJS Cloud SDK Initialize with hooks', () => {
+    describe('hooks', () => {
+        beforeEach(() => {
+            jest.spyOn(global, 'fetch').mockImplementation(() => {
+                return Promise.resolve({
+                    json: () =>
+                        Promise.resolve({
+                            key: 'test-key',
+                            type: 'String',
+                            value: 'test',
+                        }),
+                    status: 200,
+                } as Response)
+            })
+        })
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('should run hooks in correct order', async () => {
+            const client = await initializeDevCycle('dvc_server_token', {
+                enableCloudBucketing: true,
+            })
+            const user = {
+                user_id: 'node_sdk_test',
+                country: 'CA',
+            }
+            const before = jest.fn()
+            const after = jest.fn()
+            const onFinally = jest.fn()
+            const error = jest.fn()
+            client.addHook(new EvalHook(before, after, onFinally, error))
+            const variable = await client.variable(user, 'test-key', 'test')
+            expect(variable.value).toEqual('test')
+            expect(before).toHaveBeenCalled()
+            expect(after).toHaveBeenCalled()
+            expect(onFinally).toHaveBeenCalled()
+            expect(error).not.toHaveBeenCalled()
+        })
+
+        it('should return a variable if a before hook errors', async () => {
+            const client = await initializeDevCycle('dvc_server_token', {
+                enableCloudBucketing: true,
+            })
+            const user = {
+                user_id: 'node_sdk_test',
+                country: 'CA',
+            }
+            const before = jest.fn(() => {
+                throw new Error('test')
+            })
+            const after = jest.fn()
+            const onFinally = jest.fn()
+            const error = jest.fn()
+            client.addHook(new EvalHook(before, after, onFinally, error))
+            const variable = await client.variable(user, 'test-key', 'test')
+            expect(variable.value).toEqual('test')
+            expect(variable.isDefaulted).toEqual(false)
+            expect(before).toHaveBeenCalled()
+            expect(after).not.toHaveBeenCalled()
+            expect(onFinally).toHaveBeenCalled()
+            expect(error).toHaveBeenCalled()
+        })
+
+        it('should return a variable if an after hook errors', async () => {
+            const client = await initializeDevCycle('dvc_server_token', {
+                enableCloudBucketing: true,
+            })
+            const user = {
+                user_id: 'node_sdk_test',
+                country: 'CA',
+            }
+            const before = jest.fn()
+            const after = jest.fn(() => {
+                throw new Error('test')
+            })
+            const onFinally = jest.fn()
+            const error = jest.fn()
+            client.addHook(new EvalHook(before, after, onFinally, error))
+            const variable = await client.variable(user, 'test-key', 'test')
+            expect(variable.value).toEqual('test')
+            expect(variable.isDefaulted).toEqual(false)
+            expect(before).toHaveBeenCalled()
+            expect(after).toHaveBeenCalled()
+            expect(onFinally).toHaveBeenCalled()
+            expect(error).toHaveBeenCalled()
+        })
+
+        it('should return a variable if an onFinally hook errors', async () => {
+            const client = await initializeDevCycle('dvc_server_token', {
+                enableCloudBucketing: true,
+            })
+            const user = {
+                user_id: 'node_sdk_test',
+                country: 'CA',
+            }
+            const before = jest.fn()
+            const after = jest.fn()
+            const onFinally = jest.fn(() => {
+                throw new Error('test')
+            })
+            const error = jest.fn()
+            client.addHook(new EvalHook(before, after, onFinally, error))
+            const variable = await client.variable(user, 'test-key', 'test')
+            expect(variable.value).toEqual('test')
+            expect(variable.isDefaulted).toEqual(false)
+            expect(before).toHaveBeenCalled()
+            expect(after).toHaveBeenCalled()
+            expect(onFinally).toHaveBeenCalled()
+        })
+
+        it('should return a variable if an error hook errors', async () => {
+            const client = await initializeDevCycle('dvc_server_token', {
+                enableCloudBucketing: true,
+            })
+            const user = {
+                user_id: 'node_sdk_test',
+                country: 'CA',
+            }
+            const before = jest.fn()
+            const after = jest.fn(() => {
+                throw new Error('test')
+            })
+            const onFinally = jest.fn()
+            const error = jest.fn(() => {
+                throw new Error('test')
+            })
+            client.addHook(new EvalHook(before, after, onFinally, error))
+            const variable = await client.variable(user, 'test-key', 'test')
+            expect(variable.value).toEqual('test')
+            expect(variable.isDefaulted).toEqual(false)
+            expect(before).toHaveBeenCalled()
+            expect(after).toHaveBeenCalled()
+            expect(onFinally).toHaveBeenCalled()
+        })
     })
 })


### PR DESCRIPTION
# Changes

- added eval hooks to js cloud server and nodejs cloud client

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
