### PR TITLE
feat: add ESM output format to shared libs and server SDKs

### DIFF
--- a/dev-apps/js/webpack.config.js
+++ b/dev-apps/js/webpack.config.js
@@ -1,3 +1,10 @@
 const { composePlugins, withNx, withWeb } = require('@nx/webpack')
 
-module.exports = composePlugins(withNx(), withWeb(), (config) => config)
+module.exports = composePlugins(withNx(), withWeb(), (config) => {
+    config.resolve.extensionAlias = {
+        '.js': ['.ts', '.js'],
+        '.mjs': ['.mts', '.mjs'],
+        '.cjs': ['.cts', '.cjs'],
+    }
+    return config
+})

--- a/lib/shared/bucketing-test-data/package.json
+++ b/lib/shared/bucketing-test-data/package.json
@@ -2,16 +2,6 @@
     "name": "@devcycle/bucketing-test-data",
     "version": "1.36.7",
     "license": "MIT",
-    "main": "./main.cjs",
-    "module": "./main.js",
-    "types": "./main.d.ts",
-    "exports": {
-        ".": {
-            "types": "./main.d.ts",
-            "import": "./main.js",
-            "require": "./main.cjs"
-        }
-    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/bucketing-test-data/package.json
+++ b/lib/shared/bucketing-test-data/package.json
@@ -2,6 +2,16 @@
     "name": "@devcycle/bucketing-test-data",
     "version": "1.36.7",
     "license": "MIT",
+    "main": "./main.cjs",
+    "module": "./main.js",
+    "types": "./main.d.ts",
+    "exports": {
+        ".": {
+            "types": "./main.d.ts",
+            "import": "./main.js",
+            "require": "./main.cjs"
+        }
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/bucketing-test-data/project.json
+++ b/lib/shared/bucketing-test-data/project.json
@@ -18,7 +18,7 @@
                 "outputPath": "dist/lib/shared/bucketing-test-data",
                 "tsConfig": "lib/shared/bucketing-test-data/tsconfig.lib.json",
                 "main": "lib/shared/bucketing-test-data/src/main.ts",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -29,10 +29,7 @@
                     "class-transformer",
                     "class-validator",
                     "reflect-metadata"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             },
             "dependsOn": [
                 {

--- a/lib/shared/bucketing-test-data/project.json
+++ b/lib/shared/bucketing-test-data/project.json
@@ -18,7 +18,7 @@
                 "outputPath": "dist/lib/shared/bucketing-test-data",
                 "tsConfig": "lib/shared/bucketing-test-data/tsconfig.lib.json",
                 "main": "lib/shared/bucketing-test-data/src/main.ts",
-                "format": ["cjs", "esm"],
+                "format": ["cjs"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -29,7 +29,10 @@
                     "class-transformer",
                     "class-validator",
                     "reflect-metadata"
-                ]
+                ],
+                "esbuildOptions": {
+                    "outExtension": { ".js": ".js" }
+                }
             },
             "dependsOn": [
                 {

--- a/lib/shared/bucketing/package.json
+++ b/lib/shared/bucketing/package.json
@@ -8,8 +8,16 @@
         "murmurhash": "^2.0.1",
         "ua-parser-js": "^1.0.40"
     },
-    "types": "src/index.d.ts",
-    "main": "src/index.js",
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/bucketing/project.json
+++ b/lib/shared/bucketing/project.json
@@ -29,6 +29,7 @@
                 "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
+                "thirdParty": true,
                 "declaration": true,
                 "sourcemap": true,
                 "assets": [
@@ -37,7 +38,6 @@
                 ],
                 "external": [
                     "@devcycle/types",
-                    "lodash",
                     "murmurhash",
                     "ua-parser-js"
                 ]

--- a/lib/shared/bucketing/project.json
+++ b/lib/shared/bucketing/project.json
@@ -26,7 +26,7 @@
                 "outputPath": "dist/lib/shared/bucketing",
                 "main": "lib/shared/bucketing/src/index.ts",
                 "tsConfig": "lib/shared/bucketing/tsconfig.lib.json",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -40,10 +40,7 @@
                     "lodash",
                     "murmurhash",
                     "ua-parser-js"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             }
         },
         "lint": {

--- a/lib/shared/config-manager/package.json
+++ b/lib/shared/config-manager/package.json
@@ -2,8 +2,16 @@
     "name": "@devcycle/config-manager",
     "version": "1.0.0",
     "license": "MIT",
-    "main": "src/index.js",
-    "types": "src/index.d.ts",
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/config-manager/project.json
+++ b/lib/shared/config-manager/project.json
@@ -11,7 +11,7 @@
                 "outputPath": "dist/lib/shared/config-manager",
                 "main": "lib/shared/config-manager/src/index.ts",
                 "tsConfig": "lib/shared/config-manager/tsconfig.lib.json",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -25,10 +25,7 @@
                     "cross-fetch",
                     "fetch-retry",
                     "eventsource"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             }
         },
         "lint": {

--- a/lib/shared/server-request/package.json
+++ b/lib/shared/server-request/package.json
@@ -2,8 +2,16 @@
     "name": "@devcycle/server-request",
     "version": "1.0.0",
     "license": "MIT",
-    "main": "src/index.js",
-    "types": "src/index.d.ts",
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/server-request/project.json
+++ b/lib/shared/server-request/project.json
@@ -11,7 +11,7 @@
                 "outputPath": "dist/lib/shared/server-request",
                 "main": "lib/shared/server-request/src/index.ts",
                 "tsConfig": "lib/shared/server-request/tsconfig.lib.json",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -20,10 +20,7 @@
                     "lib/shared/server-request/*.md",
                     "lib/shared/server-request/package.json"
                 ],
-                "external": ["cross-fetch", "fetch-retry"],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                "external": ["cross-fetch", "fetch-retry"]
             }
         },
         "lint": {

--- a/lib/shared/sse-connection/package.json
+++ b/lib/shared/sse-connection/package.json
@@ -5,8 +5,16 @@
     "dependencies": {
         "eventsource": "^2.0.2"
     },
-    "types": "src/index.d.ts",
-    "main": "src/index.js",
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/sse-connection/project.json
+++ b/lib/shared/sse-connection/project.json
@@ -11,7 +11,7 @@
                 "outputPath": "dist/lib/shared/sse-connection",
                 "main": "lib/shared/sse-connection/src/index.ts",
                 "tsConfig": "lib/shared/sse-connection/tsconfig.lib.json",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -20,10 +20,7 @@
                     "lib/shared/sse-connection/*.md",
                     "lib/shared/sse-connection/package.json"
                 ],
-                "external": ["@devcycle/types", "eventsource"],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                "external": ["@devcycle/types", "eventsource"]
             }
         },
         "lint": {

--- a/lib/shared/vercel-edge-config/package.json
+++ b/lib/shared/vercel-edge-config/package.json
@@ -8,9 +8,16 @@
     "dependencies": {
         "class-transformer": "^0.5.1"
     },
-    "type": "commonjs",
-    "main": "./src/index.js",
-    "typings": "./src/index.d.ts",
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/DevCycleHQ/js-sdks.git"

--- a/lib/shared/vercel-edge-config/project.json
+++ b/lib/shared/vercel-edge-config/project.json
@@ -11,7 +11,7 @@
                 "outputPath": "dist/lib/shared/vercel-edge-config",
                 "main": "lib/shared/vercel-edge-config/src/index.ts",
                 "tsConfig": "lib/shared/vercel-edge-config/tsconfig.lib.json",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -24,10 +24,7 @@
                     "@devcycle/types",
                     "@vercel/edge-config",
                     "class-transformer"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             }
         },
         "lint": {

--- a/sdk/js-cloud-server/package.json
+++ b/sdk/js-cloud-server/package.json
@@ -24,6 +24,14 @@
         "fetch-retry": "^5.0.6",
         "lodash": "^4.17.21"
     },
-    "main": "index.js",
-    "types": "src/index.d.ts"
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    }
 }

--- a/sdk/js-cloud-server/project.json
+++ b/sdk/js-cloud-server/project.json
@@ -46,7 +46,7 @@
                 "outputPath": "dist/sdk/js-cloud-server",
                 "tsConfig": "sdk/js-cloud-server/tsconfig.lib.json",
                 "main": "sdk/js-cloud-server/src/index.ts",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -60,12 +60,7 @@
                     "cross-fetch",
                     "fetch-retry",
                     "lodash"
-                ],
-                "esbuildOptions": {
-                    "outExtension": {
-                        ".js": ".js"
-                    }
-                }
+                ]
             }
         },
         "npm-publish": {

--- a/sdk/nestjs/package.json
+++ b/sdk/nestjs/package.json
@@ -30,6 +30,14 @@
     "engines": {
         "node": ">=16.0.0"
     },
-    "main": "index.js",
-    "types": "src/index.d.ts"
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    }
 }

--- a/sdk/nestjs/package.json
+++ b/sdk/nestjs/package.json
@@ -30,14 +30,6 @@
     "engines": {
         "node": ">=16.0.0"
     },
-    "main": "./index.cjs",
-    "module": "./index.js",
-    "types": "./src/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./src/index.d.ts",
-            "import": "./index.js",
-            "require": "./index.cjs"
-        }
-    }
+    "main": "src/index.js",
+    "types": "src/index.d.ts"
 }

--- a/sdk/nestjs/project.json
+++ b/sdk/nestjs/project.json
@@ -41,7 +41,7 @@
                 "outputPath": "dist/sdk/nestjs",
                 "tsConfig": "sdk/nestjs/tsconfig.lib.json",
                 "main": "sdk/nestjs/src/index.ts",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -52,10 +52,7 @@
                     "@devcycle/types",
                     "nestjs-cls",
                     "@nestjs/*"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             }
         },
         "npm-publish": {

--- a/sdk/nestjs/project.json
+++ b/sdk/nestjs/project.json
@@ -35,24 +35,17 @@
             ]
         },
         "build": {
-            "executor": "@nx/esbuild:esbuild",
+            "executor": "@nx/js:tsc",
+            "metadata": {
+                "description": "Must stay on @nx/js:tsc. esbuild does not implement emitDecoratorMetadata, which NestJS DI needs to resolve DevCycleService's constructor dependencies. Under esbuild the metadata is dropped, Nest injects undefined without throwing, and the failure only surfaces on the first variable evaluation."
+            },
             "outputs": ["{options.outputPath}"],
             "options": {
                 "outputPath": "dist/sdk/nestjs",
                 "tsConfig": "sdk/nestjs/tsconfig.lib.json",
+                "packageJson": "sdk/nestjs/package.json",
                 "main": "sdk/nestjs/src/index.ts",
-                "format": ["cjs", "esm"],
-                "platform": "node",
-                "bundle": true,
-                "declaration": true,
-                "sourcemap": true,
-                "assets": ["sdk/nestjs/*.md", "sdk/nestjs/package.json"],
-                "external": [
-                    "@devcycle/nodejs-server-sdk",
-                    "@devcycle/types",
-                    "nestjs-cls",
-                    "@nestjs/*"
-                ]
+                "assets": ["sdk/nestjs/*.md"]
             }
         },
         "npm-publish": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -44,14 +44,14 @@
     "engines": {
         "node": ">=16.0.0"
     },
-    "main": "./index.cjs",
-    "module": "./index.js",
+    "main": "./src/index.cjs",
+    "module": "./src/index.js",
     "types": "./src/index.d.ts",
     "exports": {
         ".": {
             "types": "./src/index.d.ts",
-            "import": "./index.js",
-            "require": "./index.cjs"
+            "import": "./src/index.js",
+            "require": "./src/index.cjs"
         },
         "./openfeature-strategy": {
             "types": "./openfeature-strategy.d.ts",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -44,18 +44,19 @@
     "engines": {
         "node": ">=16.0.0"
     },
-    "main": "src/index.js",
-    "types": "src/index.d.ts",
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": {
-            "import": "./src/index.js",
-            "require": "./src/index.js",
-            "types": "./src/index.d.ts"
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
         },
         "./openfeature-strategy": {
+            "types": "./openfeature-strategy.d.ts",
             "import": "./openfeature-strategy.js",
-            "require": "./openfeature-strategy.js",
-            "types": "./openfeature-strategy.d.ts"
+            "require": "./openfeature-strategy.cjs"
         }
     }
 }

--- a/sdk/nodejs/project.json
+++ b/sdk/nodejs/project.json
@@ -49,7 +49,7 @@
                 "tsConfig": "sdk/nodejs/tsconfig.lib.json",
                 "main": "sdk/nodejs/src/index.ts",
                 "additionalEntryPoints": ["sdk/nodejs/openfeature-strategy.ts"],
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -64,12 +64,7 @@
                     "cross-fetch",
                     "eventsource",
                     "fetch-retry"
-                ],
-                "esbuildOptions": {
-                    "outExtension": {
-                        ".js": ".js"
-                    }
-                }
+                ]
             }
         },
         "npm-publish": {

--- a/sdk/openfeature-angular-provider/package.json
+++ b/sdk/openfeature-angular-provider/package.json
@@ -32,16 +32,19 @@
             "optional": true
         }
     },
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": {
-            "import": "./src/index.js",
-            "require": "./src/index.js",
-            "types": "./src/index.d.ts"
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
         },
         "./strategy": {
+            "types": "./strategy.d.ts",
             "import": "./strategy.js",
-            "require": "./strategy.js",
-            "types": "./strategy.d.ts"
+            "require": "./strategy.cjs"
         }
     }
 }

--- a/sdk/openfeature-angular-provider/package.json
+++ b/sdk/openfeature-angular-provider/package.json
@@ -32,14 +32,14 @@
             "optional": true
         }
     },
-    "main": "./index.cjs",
-    "module": "./index.js",
+    "main": "./src/index.cjs",
+    "module": "./src/index.js",
     "types": "./src/index.d.ts",
     "exports": {
         ".": {
             "types": "./src/index.d.ts",
-            "import": "./index.js",
-            "require": "./index.cjs"
+            "import": "./src/index.js",
+            "require": "./src/index.cjs"
         },
         "./strategy": {
             "types": "./strategy.d.ts",

--- a/sdk/openfeature-angular-provider/project.json
+++ b/sdk/openfeature-angular-provider/project.json
@@ -13,7 +13,7 @@
                 "additionalEntryPoints": [
                     "sdk/openfeature-angular-provider/strategy.ts"
                 ],
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "browser",
                 "bundle": true,
                 "declaration": true,
@@ -26,10 +26,7 @@
                     "@devcycle/js-client-sdk",
                     "@devcycle/openfeature-web-provider",
                     "@openfeature/*"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             }
         },
         "lint": {

--- a/sdk/openfeature-nestjs-provider/package.json
+++ b/sdk/openfeature-nestjs-provider/package.json
@@ -21,6 +21,14 @@
     "dependencies": {
         "@devcycle/nodejs-server-sdk": "1.55.9"
     },
-    "main": "index.js",
-    "types": "src/index.d.ts"
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
+        }
+    }
 }

--- a/sdk/openfeature-nestjs-provider/project.json
+++ b/sdk/openfeature-nestjs-provider/project.json
@@ -9,7 +9,7 @@
                 "outputPath": "dist/sdk/openfeature-nestjs-provider",
                 "tsConfig": "sdk/openfeature-nestjs-provider/tsconfig.lib.json",
                 "main": "sdk/openfeature-nestjs-provider/src/index.ts",
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "node",
                 "bundle": true,
                 "declaration": true,
@@ -18,10 +18,7 @@
                     "sdk/openfeature-nestjs-provider/*.md",
                     "sdk/openfeature-nestjs-provider/package.json"
                 ],
-                "external": ["@devcycle/nodejs-server-sdk"],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                "external": ["@devcycle/nodejs-server-sdk"]
             }
         },
         "lint": {

--- a/sdk/openfeature-react-provider/package.json
+++ b/sdk/openfeature-react-provider/package.json
@@ -32,16 +32,19 @@
             "optional": true
         }
     },
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": {
-            "import": "./src/index.js",
-            "require": "./src/index.js",
-            "types": "./src/index.d.ts"
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
         },
         "./strategy": {
+            "types": "./strategy.d.ts",
             "import": "./strategy.js",
-            "require": "./strategy.js",
-            "types": "./strategy.d.ts"
+            "require": "./strategy.cjs"
         }
     }
 }

--- a/sdk/openfeature-react-provider/package.json
+++ b/sdk/openfeature-react-provider/package.json
@@ -32,14 +32,14 @@
             "optional": true
         }
     },
-    "main": "./index.cjs",
-    "module": "./index.js",
+    "main": "./src/index.cjs",
+    "module": "./src/index.js",
     "types": "./src/index.d.ts",
     "exports": {
         ".": {
             "types": "./src/index.d.ts",
-            "import": "./index.js",
-            "require": "./index.cjs"
+            "import": "./src/index.js",
+            "require": "./src/index.cjs"
         },
         "./strategy": {
             "types": "./strategy.d.ts",

--- a/sdk/openfeature-react-provider/project.json
+++ b/sdk/openfeature-react-provider/project.json
@@ -13,7 +13,7 @@
                 "additionalEntryPoints": [
                     "sdk/openfeature-react-provider/strategy.ts"
                 ],
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "browser",
                 "bundle": true,
                 "declaration": true,
@@ -26,10 +26,7 @@
                     "@devcycle/js-client-sdk",
                     "@devcycle/openfeature-web-provider",
                     "@openfeature/*"
-                ],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                ]
             }
         },
         "lint": {

--- a/sdk/openfeature-web-provider/package.json
+++ b/sdk/openfeature-web-provider/package.json
@@ -30,16 +30,19 @@
             "optional": true
         }
     },
+    "main": "./index.cjs",
+    "module": "./index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": {
-            "import": "./src/index.js",
-            "require": "./src/index.js",
-            "types": "./src/index.d.ts"
+            "types": "./src/index.d.ts",
+            "import": "./index.js",
+            "require": "./index.cjs"
         },
         "./strategy": {
+            "types": "./strategy.d.ts",
             "import": "./strategy.js",
-            "require": "./strategy.js",
-            "types": "./strategy.d.ts"
+            "require": "./strategy.cjs"
         }
     }
 }

--- a/sdk/openfeature-web-provider/package.json
+++ b/sdk/openfeature-web-provider/package.json
@@ -30,14 +30,14 @@
             "optional": true
         }
     },
-    "main": "./index.cjs",
-    "module": "./index.js",
+    "main": "./src/index.cjs",
+    "module": "./src/index.js",
     "types": "./src/index.d.ts",
     "exports": {
         ".": {
             "types": "./src/index.d.ts",
-            "import": "./index.js",
-            "require": "./index.cjs"
+            "import": "./src/index.js",
+            "require": "./src/index.cjs"
         },
         "./strategy": {
             "types": "./strategy.d.ts",

--- a/sdk/openfeature-web-provider/project.json
+++ b/sdk/openfeature-web-provider/project.json
@@ -13,7 +13,7 @@
                 "additionalEntryPoints": [
                     "sdk/openfeature-web-provider/strategy.ts"
                 ],
-                "format": ["cjs"],
+                "format": ["cjs", "esm"],
                 "platform": "browser",
                 "bundle": true,
                 "declaration": true,
@@ -22,10 +22,7 @@
                     "sdk/openfeature-web-provider/*.md",
                     "sdk/openfeature-web-provider/package.json"
                 ],
-                "external": ["@devcycle/js-client-sdk", "@openfeature/*"],
-                "esbuildOptions": {
-                    "outExtension": { ".js": ".js" }
-                }
+                "external": ["@devcycle/js-client-sdk", "@openfeature/*"]
             }
         },
         "lint": {


### PR DESCRIPTION
## Summary
Adds dual ESM/CJS output format to shared libraries and server SDKs.

## Changes
- Add `format: ["cjs", "esm"]` to esbuild configs
- Update `package.json` exports with proper conditional exports (`import`/`require`)
- Use `.cjs` extension for CommonJS, `.js` for ESM
- Add webpack `extensionAlias` config for dev-apps

## Packages Updated
- `@devcycle/bucketing`, `@devcycle/config-manager`, `@devcycle/server-request`, `@devcycle/sse-connection`, `@devcycle/vercel-edge-config`
- `@devcycle/js-cloud-server-sdk`, `@devcycle/nestjs-server-sdk`, `@devcycle/nodejs-server-sdk`
- `@devcycle/openfeature-web-provider`, `@devcycle/openfeature-react-provider`, `@devcycle/openfeature-angular-provider`, `@devcycle/openfeature-nestjs-provider`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat-nx-migration","parentHead":"947e664ae58a8ab8b9f1b3f27961bd49667f49ed","parentPull":1185,"trunk":"main"}
```
-->
