### PR TITLE
fix: update config metadata to stringify properly

### DIFF
--- a/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
+++ b/lib/shared/bucketing-assembly-script/assembly/types/configBody.ts
@@ -266,8 +266,14 @@ export class ConfigMetadata {
 
     stringify(): string {
         const json = new JSON.Obj()
-        json.set('project', this.project.stringify())
-        json.set('environment', this.environment.stringify())
+        const project = new JSON.Obj()
+        project.set('id', this.project.id)
+        project.set('key', this.project.key)
+        const environment = new JSON.Obj()
+        environment.set('id', this.environment.id)
+        environment.set('key', this.environment.key)
+        json.set('project', project)
+        json.set('environment', environment)
         return json.stringify()
     }
 }

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -519,7 +519,6 @@ export class DevCycleClient<
         if (!this.bucketingLib) {
             return
         }
-        console.warn(this.bucketingLib.getConfigMetadata(this.sdkKey))
         return JSON.parse(
             this.bucketingLib.getConfigMetadata(this.sdkKey),
         ) as ConfigMetadata

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -519,6 +519,7 @@ export class DevCycleClient<
         if (!this.bucketingLib) {
             return
         }
+        console.warn(this.bucketingLib.getConfigMetadata(this.sdkKey))
         return JSON.parse(
             this.bucketingLib.getConfigMetadata(this.sdkKey),
         ) as ConfigMetadata


### PR DESCRIPTION
- instead of stringifying the object, adding the project and environment to be objects and stringifying the parent object
- tested locally using devapp

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
