### PR TITLE
feat: added hooks to options to initialize clients with hooks

### DIFF
--- a/sdk/js-cloud-server/__tests__/cloudClient.spec.ts
+++ b/sdk/js-cloud-server/__tests__/cloudClient.spec.ts
@@ -540,4 +540,51 @@ describe('DevCycleCloudClient with Hooks', () => {
         expect(onFinally).toHaveBeenCalled()
         expect(error).toHaveBeenCalled()
     })
+
+    it('should clear hooks', async () => {
+        const user = {
+            user_id: 'node_sdk_test',
+            country: 'CA',
+        }
+        const before = jest.fn()
+        const after = jest.fn()
+        const onFinally = jest.fn()
+        const error = jest.fn()
+        client.addHook(new EvalHook(before, after, onFinally, error))
+        client.clearHooks()
+        const variable = await client.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
+        expect(before).not.toHaveBeenCalled()
+        expect(after).not.toHaveBeenCalled()
+        expect(onFinally).not.toHaveBeenCalled()
+        expect(error).not.toHaveBeenCalled()
+    })
+
+    it('should run hooks when variable is evaluated with hooks option', async () => {
+        const before = jest.fn()
+        const after = jest.fn()
+        const onFinally = jest.fn()
+        const error = jest.fn()
+        const clientWithHooks = DVC.initializeDevCycle('dvc_server_token', {
+            logLevel: 'error',
+            hooks: [
+                {
+                    before,
+                    after,
+                    onFinally,
+                    error,
+                },
+            ],
+        })
+        const user = {
+            user_id: 'node_sdk_test',
+            country: 'CA',
+        }
+        const variable = await clientWithHooks.variable(user, 'test-key', false)
+        expect(variable.value).toEqual(true)
+        expect(before).toHaveBeenCalled()
+        expect(after).toHaveBeenCalled()
+        expect(onFinally).toHaveBeenCalled()
+        expect(error).not.toHaveBeenCalled()
+    })
 })

--- a/sdk/js-cloud-server/src/cloudClient.ts
+++ b/sdk/js-cloud-server/src/cloudClient.ts
@@ -31,6 +31,7 @@ import { DevCycleUser } from './models/user'
 import { ResponseError } from '@devcycle/server-request'
 import { EvalHooksRunner } from './hooks/EvalHooksRunner'
 import { EvalHook } from './hooks/EvalHook'
+import { DevCycleCloudOptions } from '.'
 
 const castIncomingUser = (user: DevCycleUser) => {
     if (!(user instanceof DevCycleUser)) {
@@ -78,13 +79,13 @@ export class DevCycleCloudClient<
 > {
     private sdkKey: string
     protected logger: DVCLogger
-    private options: DevCycleServerSDKOptions
+    private options: DevCycleCloudOptions
     protected platformDetails: DevCyclePlatformDetails
     private hooksRunner: EvalHooksRunner
 
     constructor(
         sdkKey: string,
-        options: DevCycleServerSDKOptions,
+        options: DevCycleCloudOptions,
         platformDetails: DevCyclePlatformDetails,
     ) {
         this.sdkKey = sdkKey
@@ -92,7 +93,7 @@ export class DevCycleCloudClient<
             options.logger || dvcDefaultLogger({ level: options.logLevel })
         this.options = options
         this.platformDetails = platformDetails
-        this.hooksRunner = new EvalHooksRunner()
+        this.hooksRunner = new EvalHooksRunner(options.hooks)
         this.logger.info('Running DevCycle NodeJS SDK in Cloud Bucketing mode')
     }
 

--- a/sdk/js-cloud-server/src/index.ts
+++ b/sdk/js-cloud-server/src/index.ts
@@ -3,6 +3,7 @@ import { DevCycleCloudClient } from './cloudClient'
 import { isValidServerSDKKey } from './utils/paramUtils'
 import { DevCycleUser } from './models/user'
 import { EvalHook } from './hooks/EvalHook'
+import { DVCVariableValue } from './types'
 export { DevCycleCloudClient, DevCycleUser }
 export * from './models/populatedUser'
 export * from './models/user'
@@ -12,13 +13,14 @@ export * from './request'
 export * from './utils/logger'
 export * from './utils/paramUtils'
 export * from './hooks/EvalHook'
-type DevCycleCloudOptions = Pick<
+export type DevCycleCloudOptions = Pick<
     DevCycleServerSDKOptions,
     'logger' | 'logLevel' | 'enableEdgeDB' | 'bucketingAPIURI'
 > & {
     platform?: 'NodeJS' | 'Electron' | 'EdgeWorker'
     platformVersion?: string
     hostname?: string
+    hooks?: EvalHook[]
 }
 
 export function initializeDevCycle(

--- a/sdk/js/__tests__/Client.test.ts
+++ b/sdk/js/__tests__/Client.test.ts
@@ -143,4 +143,43 @@ describe('DevCycleClient', () => {
         expect(mockOnFinally).toHaveBeenCalledTimes(3)
         expect(mockError).not.toHaveBeenCalled()
     })
+
+    it('should call hooks when variable is evaluated with hooks option', () => {
+        const mockBefore = jest.fn()
+        const mockAfter = jest.fn()
+        const mockOnFinally = jest.fn()
+        const mockError = jest.fn()
+
+        const client = new DevCycleClient<Variables>(
+            'test',
+            {
+                user_id: 'test',
+            },
+            {
+                hooks: [
+                    {
+                        before: (context) => {
+                            mockBefore(context)
+                        },
+                        after: (context) => {
+                            mockAfter(context)
+                        },
+                        onFinally: (context) => {
+                            mockOnFinally(context)
+                        },
+                        error: (context, error) => {
+                            mockError(context, error)
+                        },
+                    },
+                ],
+            },
+        )
+
+        client.variable('bool', true)
+
+        expect(mockBefore).toHaveBeenCalled()
+        expect(mockAfter).toHaveBeenCalled()
+        expect(mockOnFinally).toHaveBeenCalled()
+        expect(mockError).not.toHaveBeenCalled()
+    })
 })

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -132,7 +132,7 @@ export class DevCycleClient<
 
         this.sdkKey = sdkKey
         this.variableDefaultMap = {}
-        this.evalHooksRunner = new EvalHooksRunner()
+        this.evalHooksRunner = new EvalHooksRunner(options.hooks)
 
         if (
             !(
@@ -783,6 +783,10 @@ export class DevCycleClient<
 
     addHook(hook: EvalHook<DVCVariableValue>): void {
         this.evalHooksRunner.enqueue(hook)
+    }
+
+    clearHooks(): void {
+        this.evalHooksRunner.clear()
     }
 
     private handleConfigReceived(

--- a/sdk/js/src/hooks/EvalHooksRunner.ts
+++ b/sdk/js/src/hooks/EvalHooksRunner.ts
@@ -7,7 +7,7 @@ import { DVCLogger } from '@devcycle/types'
 
 export class EvalHooksRunner {
     constructor(
-        private readonly hooks: EvalHook<DVCVariableValue>[] = [],
+        private hooks: EvalHook<DVCVariableValue>[] = [],
         private readonly logger?: DVCLogger,
     ) {}
 
@@ -100,5 +100,9 @@ export class EvalHooksRunner {
 
     enqueue(hook: EvalHook<DVCVariableValue>): void {
         this.hooks.push(hook)
+    }
+
+    clear(): void {
+        this.hooks = []
     }
 }

--- a/sdk/js/src/types.ts
+++ b/sdk/js/src/types.ts
@@ -12,6 +12,7 @@ import type {
     SSEConnectionConstructor,
     EvalReason,
 } from '@devcycle/types'
+import { EvalHook } from './hooks/EvalHook'
 export { UserError } from '@devcycle/types'
 
 export type DVCVariableValue = VariableValue
@@ -141,6 +142,11 @@ export interface DevCycleOptions {
      * Example values ('of' for OpenFeature): 'js' | 'react' | 'react-native' | 'nextjs' | 'js-of' | 'react-of'
      */
     sdkPlatform?: string
+
+    /**
+     * A list of hooks to run before and after the variable evaluation.
+     */
+    hooks?: EvalHook<DVCVariableValue>[]
 }
 
 export interface DevCycleUser<T extends DVCCustomDataJSON = DVCCustomDataJSON> {


### PR DESCRIPTION
# Changes

- added hooks to options to initialize clients with

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
