### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/cf-worker-example-test.yml
+++ b/.github/workflows/cf-worker-example-test.yml
@@ -14,13 +14,13 @@ jobs:
             matrix:
                 node-version: ['24.x']
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Enable Corepack
               run: corepack enable
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'

--- a/.github/workflows/nx-affected-e2e.yml
+++ b/.github/workflows/nx-affected-e2e.yml
@@ -14,7 +14,7 @@ jobs:
             matrix:
                 node-version: ['24.x']
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Enable Corepack
@@ -25,7 +25,7 @@ jobs:
                 secrets_map: '{"NEXT_PUBLIC_E2E_OPTIN_CLIENT_KEY":"DEVCYCLE_GITHUB_js-sdks_NEXT_PUBLIC_E2E_OPTIN_CLIENT_KEY","E2E_OPTIN_SERVER_KEY":"DEVCYCLE_GITHUB_js-sdks_E2E_OPTIN_SERVER_KEY","NEXT_PUBLIC_E2E_EDGEDB_CLIENT_KEY":"DEVCYCLE_GITHUB_js-sdks_NEXT_PUBLIC_E2E_EDGEDB_CLIENT_KEY","E2E_EDGEDB_SERVER_KEY":"DEVCYCLE_GITHUB_js-sdks_E2E_EDGEDB_SERVER_KEY","E2E_NEXTJS_SERVER_KEY":"DEVCYCLE_GITHUB_js-sdks_E2E_NEXTJS_SERVER_KEY", "NEXT_PUBLIC_E2E_NEXTJS_CLIENT_KEY": "DEVCYCLE_GITHUB_js-sdks_NEXT_PUBLIC_E2E_NEXTJS_CLIENT_KEY", "DVC_E2E_SERVER_SDK_KEY": "DEVCYCLE_GITHUB_js-sdks_DVC_E2E_SERVER_SDK_KEY"}'
                 aws_account_id: '134377926370'
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
@@ -40,7 +40,7 @@ jobs:
               run: yarn affected:e2e
             - name: Upload Playwright Report
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report
                   path: dist/.playwright/e2e/

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -9,7 +9,7 @@ jobs:
         name: License Check
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v7
           - uses: DevCycleHQ/license-action@main
             with:
               language: "javascript"
@@ -19,13 +19,13 @@ jobs:
             matrix:
                 node-version: ['24.x']
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Enable Corepack
               run: corepack enable
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMATION_USER_TOKEN }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   token: ${{ secrets.AUTOMATION_USER_TOKEN }}
                   fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
                   git config --global user.name "DevCycle Automation"
 
             - name: Set up Node.js for npm publish
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                 node-version: ${{ matrix.node-version }}
                 registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -12,7 +12,7 @@ jobs:
             matrix:
                 node-version: ['24.x']
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Install system dependencies
@@ -22,7 +22,7 @@ jobs:
             - name: Enable Corepack
               run: corepack enable
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'

--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -15,6 +15,6 @@ jobs:
         name: Semantic PR title
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@v6
+            - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-prs.yml
+++ b/.github/workflows/semantic-prs.yml
@@ -15,6 +15,6 @@ jobs:
         name: Semantic PR title
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@v5
+            - uses: amannn/action-semantic-pull-request@v6
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-of-sdk.yml
+++ b/.github/workflows/update-of-sdk.yml
@@ -11,12 +11,12 @@ jobs:
   update-dvc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24.x'
           cache: 'yarn'


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.