### PR TITLE
fix: setting OpenFeature Provider sdkPlatform, update tests, mark getOpenFeatureProvider() as deprecated

### DIFF
--- a/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
+++ b/sdk/nodejs/__tests__/open-feature-provider/DevCycleProvider.test.ts
@@ -70,8 +70,8 @@ describe.each(['DevCycleClient', 'DevCycleCloudClient'])(
         }
 
         beforeEach(() => {
-            variableMock.mockClear()
-            cloudVariableMock.mockClear()
+            variableMock.mockReset()
+            cloudVariableMock.mockReset()
         })
 
         afterEach(async () => {

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -184,6 +184,9 @@ export class DevCycleClient<
         })
     }
 
+    /**
+     * @deprecated Use DevCycleProvider directly instead. See docs: https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature
+     */
     async getOpenFeatureProvider(): Promise<DevCycleProvider> {
         if (this.openFeatureProvider) return this.openFeatureProvider
 

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -185,7 +185,8 @@ export class DevCycleClient<
     }
 
     /**
-     * @deprecated Use DevCycleProvider directly instead. See docs: https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature
+     * @deprecated Use DevCycleProvider directly instead.
+     * See docs: https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature
      */
     async getOpenFeatureProvider(): Promise<DevCycleProvider> {
         if (this.openFeatureProvider) return this.openFeatureProvider

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -36,7 +36,8 @@ class DevCycleCloudClient<
     }
 
     /**
-     * @deprecated Use DevCycleProvider directly instead. See docs: https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature
+     * @deprecated Use DevCycleProvider directly instead.
+     * See docs: https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature
      */
     async getOpenFeatureProvider(): Promise<DevCycleProvider> {
         if (this.openFeatureProvider) return this.openFeatureProvider

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -35,6 +35,9 @@ class DevCycleCloudClient<
         this.sdkPlatform = options.sdkPlatform
     }
 
+    /**
+     * @deprecated Use DevCycleProvider directly instead. See docs: https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature
+     */
     async getOpenFeatureProvider(): Promise<DevCycleProvider> {
         if (this.openFeatureProvider) return this.openFeatureProvider
 

--- a/sdk/nodejs/src/open-feature/DevCycleProvider.ts
+++ b/sdk/nodejs/src/open-feature/DevCycleProvider.ts
@@ -79,10 +79,10 @@ export class DevCycleProvider implements Provider {
             | DevCycleOptionsCloudEnabled = {},
     ) {
         if (typeof clientOrKey === 'string') {
-            this.devcycleClient = initializeDevCycle(
-                clientOrKey,
-                options as DevCycleServerSDKOptions,
-            )
+            this.devcycleClient = initializeDevCycle(clientOrKey, {
+                ...(options as DevCycleServerSDKOptions),
+                sdkPlatform: 'nodejs-of',
+            })
         } else {
             this.devcycleClient = clientOrKey
         }


### PR DESCRIPTION
## Fix OpenFeature Provider SDK Platform and Test Issues

### Problem
- SDK platform not properly identified for OpenFeature integration
- Deprecated `getOpenFeatureProvider()` method lacked clear guidance
- OpenFeature provider tests failing due to improper client instantiation and mock bleeding

### Changes
- **Platform**: Set `sdkPlatform` to `'nodejs-of'` for proper tracking
- **Deprecation**: Added warnings to `getOpenFeatureProvider()` methods with migration docs
- **Tests**: Fixed client type instantiation and added proper mock cleanup with `afterEach`

### Migration
```typescript
// Before (deprecated)
const client = new DevCycleClient(sdkKey, options)
const provider = await client.getOpenFeatureProvider()

// After
const provider = new DevCycleProvider(sdkKey, options)
// For cloud: new DevCycleProvider(sdkKey, { ...options, enableCloudBucketing: true })
```

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
