### PR TITLE
add back to sdk type

### DIFF
--- a/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
+++ b/lib/shared/types/src/types/apis/sdk/clientSDKAPI.ts
@@ -399,6 +399,9 @@ export class DVCOptInUser {
 export type SDKVariable = PublicVariable & {
     value: VariableValue
     _feature?: string
+    /**
+     * @deprecated use eval instead
+     */
     evalReason?: unknown
     eval?: EvalReason
 }
@@ -410,6 +413,10 @@ export type SDKFeature = Pick<
     _variation: string
     variationName: string
     variationKey: string
+    /**
+     * @deprecated use eval instead
+     */
+    evalReason?: unknown
     eval?: EvalReason
 }
 


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
