### PR TITLE
fix: pin downlevel-dts version

### DIFF
--- a/lib/shared/types/project.json
+++ b/lib/shared/types/project.json
@@ -63,7 +63,7 @@
         "build:emit-legacy-types": {
             "executor": "nx:run-commands",
             "options": {
-                "command": "npx --yes downlevel-dts . ts3.5 --to=3.5",
+                "command": "npx --yes --package=downlevel-dts@0.11.0 --package=typescript@$(node -p \"require('typescript/package.json').version\") downlevel-dts . ts3.5 --to=3.5",
                 "cwd": "dist/lib/shared/types",
                 "forwardAllArgs": true
             },

--- a/sdk/js/project.json
+++ b/sdk/js/project.json
@@ -81,7 +81,7 @@
         "build:emit-legacy-types": {
             "executor": "nx:run-commands",
             "options": {
-                "command": "npx --yes downlevel-dts . ts3.5 --to=3.5",
+                "command": "npx --yes --package=downlevel-dts@0.11.0 --package=typescript@$(node -p \"require('typescript/package.json').version\") downlevel-dts . ts3.5 --to=3.5",
                 "cwd": "dist/sdk/js",
                 "forwardAllArgs": true
             },


### PR DESCRIPTION
## Summary
- Pin `downlevel-dts` to `0.11.0` for legacy declaration generation.
- Resolve the TypeScript version from the workspace at runtime instead of hard-coding it.

This prevents `downlevel-dts` from pulling its incompatible `typescript: "next"` dependency, which caused releases to fail with `ts.createProgram is not a function`.

Broken release: https://github.com/DevCycleHQ/js-sdks/actions/runs/31109375341

Verified both `js:build:emit-legacy-types` and `shared-types:build:emit-legacy-types`.