### PR TITLE
feat: added variable definition typing for decorators in nestjs sdk

### DIFF
--- a/sdk/nestjs/src/RequireVariableValue.ts
+++ b/sdk/nestjs/src/RequireVariableValue.ts
@@ -10,20 +10,18 @@ import {
 } from '@nestjs/common'
 import { DVCVariableValue, DevCycleClient } from '@devcycle/nodejs-server-sdk'
 import { ClsService } from 'nestjs-cls'
-
-type VariableValues = {
-    [key: string]: DVCVariableValue
-}
+import { VariableDefinitions } from '@devcycle/types'
+import { VariableValueData } from './VariableValue'
 
 export const RequireVariableValue = (
-    requiredVariables: VariableValues,
+    requiredVariables: VariableValueData<keyof VariableDefinitions>,
 ): ClassDecorator & MethodDecorator =>
     applyDecorators(
         UseInterceptors(RequireVariableValueInterceptor(requiredVariables)),
     )
 
 const RequireVariableValueInterceptor = (
-    requiredVariableValues: VariableValues,
+    requiredVariableValues: VariableValueData<keyof VariableDefinitions>,
 ) => {
     class RequireVariableValueInterceptor implements NestInterceptor {
         constructor(

--- a/sdk/nestjs/src/VariableValue.ts
+++ b/sdk/nestjs/src/VariableValue.ts
@@ -5,23 +5,31 @@ import {
     DevCycleUser,
 } from '@devcycle/nodejs-server-sdk'
 import { ClsServiceManager } from 'nestjs-cls'
+import { VariableDefinitions } from '@devcycle/types'
 
-type VariableValueData = {
-    key: string
-    default: DVCVariableValue
+export type VariableValueData<
+    K extends keyof VariableDefinitions,
+    T extends VariableDefinitions = VariableDefinitions,
+> = {
+    key: K extends string ? K : never
+    default: T extends DVCVariableValue & VariableDefinitions[K]
+        ? DVCVariableValue
+        : never
 }
 
-export const VariableValue = createParamDecorator((data: VariableValueData) => {
-    const cls = ClsServiceManager.getClsService()
+export const VariableValue = createParamDecorator(
+    (data: VariableValueData<keyof VariableDefinitions>) => {
+        const cls = ClsServiceManager.getClsService()
 
-    const client = cls.get('dvc_client') as DevCycleClient | undefined
-    const user = cls.get('dvc_user') as DevCycleUser | undefined
+        const client = cls.get('dvc_client') as DevCycleClient | undefined
+        const user = cls.get('dvc_user') as DevCycleUser | undefined
 
-    if (!client || !user) {
-        throw new Error(
-            'Missing DevCycle context. Is the DevCycleModule imported?',
-        )
-    }
+        if (!client || !user) {
+            throw new Error(
+                'Missing DevCycle context. Is the DevCycleModule imported?',
+            )
+        }
 
-    return client.variableValue(user, data.key, data.default)
-})
+        return client.variableValue(user, data.key, data.default)
+    },
+)


### PR DESCRIPTION
# Changes

- changed variable decorators to use variable definitions so that there's more strict typing on the variable keys if the user chooses to define them

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
