### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/e2e/js/js-esm/package.json
+++ b/e2e/js/js-esm/package.json
@@ -37,6 +37,7 @@
         "minimatch@^3.1.1": "^3.1.5",
         "lodash": "^4.18.1",
         "follow-redirects": "^1.16.0",
+        "shell-quote@^1.8.3": "^1.8.4",
         "ip-address@npm:^9.0.5": "^10.1.1",
         "uuid": "^11.1.1"
     }

--- a/e2e/js/js-esm/yarn.lock
+++ b/e2e/js/js-esm/yarn.lock
@@ -4085,10 +4085,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
+"shell-quote@npm:^1.8.3, shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `shell-quote` to 1.8.4 in `e2e/js/js-esm` to resolve a **critical** vulnerability (CVE-2026-9277: `shell-quote` `quote()` does not escape newlines in object `.op` values). Added a `shell-quote@^1.8.3` resolution to the e2e project's `package.json` and updated its `yarn.lock` (alert #1123).

The root `package.json` already pins `shell-quote` to `^1.8.4`; this PR closes the remaining gap in the nested `e2e/js/js-esm` lockfile.