### PR TITLE
fix(client): ReferenceError: Property 'document' doesn't exist on react native

### DIFF
--- a/sdk/js/src/Client.ts
+++ b/sdk/js/src/Client.ts
@@ -715,7 +715,7 @@ export class DevCycleClient<
 
         this._closing = true
 
-        if (document && this.pageVisibilityHandler) {
+        if (typeof document !== undefined && this.pageVisibilityHandler) {
             document.removeEventListener(
                 'visibilitychange',
                 this.pageVisibilityHandler,


### PR DESCRIPTION
When using `@devcycle/react-client-sdk` we keep getting a reference error because the global `document` object doesn't exist on react-native.

Seems like we are guarding against this when [registering the visibility changed handlers](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/Client.ts#L916-L918), but not when closing the client and unregistering.