### PR TITLE
feat: provide featureId to hooks

### DIFF
--- a/sdk/js-cloud-server/src/models/variable.ts
+++ b/sdk/js-cloud-server/src/models/variable.ts
@@ -58,3 +58,7 @@ export class DVCVariable<
         this.type = type
     }
 }
+
+export class VariableMetadata {
+    constructor(public featureId?: string | null) {}
+}

--- a/sdk/js-cloud-server/src/models/variable.ts
+++ b/sdk/js-cloud-server/src/models/variable.ts
@@ -60,7 +60,7 @@ export class DVCVariable<
 }
 
 export class VariableMetadata {
-    constructor(public featureId?: string | null) {}
+    constructor(public featureId?: string) {}
 }
 
 export class VariableWithMetadata<T extends DVCVariableValue> {

--- a/sdk/js-cloud-server/src/models/variable.ts
+++ b/sdk/js-cloud-server/src/models/variable.ts
@@ -63,12 +63,12 @@ export class VariableMetadata {
     constructor(public featureId?: string | null) {}
 }
 
-export class VariableWithMetadata<
-    T extends DVCVariableValue,
-    K extends VariableKey = VariableKey,
-> {
-    metadata?: VariableMetadata
-    constructor(public variable: DVCVariable<T, K>, featureId?: string | null) {
+export class VariableWithMetadata<T extends DVCVariableValue> {
+    variable: DVCVariable<T>
+    metadata: VariableMetadata
+
+    constructor(variableParams: VariableParam<T>, featureId?: string) {
+        this.variable = new DVCVariable<T>(variableParams)
         this.metadata = new VariableMetadata(featureId)
     }
 }

--- a/sdk/js-cloud-server/src/models/variable.ts
+++ b/sdk/js-cloud-server/src/models/variable.ts
@@ -63,7 +63,7 @@ export class VariableMetadata {
     constructor(public featureId?: string) {}
 }
 
-export class VariableWithMetadata<T extends DVCVariableValue> {
+export class VariableAndMetadata<T extends DVCVariableValue> {
     variable: DVCVariable<T>
     metadata: VariableMetadata
 

--- a/sdk/js-cloud-server/src/models/variable.ts
+++ b/sdk/js-cloud-server/src/models/variable.ts
@@ -62,3 +62,13 @@ export class DVCVariable<
 export class VariableMetadata {
     constructor(public featureId?: string | null) {}
 }
+
+export class VariableWithMetadata<
+    T extends DVCVariableValue,
+    K extends VariableKey = VariableKey,
+> {
+    metadata?: VariableMetadata
+    constructor(public variable: DVCVariable<T, K>, featureId?: string | null) {
+        this.metadata = new VariableMetadata(featureId)
+    }
+}

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -1,3 +1,4 @@
+import { VariableWithMetadata } from '@devcycle/js-cloud-server-sdk'
 import { EvalHook } from '../src/hooks/EvalHook'
 import { EvalHooksRunner } from '../src/hooks/EvalHooksRunner'
 
@@ -18,22 +19,23 @@ describe('EvalHooksRunner', () => {
         )
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
+        const variableMock: VariableWithMetadata<string, string> = {
+            variable: {
+                key: 'test-key',
+                defaultValue: 'test-value',
+                type: 'String',
+                value: 'test-value',
+                isDefaulted: false,
+            },
+            metadata: { featureId: 'featureId' },
+        }
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },
             'test-key',
             'test-value',
             {},
             () => {
-                return {
-                    variable: {
-                        key: 'test-key',
-                        defaultValue: 'test-value',
-                        type: 'String',
-                        value: 'test-value',
-                        isDefaulted: false,
-                    },
-                    metadata: { featureId: 'featureId' },
-                }
+                return variableMock
             },
         )
         expect(result).toEqual({
@@ -45,11 +47,31 @@ describe('EvalHooksRunner', () => {
         })
         expect(hook1.before).toHaveBeenCalledTimes(1)
         expect(hook1.after).toHaveBeenCalledTimes(1)
+        expect(hook1.after).toHaveBeenCalledWith(
+            expect.any(Object),
+            variableMock.variable,
+            variableMock.metadata,
+        )
         expect(hook1.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook1.onFinally).toHaveBeenCalledWith(
+            expect.any(Object),
+            variableMock.variable,
+            variableMock.metadata,
+        )
         expect(hook1.error).not.toHaveBeenCalled()
         expect(hook2.before).toHaveBeenCalledTimes(1)
         expect(hook2.after).toHaveBeenCalledTimes(1)
+        expect(hook2.after).toHaveBeenCalledWith(
+            expect.any(Object),
+            variableMock.variable,
+            variableMock.metadata,
+        )
         expect(hook2.onFinally).toHaveBeenCalledTimes(1)
+        expect(hook2.onFinally).toHaveBeenCalledWith(
+            expect.any(Object),
+            variableMock.variable,
+            variableMock.metadata,
+        )
     })
 
     it('should run hooks in correct order when resolver fails', () => {

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@devcycle/js-cloud-server-sdk'
 import { EvalHook } from '../src/hooks/EvalHook'
 import { EvalHooksRunner } from '../src/hooks/EvalHooksRunner'
+import { VariableType } from '@devcycle/types'
 
 describe('EvalHooksRunner', () => {
     it('should run hooks in correct order when resolver succeeds', async () => {
@@ -26,9 +27,8 @@ describe('EvalHooksRunner', () => {
             {
                 key: 'test-key',
                 defaultValue: 'test-value',
-                type: 'String',
+                type: VariableType.string,
                 value: 'test-value',
-                isDefaulted: false,
             },
             'featureId',
         )
@@ -139,17 +139,17 @@ describe('EvalHooksRunner', () => {
         )
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
+        const mockVariable = new VariableWithMetadata<string>(
+            {
+                key: 'test-key',
+                defaultValue: 'test-value',
+                type: VariableType.string,
+                value: 'test-value',
+            },
+            'test',
+        )
         const resolver = jest.fn().mockImplementation((context) => {
-            return {
-                variable: {
-                    key: 'test-key',
-                    defaultValue: 'test-value',
-                    type: 'String',
-                    value: 'test-value',
-                    isDefaulted: false,
-                },
-                metadata: { featureId: 'test' },
-            }
+            return mockVariable
         })
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },
@@ -209,15 +209,14 @@ describe('EvalHooksRunner', () => {
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
 
-        const variable = {
+        const mockVariable = new VariableWithMetadata<string>({
             key: 'test-key',
             defaultValue: 'test-value',
-            type: 'String',
+            type: VariableType.string,
             value: 'test-value',
-            isDefaulted: false,
-        }
+        })
         const resolver = jest.fn().mockImplementation((context) => {
-            return { variable }
+            return mockVariable
         })
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },
@@ -226,7 +225,7 @@ describe('EvalHooksRunner', () => {
             {},
             resolver,
         )
-        expect(result).toEqual(variable)
+        expect(result).toEqual(mockVariable.variable)
 
         expect(hook1.before).toHaveBeenCalledTimes(1)
         expect(hook1.after).toHaveBeenCalledTimes(0)

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -24,13 +24,16 @@ describe('EvalHooksRunner', () => {
             'test-value',
             {},
             () => {
-                return {
-                    key: 'test-key',
-                    defaultValue: 'test-value',
-                    type: 'String',
-                    value: 'test-value',
-                    isDefaulted: false,
-                }
+                return [
+                    {
+                        key: 'test-key',
+                        defaultValue: 'test-value',
+                        type: 'String',
+                        value: 'test-value',
+                        isDefaulted: false,
+                    },
+                    { featureId: 'featureId' },
+                ]
             },
         )
         expect(result).toEqual({
@@ -112,13 +115,16 @@ describe('EvalHooksRunner', () => {
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
         const resolver = jest.fn().mockImplementation((context) => {
-            return {
-                key: 'test-key',
-                defaultValue: 'test-value',
-                type: 'String',
-                value: 'test-value',
-                isDefaulted: false,
-            }
+            return [
+                {
+                    key: 'test-key',
+                    defaultValue: 'test-value',
+                    type: 'String',
+                    value: 'test-value',
+                    isDefaulted: false,
+                },
+                { featureId: 'test' },
+            ]
         })
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -1,4 +1,7 @@
-import { VariableWithMetadata } from '@devcycle/js-cloud-server-sdk'
+import {
+    DVCVariable,
+    VariableWithMetadata,
+} from '@devcycle/js-cloud-server-sdk'
 import { EvalHook } from '../src/hooks/EvalHook'
 import { EvalHooksRunner } from '../src/hooks/EvalHooksRunner'
 
@@ -19,23 +22,23 @@ describe('EvalHooksRunner', () => {
         )
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
-        const variableMock: VariableWithMetadata<string, string> = {
-            variable: {
+        const mockVariable = new VariableWithMetadata<string>(
+            {
                 key: 'test-key',
                 defaultValue: 'test-value',
                 type: 'String',
                 value: 'test-value',
                 isDefaulted: false,
             },
-            metadata: { featureId: 'featureId' },
-        }
+            'featureId',
+        )
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },
             'test-key',
             'test-value',
             {},
             () => {
-                return variableMock
+                return mockVariable
             },
         )
         expect(result).toEqual({
@@ -49,28 +52,28 @@ describe('EvalHooksRunner', () => {
         expect(hook1.after).toHaveBeenCalledTimes(1)
         expect(hook1.after).toHaveBeenCalledWith(
             expect.any(Object),
-            variableMock.variable,
-            variableMock.metadata,
+            mockVariable.variable,
+            mockVariable.metadata,
         )
         expect(hook1.onFinally).toHaveBeenCalledTimes(1)
         expect(hook1.onFinally).toHaveBeenCalledWith(
             expect.any(Object),
-            variableMock.variable,
-            variableMock.metadata,
+            mockVariable.variable,
+            mockVariable.metadata,
         )
         expect(hook1.error).not.toHaveBeenCalled()
         expect(hook2.before).toHaveBeenCalledTimes(1)
         expect(hook2.after).toHaveBeenCalledTimes(1)
         expect(hook2.after).toHaveBeenCalledWith(
             expect.any(Object),
-            variableMock.variable,
-            variableMock.metadata,
+            mockVariable.variable,
+            mockVariable.metadata,
         )
         expect(hook2.onFinally).toHaveBeenCalledTimes(1)
         expect(hook2.onFinally).toHaveBeenCalledWith(
             expect.any(Object),
-            variableMock.variable,
-            variableMock.metadata,
+            mockVariable.variable,
+            mockVariable.metadata,
         )
     })
 

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -24,16 +24,16 @@ describe('EvalHooksRunner', () => {
             'test-value',
             {},
             () => {
-                return [
-                    {
+                return {
+                    variable: {
                         key: 'test-key',
                         defaultValue: 'test-value',
                         type: 'String',
                         value: 'test-value',
                         isDefaulted: false,
                     },
-                    { featureId: 'featureId' },
-                ]
+                    metadata: { featureId: 'featureId' },
+                }
             },
         )
         expect(result).toEqual({
@@ -115,16 +115,16 @@ describe('EvalHooksRunner', () => {
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
         const resolver = jest.fn().mockImplementation((context) => {
-            return [
-                {
+            return {
+                variable: {
                     key: 'test-key',
                     defaultValue: 'test-value',
                     type: 'String',
                     value: 'test-value',
                     isDefaulted: false,
                 },
-                { featureId: 'test' },
-            ]
+                metadata: { featureId: 'test' },
+            }
         })
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },
@@ -192,7 +192,7 @@ describe('EvalHooksRunner', () => {
             isDefaulted: false,
         }
         const resolver = jest.fn().mockImplementation((context) => {
-            return [variable]
+            return { variable }
         })
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -1,7 +1,4 @@
-import {
-    DVCVariable,
-    VariableWithMetadata,
-} from '@devcycle/js-cloud-server-sdk'
+import { VariableAndMetadata } from '@devcycle/js-cloud-server-sdk'
 import { EvalHook } from '../src/hooks/EvalHook'
 import { EvalHooksRunner } from '../src/hooks/EvalHooksRunner'
 import { VariableType } from '@devcycle/types'
@@ -23,7 +20,7 @@ describe('EvalHooksRunner', () => {
         )
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
-        const mockVariable = new VariableWithMetadata<string>(
+        const mockVariable = new VariableAndMetadata<string>(
             {
                 key: 'test-key',
                 defaultValue: 'test-value',
@@ -139,7 +136,7 @@ describe('EvalHooksRunner', () => {
         )
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
-        const mockVariable = new VariableWithMetadata<string>(
+        const mockVariable = new VariableAndMetadata<string>(
             {
                 key: 'test-key',
                 defaultValue: 'test-value',
@@ -209,7 +206,7 @@ describe('EvalHooksRunner', () => {
         hooksRunner.enqueue(hook1)
         hooksRunner.enqueue(hook2)
 
-        const mockVariable = new VariableWithMetadata<string>({
+        const mockVariable = new VariableAndMetadata<string>({
             key: 'test-key',
             defaultValue: 'test-value',
             type: VariableType.string,

--- a/sdk/nodejs/__tests__/evalHooksRunner.test.ts
+++ b/sdk/nodejs/__tests__/evalHooksRunner.test.ts
@@ -192,7 +192,7 @@ describe('EvalHooksRunner', () => {
             isDefaulted: false,
         }
         const resolver = jest.fn().mockImplementation((context) => {
-            return variable
+            return [variable]
         })
         const result = hooksRunner.runHooksForEvaluation(
             { user_id: 'test-user' },

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -26,7 +26,6 @@ import os from 'os'
 import {
     DevCycleUser,
     DVCVariable,
-    VariableMetadata,
     VariableParam,
     checkParamDefined,
     dvcDefaultLogger,

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -35,7 +35,7 @@ import {
     DevCycleEvent,
     DVCPopulatedUser,
     DevCyclePlatformDetails,
-    VariableWithMetadata,
+    VariableAndMetadata,
 } from '@devcycle/js-cloud-server-sdk'
 import { DVCPopulatedUserFromDevCycleUser } from './models/populatedUserHelpers'
 import { randomUUID } from 'crypto'
@@ -238,7 +238,7 @@ export class DevCycleClient<
     _variable<
         K extends string & keyof Variables,
         T extends DVCVariableValue & Variables[K],
-    >(user: DevCycleUser, key: K, defaultValue: T): VariableWithMetadata<T> {
+    >(user: DevCycleUser, key: K, defaultValue: T): VariableAndMetadata<T> {
         const incomingUser = castIncomingUser(user)
         // this will throw if type is invalid
         const type = getVariableTypeFromValue(
@@ -270,7 +270,7 @@ export class DevCycleClient<
                 },
             })
 
-            return new VariableWithMetadata({
+            return new VariableAndMetadata({
                 defaultValue,
                 type,
                 key,
@@ -313,7 +313,7 @@ export class DevCycleClient<
             }
         }
 
-        return new VariableWithMetadata(options, configVariable?._feature)
+        return new VariableAndMetadata(options, configVariable?._feature)
     }
 
     variableValue<

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -239,7 +239,7 @@ export class DevCycleClient<
     _variable<
         K extends string & keyof Variables,
         T extends DVCVariableValue & Variables[K],
-    >(user: DevCycleUser, key: K, defaultValue: T): VariableWithMetadata<T, K> {
+    >(user: DevCycleUser, key: K, defaultValue: T): VariableWithMetadata<T> {
         const incomingUser = castIncomingUser(user)
         // this will throw if type is invalid
         const type = getVariableTypeFromValue(
@@ -271,14 +271,12 @@ export class DevCycleClient<
                 },
             })
 
-            return new VariableWithMetadata(
-                new DVCVariable({
-                    defaultValue,
-                    type,
-                    key,
-                    eval: evalReason,
-                }),
-            )
+            return new VariableWithMetadata({
+                defaultValue,
+                type,
+                key,
+                eval: evalReason,
+            })
         }
 
         const configVariable = variableForUser_PB(
@@ -316,10 +314,7 @@ export class DevCycleClient<
             }
         }
 
-        return new VariableWithMetadata(
-            new DVCVariable(options),
-            configVariable?._feature,
-        )
+        return new VariableWithMetadata(options, configVariable?._feature)
     }
 
     variableValue<

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -26,6 +26,7 @@ import os from 'os'
 import {
     DevCycleUser,
     DVCVariable,
+    VariableMetadata,
     VariableParam,
     checkParamDefined,
     dvcDefaultLogger,
@@ -237,7 +238,11 @@ export class DevCycleClient<
     _variable<
         K extends string & keyof Variables,
         T extends DVCVariableValue & Variables[K],
-    >(user: DevCycleUser, key: K, defaultValue: T): DVCVariable<T> {
+    >(
+        user: DevCycleUser,
+        key: K,
+        defaultValue: T,
+    ): [DVCVariable<T>, VariableMetadata] {
         const incomingUser = castIncomingUser(user)
         // this will throw if type is invalid
         const type = getVariableTypeFromValue(
@@ -269,12 +274,15 @@ export class DevCycleClient<
                 },
             })
 
-            return new DVCVariable({
-                defaultValue,
-                type,
-                key,
-                eval: evalReason,
-            })
+            return [
+                new DVCVariable({
+                    defaultValue,
+                    type,
+                    key,
+                    eval: evalReason,
+                }),
+                new VariableMetadata(),
+            ]
         }
 
         const configVariable = variableForUser_PB(
@@ -312,7 +320,10 @@ export class DevCycleClient<
             }
         }
 
-        return new DVCVariable(options)
+        return [
+            new DVCVariable(options),
+            new VariableMetadata(configVariable?._feature),
+        ]
     }
 
     variableValue<

--- a/sdk/nodejs/src/client.ts
+++ b/sdk/nodejs/src/client.ts
@@ -36,6 +36,7 @@ import {
     DevCycleEvent,
     DVCPopulatedUser,
     DevCyclePlatformDetails,
+    VariableWithMetadata,
 } from '@devcycle/js-cloud-server-sdk'
 import { DVCPopulatedUserFromDevCycleUser } from './models/populatedUserHelpers'
 import { randomUUID } from 'crypto'
@@ -238,11 +239,7 @@ export class DevCycleClient<
     _variable<
         K extends string & keyof Variables,
         T extends DVCVariableValue & Variables[K],
-    >(
-        user: DevCycleUser,
-        key: K,
-        defaultValue: T,
-    ): [DVCVariable<T>, VariableMetadata] {
+    >(user: DevCycleUser, key: K, defaultValue: T): VariableWithMetadata<T, K> {
         const incomingUser = castIncomingUser(user)
         // this will throw if type is invalid
         const type = getVariableTypeFromValue(
@@ -274,15 +271,14 @@ export class DevCycleClient<
                 },
             })
 
-            return [
+            return new VariableWithMetadata(
                 new DVCVariable({
                     defaultValue,
                     type,
                     key,
                     eval: evalReason,
                 }),
-                new VariableMetadata(),
-            ]
+            )
         }
 
         const configVariable = variableForUser_PB(
@@ -320,10 +316,10 @@ export class DevCycleClient<
             }
         }
 
-        return [
+        return new VariableWithMetadata(
             new DVCVariable(options),
-            new VariableMetadata(configVariable?._feature),
-        ]
+            configVariable?._feature,
+        )
     }
 
     variableValue<

--- a/sdk/nodejs/src/hooks/EvalHook.ts
+++ b/sdk/nodejs/src/hooks/EvalHook.ts
@@ -1,3 +1,4 @@
+import { VariableMetadata } from '@devcycle/js-cloud-server-sdk'
 import { DVCVariable, DVCVariableValue } from '../../src/'
 import { HookContext } from './HookContext'
 
@@ -9,10 +10,12 @@ export class EvalHook {
         readonly after: <T extends DVCVariableValue>(
             context: HookContext<T>,
             variableDetails: DVCVariable<T>,
+            variableMetadata: VariableMetadata,
         ) => void,
         readonly onFinally: <T extends DVCVariableValue>(
             context: HookContext<T>,
             variableDetails: DVCVariable<T> | undefined,
+            variableMetadata: VariableMetadata | undefined,
         ) => void,
         readonly error: <T extends DVCVariableValue>(
             context: HookContext<T>,

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -30,7 +30,8 @@ export class EvalHooksRunner {
         let variableMetadata: VariableMetadata | undefined
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            const { variable, metadata } : VariableAndMetadata<T> = resolver.call(beforeContext)
+            const { variable, metadata }: VariableAndMetadata<T> =
+                resolver.call(beforeContext)
             variableDetails = variable
             variableMetadata = metadata
             this.runAfter(

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -1,6 +1,6 @@
 import {
     VariableMetadata,
-    VariableWithMetadata,
+    VariableAndMetadata,
 } from '@devcycle/js-cloud-server-sdk'
 import { DevCycleUser, DVCVariable } from '../../src/'
 import { EvalHook } from './EvalHook'
@@ -19,7 +19,7 @@ export class EvalHooksRunner {
         key: string,
         defaultValue: T,
         metadata: HookMetadata,
-        resolver: (context: HookContext<T>) => VariableWithMetadata<T>,
+        resolver: (context: HookContext<T>) => VariableAndMetadata<T>,
     ): DVCVariable<T> {
         const context = new HookContext<T>(user, key, defaultValue, metadata)
         const savedHooks = [...this.hooks]

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -1,4 +1,7 @@
-import { VariableMetadata } from '@devcycle/js-cloud-server-sdk'
+import {
+    VariableMetadata,
+    VariableWithMetadata,
+} from '@devcycle/js-cloud-server-sdk'
 import { DevCycleUser, DVCVariable } from '../../src/'
 import { EvalHook } from './EvalHook'
 import { HookContext, HookMetadata } from './HookContext'
@@ -16,9 +19,7 @@ export class EvalHooksRunner {
         key: string,
         defaultValue: T,
         metadata: HookMetadata,
-        resolver: (
-            context: HookContext<T>,
-        ) => [DVCVariable<T>, VariableMetadata],
+        resolver: (context: HookContext<T>) => VariableWithMetadata<T>,
     ): DVCVariable<T> {
         const context = new HookContext<T>(user, key, defaultValue, metadata)
         const savedHooks = [...this.hooks]
@@ -29,9 +30,9 @@ export class EvalHooksRunner {
         let variableMetadata: VariableMetadata
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            const [variable, metadata] = resolver.call(beforeContext)
-            variableDetails = variable
-            variableMetadata = metadata
+            const result = resolver.call(beforeContext)
+            variableDetails = result.variable
+            variableMetadata = result.metatdata
             this.runAfter(
                 savedHooks,
                 beforeContext,
@@ -46,7 +47,7 @@ export class EvalHooksRunner {
                 error.name === 'AfterHookError'
             ) {
                 // make sure to return with a variable if before or after hook errors
-                const [variable] = resolver.call(context)
+                const { variable } = resolver.call(context)
                 return variable
             }
             throw error

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -26,11 +26,11 @@ export class EvalHooksRunner {
         const reversedHooks = [...savedHooks].reverse()
 
         let beforeContext = context
-        let variableDetails: DVCVariable<T>
-        let variableMetadata: VariableMetadata
+        let variableDetails: DVCVariable<T> | undefined
+        let variableMetadata: VariableMetadata | undefined
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            const { variable, metadata } = resolver.call(beforeContext)
+            const { variable, metadata } : VariableAndMetadata<T> = resolver.call(beforeContext)
             variableDetails = variable
             variableMetadata = metadata
             this.runAfter(
@@ -41,7 +41,12 @@ export class EvalHooksRunner {
             )
         } catch (error) {
             this.runError(reversedHooks, context, error)
-            this.runFinally(reversedHooks, context, undefined, undefined)
+            this.runFinally(
+                reversedHooks,
+                context,
+                variableDetails,
+                variableMetadata,
+            )
             if (
                 error.name === 'BeforeHookError' ||
                 error.name === 'AfterHookError'

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -30,9 +30,9 @@ export class EvalHooksRunner {
         let variableMetadata: VariableMetadata
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            const result = resolver.call(beforeContext)
-            variableDetails = result.variable
-            variableMetadata = result.metadata
+            const { variable, metadata } = resolver.call(beforeContext)
+            variableDetails = variable
+            variableMetadata = metadata
             this.runAfter(
                 savedHooks,
                 beforeContext,

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -29,7 +29,9 @@ export class EvalHooksRunner {
         let variableMetadata: VariableMetadata
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            ;[variableDetails, variableMetadata] = resolver.call(beforeContext)
+            let [details, metadata] = resolver.call(beforeContext)
+            variableDetails = details
+            variableMetadata = metadata
             this.runAfter(
                 savedHooks,
                 beforeContext,

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -29,7 +29,7 @@ export class EvalHooksRunner {
         let variableMetadata: VariableMetadata
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            let [details, metadata] = resolver.call(beforeContext)
+            const [details, metadata] = resolver.call(beforeContext)
             variableDetails = details
             variableMetadata = metadata
             this.runAfter(

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -29,8 +29,8 @@ export class EvalHooksRunner {
         let variableMetadata: VariableMetadata
         try {
             beforeContext = this.runBefore(savedHooks, context)
-            const [details, metadata] = resolver.call(beforeContext)
-            variableDetails = details
+            const [variable, metadata] = resolver.call(beforeContext)
+            variableDetails = variable
             variableMetadata = metadata
             this.runAfter(
                 savedHooks,
@@ -46,7 +46,8 @@ export class EvalHooksRunner {
                 error.name === 'AfterHookError'
             ) {
                 // make sure to return with a variable if before or after hook errors
-                return resolver.call(context)
+                const [variable] = resolver.call(context)
+                return variable
             }
             throw error
         }

--- a/sdk/nodejs/src/hooks/EvalHooksRunner.ts
+++ b/sdk/nodejs/src/hooks/EvalHooksRunner.ts
@@ -32,7 +32,7 @@ export class EvalHooksRunner {
             beforeContext = this.runBefore(savedHooks, context)
             const result = resolver.call(beforeContext)
             variableDetails = result.variable
-            variableMetadata = result.metatdata
+            variableMetadata = result.metadata
             this.runAfter(
                 savedHooks,
                 beforeContext,


### PR DESCRIPTION
featureId is needed in hooks for dynatrace integration to construct feature url. 

Created a VariableMetadata class to provide the data to the hook wrapper while maintaining the original public variable functions signature.