### PR TITLE
add eval to variable result, add default reasons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# DevCycle JS SDKs - Agent Guidelines
+
+## Build/Lint/Test Commands
+- **Lint all**: `yarn lint` or `nx run-many --parallel --target lint --all`
+- **Test all**: `yarn test` or `nx run-many --parallel --target test --all`
+- **Type check**: `yarn check-types` or `nx run-many --parallel --target check-types --all`
+- **Single project test**: `nx test <project-name>` (e.g., `nx test nodejs`)
+- **Single project lint**: `nx lint <project-name>`
+- **Build**: `nx build <project-name>`
+- **Format**: `yarn prettier:format`
+
+## Code Style Guidelines
+- **Formatting**: Prettier handles all formatting (4 spaces, single quotes, no semicolons, trailing commas)
+- **Linting**: ESLint enforces code quality with TypeScript strict rules
+- **Naming**: camelCase for files/variables, kebab-case for folders
+- **Imports**: Use package names for internal libraries (`@devcycle/bucketing`) not relative paths
+- **Types**: Explicit module boundary types required (`@typescript-eslint/explicit-module-boundary-types`)
+- **Lodash**: Import specific methods only (`lodash/import-scope: method`)
+
+## Git Conventions
+- **Commits**: Follow Conventional Commits: `<type>: <description>` (feat, fix, docs, etc.)
+- **Aviator CLI**: Optional but recommended for stacked branches (`av branch`, `av sync --push=yes`, `av pr`)

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -18,6 +18,8 @@ import {
     VariableDefinitions,
     InferredVariableType,
     DVCCustomDataJSON,
+    EVAL_REASONS,
+    DEFAULT_REASON_DETAILS,
 } from '@devcycle/types'
 import os from 'os'
 import {
@@ -256,6 +258,10 @@ export class DevCycleClient<
                 defaultValue,
                 type,
                 key,
+                eval: {
+                    reason: EVAL_REASONS.DEFAULT,
+                    details: DEFAULT_REASON_DETAILS.MISSING_CONFIG,
+                },
             })
         }
 
@@ -275,8 +281,12 @@ export class DevCycleClient<
         if (configVariable) {
             if (type === configVariable.type) {
                 options.value = configVariable.value as VariableTypeAlias<T>
-                options.evalReason = configVariable.eval?.reason
+                options.eval = configVariable?.eval
             } else {
+                options.eval = {
+                    reason: EVAL_REASONS.DEFAULT,
+                    details: DEFAULT_REASON_DETAILS.TYPE_MISMATCH,
+                }
                 this.logger.error(
                     `Type mismatch for variable ${key}. Expected ${type}, got ${configVariable.type}`,
                 )

--- a/sdk/nodejs/src/pb-types/pbTypeHelpers.ts
+++ b/sdk/nodejs/src/pb-types/pbTypeHelpers.ts
@@ -48,5 +48,6 @@ export function pbSDKVariableTransform(
             !variable.evalReason || variable.evalReason.isNull
                 ? null
                 : variable.evalReason,
+        eval: variable.eval,
     }
 }


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
