### PR TITLE
feat: add _feature to the evaluated variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 .yarn/*
 !.yarn/patches
 !.yarn/plugins
-!.yarn/releases
 !.yarn/sdks
 !.yarn/versions
 lerna-debug.log

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,5 +5,3 @@ compressionLevel: mixed
 enableGlobalCache: false
 
 nodeLinker: pnpm
-
-yarnPath: .yarn/releases/yarn-4.9.1.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ compressionLevel: mixed
 enableGlobalCache: false
 
 nodeLinker: pnpm
+
+yarnPath: .yarn/releases/yarn-4.9.1.cjs

--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -360,6 +360,7 @@ export class DevCycleClient<
             if (configVariable) {
                 if (configVariable.type === type) {
                     data.value = configVariable.value as VariableTypeAlias<T>
+                    data._feature = configVariable._feature
                     data.eval = configVariable.eval
                 } else {
                     this.logger.warn(

--- a/sdk/js/src/Variable.ts
+++ b/sdk/js/src/Variable.ts
@@ -7,7 +7,7 @@ export interface DVCVariableOptions<T> {
     defaultValue: T
     value?: VariableTypeAlias<T>
     eval?: EvalReason
-    _feature?: string
+    _feature?: string | null
 }
 
 export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
@@ -18,7 +18,7 @@ export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
     readonly defaultValue: T
     isDefaulted: boolean
     readonly eval?: EvalReason
-    readonly _feature?: string
+    readonly _feature: string | null
 
     constructor(variable: DVCVariableOptions<T>) {
         const { key, defaultValue } = variable
@@ -36,7 +36,7 @@ export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
 
         this.defaultValue = variable.defaultValue
         this.eval = variable.eval
-        this._feature = variable._feature || undefined
+        this._feature = variable._feature || null
     }
 
     onUpdate(callback: (value: VariableTypeAlias<T>) => void): DVCVariable<T> {

--- a/sdk/js/src/Variable.ts
+++ b/sdk/js/src/Variable.ts
@@ -7,6 +7,7 @@ export interface DVCVariableOptions<T> {
     defaultValue: T
     value?: VariableTypeAlias<T>
     eval?: EvalReason
+    _feature?: string
 }
 
 export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
@@ -17,6 +18,7 @@ export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
     readonly defaultValue: T
     isDefaulted: boolean
     readonly eval?: EvalReason
+    readonly _feature?: string
 
     constructor(variable: DVCVariableOptions<T>) {
         const { key, defaultValue } = variable
@@ -34,6 +36,7 @@ export class DVCVariable<T extends DVCVariableValue> implements Variable<T> {
 
         this.defaultValue = variable.defaultValue
         this.eval = variable.eval
+        this._feature = variable._feature || undefined
     }
 
     onUpdate(callback: (value: VariableTypeAlias<T>) => void): DVCVariable<T> {

--- a/sdk/nodejs/src/pb-types/pbTypeHelpers.ts
+++ b/sdk/nodejs/src/pb-types/pbTypeHelpers.ts
@@ -48,5 +48,9 @@ export function pbSDKVariableTransform(
             !variable.evalReason || variable.evalReason.isNull
                 ? null
                 : variable.evalReason,
+        _feature:
+            !variable._feature || variable._feature.isNull
+                ? null
+                : variable._feature.value,
     }
 }

--- a/sdk/openfeature-angular-provider/__tests__/DevCycleAngularProvider.test.ts
+++ b/sdk/openfeature-angular-provider/__tests__/DevCycleAngularProvider.test.ts
@@ -43,7 +43,7 @@ async function initOFClient(): Promise<{
                 value: true,
                 defaultValue: false,
                 isDefaulted: false,
-                _feature: 'boolean-flag',
+                _feature: '614ef6aa473928459060721a',
                 eval: {
                     reason: EVAL_REASONS.TARGETING_MATCH,
                 },

--- a/sdk/openfeature-angular-provider/__tests__/DevCycleAngularProvider.test.ts
+++ b/sdk/openfeature-angular-provider/__tests__/DevCycleAngularProvider.test.ts
@@ -43,6 +43,7 @@ async function initOFClient(): Promise<{
                 value: true,
                 defaultValue: false,
                 isDefaulted: false,
+                _feature: 'boolean-flag',
                 eval: {
                     reason: EVAL_REASONS.TARGETING_MATCH,
                 },

--- a/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
+++ b/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
@@ -43,7 +43,7 @@ async function initOFClient(): Promise<{
                 value: true,
                 defaultValue: false,
                 isDefaulted: false,
-                _feature: 'boolean-flag',
+                _feature: '614ef6aa473928459060721a',
                 eval: {
                     reason: EVAL_REASONS.TARGETING_MATCH,
                 },

--- a/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
+++ b/sdk/openfeature-react-provider/__tests__/DevCycleReactProvider.test.ts
@@ -43,6 +43,7 @@ async function initOFClient(): Promise<{
                 value: true,
                 defaultValue: false,
                 isDefaulted: false,
+                _feature: 'boolean-flag',
                 eval: {
                     reason: EVAL_REASONS.TARGETING_MATCH,
                 },

--- a/sdk/openfeature-web-provider/__tests__/DevCycleProvider.test.ts
+++ b/sdk/openfeature-web-provider/__tests__/DevCycleProvider.test.ts
@@ -43,7 +43,7 @@ async function initOFClient(): Promise<{
                 value: true,
                 defaultValue: false,
                 isDefaulted: false,
-                _feature: 'boolean-flag',
+                _feature: '614ef6aa473928459060721a',
                 eval: {
                     reason: EVAL_REASONS.TARGETING_MATCH,
                 },

--- a/sdk/openfeature-web-provider/__tests__/DevCycleProvider.test.ts
+++ b/sdk/openfeature-web-provider/__tests__/DevCycleProvider.test.ts
@@ -43,6 +43,7 @@ async function initOFClient(): Promise<{
                 value: true,
                 defaultValue: false,
                 isDefaulted: false,
+                _feature: 'boolean-flag',
                 eval: {
                     reason: EVAL_REASONS.TARGETING_MATCH,
                 },


### PR DESCRIPTION
- add _feature property to protobuf version and also to the DVC variable  

benchmark changes
<img width="999" alt="image" src="https://github.com/user-attachments/assets/54981333-746f-46b3-a798-211683980167" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
