### PR TITLE
chore: Cleanup unused package resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,6 @@
         "semver@7.3.7": "^7.5.2",
         "semver@7.5.3": "^7.5.2",
         "@altack/nx-bundlefy@^0.16.0": "patch:@altack/nx-bundlefy@npm%3A0.16.0#./.yarn/patches/@altack-nx-bundlefy-npm-0.16.0-fc464002e3.patch",
-        "express@4.18.3": "~4.19.2",
         "ejs@3.1.8": "3.1.10",
         "path-to-regexp@3.2.0": "^3.3.0",
         "path-to-regexp@0.1.10": "^0.1.12",


### PR DESCRIPTION
Remove an outdated `express` resolution from `package.json`.

The `express@4.18.3": "~4.19.2"` resolution was removed after `yarn why` confirmed that `express` was already resolving to newer versions (4.21.x), rendering this specific resolution unnecessary and outdated.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-92f77939-0579-45f8-b6cf-cb6cff589099) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-92f77939-0579-45f8-b6cf-cb6cff589099)